### PR TITLE
fix(core/menu-item): prevent text selection

### DIFF
--- a/packages/core/src/components/menu-item/menu-item.scss
+++ b/packages/core/src/components/menu-item/menu-item.scss
@@ -76,6 +76,7 @@ ix-menu-item {
     @include ellipsis;
     color: var(--theme-nav-item-primary--color);
     margin: 0 1.25rem;
+    user-select: none;
   }
 
   &.active,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/siemens/ix) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test` and `yarn visual-regression` (docker needed)).
  5. Format your code with [prettier](https://github.com/prettier/prettier).
  6. Make sure your code lints.

-->

## Summary

Preventing the text inside menu items to be selected by user leads to less confusion when clicking on respective items since no text hightlighting will get shown. It is rather unlikely that the user will want to select the menu text to e.g. copy/paste it.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
