### PR TITLE
feat(core/appliaction-header): load optional application logo

### DIFF
--- a/packages/core/src/components/application-header/application-header.tsx
+++ b/packages/core/src/components/application-header/application-header.tsx
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Component, h, Host, Prop } from '@stencil/core';
+import { Component, Element, h, Host, Prop } from '@stencil/core';
 
 @Component({
   tag: 'ix-application-header',
@@ -15,10 +15,25 @@ import { Component, h, Host, Prop } from '@stencil/core';
   shadow: true,
 })
 export class ApplicationHeader {
+  @Element() host!: HTMLIxApplicationHeaderElement;
+
   /**
    * Application name
    */
   @Prop() name: string;
+
+  componentDidLoad() {
+    this.attachSiemensLogoIfLoaded();
+  }
+
+  private async attachSiemensLogoIfLoaded() {
+    await window.customElements.whenDefined('ix-siemens-logo');
+    const logoElement = document.createElement('ix-siemens-logo');
+
+    if (!this.host.querySelector('[slot="logo"]')) {
+      this.host.shadowRoot.querySelector('.logo').appendChild(logoElement);
+    }
+  }
 
   render() {
     return (

--- a/packages/core/src/index.html
+++ b/packages/core/src/index.html
@@ -18,14 +18,6 @@ SPDX-License-Identifier: MIT
     <script nomodule src="/build/siemens-ix.js"></script>
 
     <link rel="stylesheet" href="/build/siemens-ix.css" />
-    <!-- Temp. Workaround for brand theme to live inside core package  -->
-    <link rel="stylesheet" href="/build/ix-brand-theme/ix-brand-theme.css" />
-    <script
-      type="module"
-      src="/build/ix-brand-theme/ix-brand-theme.esm.js"
-    ></script>
-    <script nomodule src="/build/ix-brand-theme/ix-brand-theme.js"></script>
-
     <link rel="stylesheet" href="/build/ix-icons/css/ix-icons.css" />
   </head>
   <body style="margin: 0px; height: 100vh">


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/siemens/ix) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test` and `yarn visual-regression` (docker needed)).
  5. Format your code with [prettier](https://github.com/prettier/prettier).
  6. Make sure your code lints.

-->

## Summary

Load default siemens logo if brand theme related svg is existing