### PR TITLE
feat(documentation/generate-api): generate docs tags into api table

### DIFF
--- a/packages/documentation/docs/auto-generated/ix-animated-tab/props.md
+++ b/packages/documentation/docs/auto-generated/ix-animated-tab/props.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|count| Show notification number | `count` | `number` | `undefined` |
-|icon| Icon of the tab | `icon` | `string` | `undefined` |
+|<div className="Api__Table"> <div>count</div> <div className="Api__Table Docs__Tags"></div></div>| Show notification number | `count` | `number` | `undefined` |
+|<div className="Api__Table"> <div>icon</div> <div className="Api__Table Docs__Tags"></div></div>| Icon of the tab | `icon` | `string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-animated-tabs/events.md
+++ b/packages/documentation/docs/auto-generated/ix-animated-tabs/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|tabClick| Tab navigated | `any`
+|<div className="Api__Table"> <div>tabClick</div> <div className="Api__Table Docs__Tags"></div></div>| Tab navigated | `any`

--- a/packages/documentation/docs/auto-generated/ix-animated-tabs/props.md
+++ b/packages/documentation/docs/auto-generated/ix-animated-tabs/props.md
@@ -1,5 +1,5 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|disableAnimations|  | `disable-animations` | `boolean` | `false` |
-|selectedIndex| Current selected tab index | `selected-index` | `number` | `0` |
-|tabPlacement| Placement of the tabs | `tab-placement` | `"bottom" ｜ "top"` | `'top'` |
+|<div className="Api__Table"> <div>disableAnimations</div> <div className="Api__Table Docs__Tags"></div></div>|  | `disable-animations` | `boolean` | `false` |
+|<div className="Api__Table"> <div>selectedIndex</div> <div className="Api__Table Docs__Tags"></div></div>| Current selected tab index | `selected-index` | `number` | `0` |
+|<div className="Api__Table"> <div>tabPlacement</div> <div className="Api__Table Docs__Tags"></div></div>| Placement of the tabs | `tab-placement` | `"bottom" ｜ "top"` | `'top'` |

--- a/packages/documentation/docs/auto-generated/ix-application-header/props.md
+++ b/packages/documentation/docs/auto-generated/ix-application-header/props.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|name| Application name | `name` | `string` | `undefined` |
+|<div className="Api__Table"> <div>name</div> <div className="Api__Table Docs__Tags"></div></div>| Application name | `name` | `string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-basic-navigation/props.md
+++ b/packages/documentation/docs/auto-generated/ix-basic-navigation/props.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|applicationName| Application name | `application-name` | `string` | `undefined` |
-|hideHeader| Hide application header | `hide-header` | `boolean` | `false` |
+|<div className="Api__Table"> <div>applicationName</div> <div className="Api__Table Docs__Tags"></div></div>| Application name | `application-name` | `string` | `undefined` |
+|<div className="Api__Table"> <div>hideHeader</div> <div className="Api__Table Docs__Tags"></div></div>| Hide application header | `hide-header` | `boolean` | `false` |

--- a/packages/documentation/docs/auto-generated/ix-blind/events.md
+++ b/packages/documentation/docs/auto-generated/ix-blind/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|collapsedChange| Collapsed state changed | `boolean`
+|<div className="Api__Table"> <div>collapsedChange</div> <div className="Api__Table Docs__Tags"></div></div>| Collapsed state changed | `boolean`

--- a/packages/documentation/docs/auto-generated/ix-blind/props.md
+++ b/packages/documentation/docs/auto-generated/ix-blind/props.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|collapsed| Collapsed state | `collapsed` | `boolean` | `false` |
-|label| Label of blind | `label` | `string` | `undefined` |
+|<div className="Api__Table"> <div>collapsed</div> <div className="Api__Table Docs__Tags"></div></div>| Collapsed state | `collapsed` | `boolean` | `false` |
+|<div className="Api__Table"> <div>label</div> <div className="Api__Table Docs__Tags"></div></div>| Label of blind | `label` | `string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-breadcrumb-item/props.md
+++ b/packages/documentation/docs/auto-generated/ix-breadcrumb-item/props.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|icon| Icon to be displayed next ot the label | `icon` | `string` | `undefined` |
-|label| Breadcrumb label | `label` | `string` | `undefined` |
+|<div className="Api__Table"> <div>icon</div> <div className="Api__Table Docs__Tags"></div></div>| Icon to be displayed next ot the label | `icon` | `string` | `undefined` |
+|<div className="Api__Table"> <div>label</div> <div className="Api__Table Docs__Tags"></div></div>| Breadcrumb label | `label` | `string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-breadcrumb/events.md
+++ b/packages/documentation/docs/auto-generated/ix-breadcrumb/events.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|itemClick| Crumb item clicked event | `string`
-|nextClick| Next item clicked event | `{ event: UIEvent; item: string; }`
+|<div className="Api__Table"> <div>itemClick</div> <div className="Api__Table Docs__Tags"></div></div>| Crumb item clicked event | `string`
+|<div className="Api__Table"> <div>nextClick</div> <div className="Api__Table Docs__Tags"></div></div>| Next item clicked event | `{ event: UIEvent; item: string; }`

--- a/packages/documentation/docs/auto-generated/ix-breadcrumb/props.md
+++ b/packages/documentation/docs/auto-generated/ix-breadcrumb/props.md
@@ -1,5 +1,5 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|ghost| Ghost breadcrumbs will not show solid backgrounds on individual crumbs unless there is a mouse event (e.g. hover) | `ghost` | `boolean` | `false` |
-|nextItems| Items will be accessible through a dropdown | `undefined` | `string[]` | `[]` |
-|visibleItemCount| Excess items will get hidden inside of dropdown | `visible-item-count` | `number` | `9` |
+|<div className="Api__Table"> <div>ghost</div> <div className="Api__Table Docs__Tags"></div></div>| Ghost breadcrumbs will not show solid backgrounds on individual crumbs unless there is a mouse event (e.g. hover) | `ghost` | `boolean` | `false` |
+|<div className="Api__Table"> <div>nextItems</div> <div className="Api__Table Docs__Tags"></div></div>| Items will be accessible through a dropdown | `undefined` | `string[]` | `[]` |
+|<div className="Api__Table"> <div>visibleItemCount</div> <div className="Api__Table Docs__Tags"></div></div>| Excess items will get hidden inside of dropdown | `visible-item-count` | `number` | `9` |

--- a/packages/documentation/docs/auto-generated/ix-button/props.md
+++ b/packages/documentation/docs/auto-generated/ix-button/props.md
@@ -1,9 +1,9 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|disabled| Disable the button | `disabled` | `boolean` | `false` |
-|ghost| Button with no background or outline | `ghost` | `boolean` | `false` |
-|invisible| Invisible button | `invisible` | `boolean` | `false` |
-|outline| Outline button | `outline` | `boolean` | `false` |
-|selected| Show button as selected. Should be used with outline or invisible | `selected` | `boolean` | `false` |
-|type| Type of the button | `type` | `"button" ｜ "submit"` | `'button'` |
-|variant| Button varaint | `variant` | `"Primary" ｜ "Secondary"` | `'Primary'` |
+|<div className="Api__Table"> <div>disabled</div> <div className="Api__Table Docs__Tags"></div></div>| Disable the button | `disabled` | `boolean` | `false` |
+|<div className="Api__Table"> <div>ghost</div> <div className="Api__Table Docs__Tags"></div></div>| Button with no background or outline | `ghost` | `boolean` | `false` |
+|<div className="Api__Table"> <div>invisible</div> <div className="Api__Table Docs__Tags"></div></div>| Invisible button | `invisible` | `boolean` | `false` |
+|<div className="Api__Table"> <div>outline</div> <div className="Api__Table Docs__Tags"></div></div>| Outline button | `outline` | `boolean` | `false` |
+|<div className="Api__Table"> <div>selected</div> <div className="Api__Table Docs__Tags"></div></div>| Show button as selected. Should be used with outline or invisible | `selected` | `boolean` | `false` |
+|<div className="Api__Table"> <div>type</div> <div className="Api__Table Docs__Tags"></div></div>| Type of the button | `type` | `"button" ｜ "submit"` | `'button'` |
+|<div className="Api__Table"> <div>variant</div> <div className="Api__Table Docs__Tags"></div></div>| Button varaint | `variant` | `"Primary" ｜ "Secondary"` | `'Primary'` |

--- a/packages/documentation/docs/auto-generated/ix-category-filter/events.md
+++ b/packages/documentation/docs/auto-generated/ix-category-filter/events.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|filterChanged| Event dispatched whenever the filter state changes. | `FilterState`
-|inputChanged| Event dispatched whenever the text input changes. | `InputState`
+|<div className="Api__Table"> <div>filterChanged</div> <div className="Api__Table Docs__Tags"></div></div>| Event dispatched whenever the filter state changes. | `FilterState`
+|<div className="Api__Table"> <div>inputChanged</div> <div className="Api__Table Docs__Tags"></div></div>| Event dispatched whenever the text input changes. | `InputState`

--- a/packages/documentation/docs/auto-generated/ix-category-filter/props.md
+++ b/packages/documentation/docs/auto-generated/ix-category-filter/props.md
@@ -1,14 +1,14 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|categories| Configuration object hash used to populate the dropwdown menu for typeahead and quick selection functionality. Each ID maps to an object with a label and an array of options to select from. | `undefined` | `{ [id: string]: { label: string; options: string[]; }; }` | `undefined` |
-|filterState| A set of search criteria to populate the component with. | `undefined` | `FilterState` | `undefined` |
-|hideIcon| Allows to hide the icon inside the text input. Defaults to false | `hide-icon` | `boolean` | `undefined` |
-|i18nPlainText| i18n | `i-1-8n-plain-text` | `string` | `'Filter by text'` |
-|icon| The icon next to the actual text input Defaults to 'search' | `icon` | `string` | `'search'` |
-|initialState| When set this will initially populate the component with the provided search criteria. This will trigger all input events accordingly. | `undefined` | `FilterState` | `undefined` |
-|labelCategories| i18n | `label-categories` | `string` | `'Categories'` |
-|nonSelectableCategories| In certain use cases some categories are not available for selection any more. To allow proper display of set filters with these categories this ID to label mapping can be populated. Configuration object hash used to supply labels to the filter chips in the input field. Each ID maps to a string representing the label to display. | `undefined` | `{ [id: string]: string; }` | `{}` |
-|placeholder| Placeholder text to be displayed in an empty input field. | `placeholder` | `string` | `undefined` |
-|repeatCategories| If set to true allows that a single category can be set more than once. An already set category will not appear in the category dropdown if set to false.<br /><br />Defaults to true | `repeat-categories` | `boolean` | `true` |
-|suggestions| A list of strings that will be supplied as typeahead suggestions not tied to any categories. | `undefined` | `string[]` | `undefined` |
-|tmpDisableScrollIntoView|  | `tmp-disable-scroll-into-view` | `boolean` | `true` |
+|<div className="Api__Table"> <div>categories</div> <div className="Api__Table Docs__Tags"></div></div>| Configuration object hash used to populate the dropwdown menu for typeahead and quick selection functionality. Each ID maps to an object with a label and an array of options to select from. | `undefined` | `{ [id: string]: { label: string; options: string[]; }; }` | `undefined` |
+|<div className="Api__Table"> <div>filterState</div> <div className="Api__Table Docs__Tags"></div></div>| A set of search criteria to populate the component with. | `undefined` | `FilterState` | `undefined` |
+|<div className="Api__Table"> <div>hideIcon</div> <div className="Api__Table Docs__Tags"></div></div>| Allows to hide the icon inside the text input. Defaults to false | `hide-icon` | `boolean` | `undefined` |
+|<div className="Api__Table"> <div>i18nPlainText</div> <div className="Api__Table Docs__Tags"></div></div>| i18n | `i-1-8n-plain-text` | `string` | `'Filter by text'` |
+|<div className="Api__Table"> <div>icon</div> <div className="Api__Table Docs__Tags"></div></div>| The icon next to the actual text input Defaults to 'search' | `icon` | `string` | `'search'` |
+|<div className="Api__Table"> <div>initialState</div> <div className="Api__Table Docs__Tags"></div></div>| When set this will initially populate the component with the provided search criteria. This will trigger all input events accordingly. | `undefined` | `FilterState` | `undefined` |
+|<div className="Api__Table"> <div>labelCategories</div> <div className="Api__Table Docs__Tags"></div></div>| i18n | `label-categories` | `string` | `'Categories'` |
+|<div className="Api__Table"> <div>nonSelectableCategories</div> <div className="Api__Table Docs__Tags"></div></div>| In certain use cases some categories are not available for selection any more. To allow proper display of set filters with these categories this ID to label mapping can be populated. Configuration object hash used to supply labels to the filter chips in the input field. Each ID maps to a string representing the label to display. | `undefined` | `{ [id: string]: string; }` | `{}` |
+|<div className="Api__Table"> <div>placeholder</div> <div className="Api__Table Docs__Tags"></div></div>| Placeholder text to be displayed in an empty input field. | `placeholder` | `string` | `undefined` |
+|<div className="Api__Table"> <div>repeatCategories</div> <div className="Api__Table Docs__Tags"></div></div>| If set to true allows that a single category can be set more than once. An already set category will not appear in the category dropdown if set to false.<br /><br />Defaults to true | `repeat-categories` | `boolean` | `true` |
+|<div className="Api__Table"> <div>suggestions</div> <div className="Api__Table Docs__Tags"></div></div>| A list of strings that will be supplied as typeahead suggestions not tied to any categories. | `undefined` | `string[]` | `undefined` |
+|<div className="Api__Table"> <div>tmpDisableScrollIntoView</div> <div className="Api__Table Docs__Tags"></div></div>|  | `tmp-disable-scroll-into-view` | `boolean` | `true` |

--- a/packages/documentation/docs/auto-generated/ix-chip/events.md
+++ b/packages/documentation/docs/auto-generated/ix-chip/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|close| Fire event if close button is clicked | `any`
+|<div className="Api__Table"> <div>close</div> <div className="Api__Table Docs__Tags"></div></div>| Fire event if close button is clicked | `any`

--- a/packages/documentation/docs/auto-generated/ix-chip/props.md
+++ b/packages/documentation/docs/auto-generated/ix-chip/props.md
@@ -1,9 +1,9 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|active| Display chip in active state. Only working witht `variant="primary"` | `active` | `boolean` | `false` |
-|background| Custom color for pill. Only working for `variant='custom'` | `background` | `string` | `undefined` |
-|closable| Show close icon | `closable` | `boolean` | `false` |
-|color| Custom font color for pill. Only working for `variant='custom'` | `color` | `string` | `undefined` |
-|icon| Show icon | `icon` | `string` | `undefined` |
-|outline| Show chip with outline style | `outline` | `boolean` | `false` |
-|variant| Chip variant | `variant` | `"alarm" ｜ "critical" ｜ "custom" ｜ "info" ｜ "neutral" ｜ "primary" ｜ "success" ｜ "warning"` | `'primary'` |
+|<div className="Api__Table"> <div>active</div> <div className="Api__Table Docs__Tags"></div></div>| Display chip in active state. Only working witht `variant="primary"` | `active` | `boolean` | `false` |
+|<div className="Api__Table"> <div>background</div> <div className="Api__Table Docs__Tags"></div></div>| Custom color for pill. Only working for `variant='custom'` | `background` | `string` | `undefined` |
+|<div className="Api__Table"> <div>closable</div> <div className="Api__Table Docs__Tags"></div></div>| Show close icon | `closable` | `boolean` | `false` |
+|<div className="Api__Table"> <div>color</div> <div className="Api__Table Docs__Tags"></div></div>| Custom font color for pill. Only working for `variant='custom'` | `color` | `string` | `undefined` |
+|<div className="Api__Table"> <div>icon</div> <div className="Api__Table Docs__Tags"></div></div>| Show icon | `icon` | `string` | `undefined` |
+|<div className="Api__Table"> <div>outline</div> <div className="Api__Table Docs__Tags"></div></div>| Show chip with outline style | `outline` | `boolean` | `false` |
+|<div className="Api__Table"> <div>variant</div> <div className="Api__Table Docs__Tags"></div></div>| Chip variant | `variant` | `"alarm" ｜ "critical" ｜ "custom" ｜ "info" ｜ "neutral" ｜ "primary" ｜ "success" ｜ "warning"` | `'primary'` |

--- a/packages/documentation/docs/auto-generated/ix-counter-pill/props.md
+++ b/packages/documentation/docs/auto-generated/ix-counter-pill/props.md
@@ -1,7 +1,7 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|alignLeft| Align pill content left | `align-left` | `boolean` | `false` |
-|background| Custom color for pill. Only working for `variant='custom'` | `background` | `string` | `undefined` |
-|color| Custom font color for pill. Only working for `variant='custom'` | `color` | `string` | `undefined` |
-|outline| Show pill as outline | `outline` | `boolean` | `false` |
-|variant| Pill variant | `variant` | `"alarm" ｜ "critical" ｜ "custom" ｜ "info" ｜ "neutral" ｜ "primary" ｜ "success" ｜ "warning"` | `'primary'` |
+|<div className="Api__Table"> <div>alignLeft</div> <div className="Api__Table Docs__Tags"></div></div>| Align pill content left | `align-left` | `boolean` | `false` |
+|<div className="Api__Table"> <div>background</div> <div className="Api__Table Docs__Tags"></div></div>| Custom color for pill. Only working for `variant='custom'` | `background` | `string` | `undefined` |
+|<div className="Api__Table"> <div>color</div> <div className="Api__Table Docs__Tags"></div></div>| Custom font color for pill. Only working for `variant='custom'` | `color` | `string` | `undefined` |
+|<div className="Api__Table"> <div>outline</div> <div className="Api__Table Docs__Tags"></div></div>| Show pill as outline | `outline` | `boolean` | `false` |
+|<div className="Api__Table"> <div>variant</div> <div className="Api__Table Docs__Tags"></div></div>| Pill variant | `variant` | `"alarm" ｜ "critical" ｜ "custom" ｜ "info" ｜ "neutral" ｜ "primary" ｜ "success" ｜ "warning"` | `'primary'` |

--- a/packages/documentation/docs/auto-generated/ix-date-picker/events.md
+++ b/packages/documentation/docs/auto-generated/ix-date-picker/events.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|dateChange| Time change event | `string`
-|done| done event | `string`
+|<div className="Api__Table"> <div>dateChange</div> <div className="Api__Table Docs__Tags"></div></div>| Time change event | `string`
+|<div className="Api__Table"> <div>done</div> <div className="Api__Table Docs__Tags"></div></div>| done event | `string`

--- a/packages/documentation/docs/auto-generated/ix-date-picker/props.md
+++ b/packages/documentation/docs/auto-generated/ix-date-picker/props.md
@@ -1,6 +1,6 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|corners| Set corners style | `corners` | `"left" ｜ "right" ｜ "rounded"` | `'rounded'` |
-|format| output date format | `format` | `string` | `'yyyy/LL/dd'` |
-|individual| set styles | `individual` | `boolean` | `true` |
-|range| Set range size | `range` | `boolean` | `true` |
+|<div className="Api__Table"> <div>corners</div> <div className="Api__Table Docs__Tags"></div></div>| Set corners style | `corners` | `"left" ｜ "right" ｜ "rounded"` | `'rounded'` |
+|<div className="Api__Table"> <div>format</div> <div className="Api__Table Docs__Tags"></div></div>| output date format | `format` | `string` | `'yyyy/LL/dd'` |
+|<div className="Api__Table"> <div>individual</div> <div className="Api__Table Docs__Tags"></div></div>| set styles | `individual` | `boolean` | `true` |
+|<div className="Api__Table"> <div>range</div> <div className="Api__Table Docs__Tags"></div></div>| Set range size | `range` | `boolean` | `true` |

--- a/packages/documentation/docs/auto-generated/ix-date-time-card/props.md
+++ b/packages/documentation/docs/auto-generated/ix-date-time-card/props.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|corners| Set corners style | `corners` | `"left" ｜ "right" ｜ "rounded"` | `'rounded'` |
-|individual| set styles | `individual` | `boolean` | `true` |
+|<div className="Api__Table"> <div>corners</div> <div className="Api__Table Docs__Tags"></div></div>| Set corners style | `corners` | `"left" ｜ "right" ｜ "rounded"` | `'rounded'` |
+|<div className="Api__Table"> <div>individual</div> <div className="Api__Table Docs__Tags"></div></div>| set styles | `individual` | `boolean` | `true` |

--- a/packages/documentation/docs/auto-generated/ix-datetime-picker/events.md
+++ b/packages/documentation/docs/auto-generated/ix-datetime-picker/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|done| Time event | `string`
+|<div className="Api__Table"> <div>done</div> <div className="Api__Table Docs__Tags"></div></div>| Time event | `string`

--- a/packages/documentation/docs/auto-generated/ix-datetime-picker/props.md
+++ b/packages/documentation/docs/auto-generated/ix-datetime-picker/props.md
@@ -1,7 +1,7 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|range| Set range size | `range` | `boolean` | `true` |
-|showHour| Show Hour Input | `show-hour` | `boolean` | `false` |
-|showMinutes| Show Minutes Input | `show-minutes` | `boolean` | `false` |
-|showSeconds| Show Seconds Input | `show-seconds` | `boolean` | `false` |
-|showTimeReference| Show Time Reference Input | `show-time-reference` | `boolean` | `false` |
+|<div className="Api__Table"> <div>range</div> <div className="Api__Table Docs__Tags"></div></div>| Set range size | `range` | `boolean` | `true` |
+|<div className="Api__Table"> <div>showHour</div> <div className="Api__Table Docs__Tags"></div></div>| Show Hour Input | `show-hour` | `boolean` | `false` |
+|<div className="Api__Table"> <div>showMinutes</div> <div className="Api__Table Docs__Tags"></div></div>| Show Minutes Input | `show-minutes` | `boolean` | `false` |
+|<div className="Api__Table"> <div>showSeconds</div> <div className="Api__Table Docs__Tags"></div></div>| Show Seconds Input | `show-seconds` | `boolean` | `false` |
+|<div className="Api__Table"> <div>showTimeReference</div> <div className="Api__Table Docs__Tags"></div></div>| Show Time Reference Input | `show-time-reference` | `boolean` | `false` |

--- a/packages/documentation/docs/auto-generated/ix-drawer/events.md
+++ b/packages/documentation/docs/auto-generated/ix-drawer/events.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|drawerClose| Fire event after drawer is close | `any`
-|open| Fire event after drawer is open | `any`
+|<div className="Api__Table"> <div>drawerClose</div> <div className="Api__Table Docs__Tags"></div></div>| Fire event after drawer is close | `any`
+|<div className="Api__Table"> <div>open</div> <div className="Api__Table Docs__Tags"></div></div>| Fire event after drawer is open | `any`

--- a/packages/documentation/docs/auto-generated/ix-drawer/props.md
+++ b/packages/documentation/docs/auto-generated/ix-drawer/props.md
@@ -1,8 +1,8 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|closeOnClickOutside| Fired in case of an outside click during drawer showed state | `close-on-click-outside` | `boolean` | `true` |
-|fullHeight| Render the drawer with maximum height | `full-height` | `boolean` | `false` |
-|maxWidth| Max width interpreted as REM | `max-width` | `number` | `28` |
-|minWidth| Min width interpreted as REM | `min-width` | `number` | `16` |
-|show| Show or hide the drawer | `show` | `boolean` | `false` |
-|width| Width interpreted as REM if not set to 'auto' | `width` | `"auto" ｜ number` | `this.minWidth` |
+|<div className="Api__Table"> <div>closeOnClickOutside</div> <div className="Api__Table Docs__Tags"></div></div>| Fired in case of an outside click during drawer showed state | `close-on-click-outside` | `boolean` | `true` |
+|<div className="Api__Table"> <div>fullHeight</div> <div className="Api__Table Docs__Tags"></div></div>| Render the drawer with maximum height | `full-height` | `boolean` | `false` |
+|<div className="Api__Table"> <div>maxWidth</div> <div className="Api__Table Docs__Tags"></div></div>| Max width interpreted as REM | `max-width` | `number` | `28` |
+|<div className="Api__Table"> <div>minWidth</div> <div className="Api__Table Docs__Tags"></div></div>| Min width interpreted as REM | `min-width` | `number` | `16` |
+|<div className="Api__Table"> <div>show</div> <div className="Api__Table Docs__Tags"></div></div>| Show or hide the drawer | `show` | `boolean` | `false` |
+|<div className="Api__Table"> <div>width</div> <div className="Api__Table Docs__Tags"></div></div>| Width interpreted as REM if not set to 'auto' | `width` | `"auto" ｜ number` | `this.minWidth` |

--- a/packages/documentation/docs/auto-generated/ix-dropdown-item/events.md
+++ b/packages/documentation/docs/auto-generated/ix-dropdown-item/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|itemClick| Click on item | `HTMLIxDropdownItemElement`
+|<div className="Api__Table"> <div>itemClick</div> <div className="Api__Table Docs__Tags"></div></div>| Click on item | `HTMLIxDropdownItemElement`

--- a/packages/documentation/docs/auto-generated/ix-dropdown-item/props.md
+++ b/packages/documentation/docs/auto-generated/ix-dropdown-item/props.md
@@ -1,7 +1,7 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|checked| Whether the item is checked or not. If true a checkmark will mark the item as checked. | `checked` | `boolean` | `false` |
-|disabled| Disable item and remove event listeners | `disabled` | `boolean` | `false` |
-|hover| Display hover state | `hover` | `boolean` | `false` |
-|icon| Icon of dropdown item | `icon` | `string` | `undefined` |
-|label| Label of dropdown item | `label` | `string` | `undefined` |
+|<div className="Api__Table"> <div>checked</div> <div className="Api__Table Docs__Tags"></div></div>| Whether the item is checked or not. If true a checkmark will mark the item as checked. | `checked` | `boolean` | `false` |
+|<div className="Api__Table"> <div>disabled</div> <div className="Api__Table Docs__Tags"></div></div>| Disable item and remove event listeners | `disabled` | `boolean` | `false` |
+|<div className="Api__Table"> <div>hover</div> <div className="Api__Table Docs__Tags"></div></div>| Display hover state | `hover` | `boolean` | `false` |
+|<div className="Api__Table"> <div>icon</div> <div className="Api__Table Docs__Tags"></div></div>| Icon of dropdown item | `icon` | `string` | `undefined` |
+|<div className="Api__Table"> <div>label</div> <div className="Api__Table Docs__Tags"></div></div>| Label of dropdown item | `label` | `string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-dropdown/events.md
+++ b/packages/documentation/docs/auto-generated/ix-dropdown/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|showChanged| Fire event after visibility of dropdown has changed | `boolean`
+|<div className="Api__Table"> <div>showChanged</div> <div className="Api__Table Docs__Tags"></div></div>| Fire event after visibility of dropdown has changed | `boolean`

--- a/packages/documentation/docs/auto-generated/ix-dropdown/props.md
+++ b/packages/documentation/docs/auto-generated/ix-dropdown/props.md
@@ -1,11 +1,11 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|adjustDropdownWidthToReferenceWidth| Adjust dropdown width to the parent width | `adjust-dropdown-width-to-reference-width` | `boolean` | `false` |
-|adjustDropdownWidthToReferenceWith| Adjust dropdown width to the parent width | `adjust-dropdown-width-to-reference-with` | `boolean` | `false` |
-|anchor| Define an anchor element | `anchor` | `HTMLElement ｜ string` | `undefined` |
-|closeBehavior| Close behavior | `close-behavior` | `"both" ｜ "inside" ｜ "outside" ｜ boolean` | `'both'` |
-|header| An optional header shown at the top of the dropdown | `header` | `string` | `undefined` |
-|placement| Placement of the dropdown | `placement` | `"auto" ｜ "auto-end" ｜ "auto-start" ｜ "bottom" ｜ "bottom-end" ｜ "bottom-start" ｜ "left" ｜ "left-end" ｜ "left-start" ｜ "right" ｜ "right-end" ｜ "right-start" ｜ "top" ｜ "top-end" ｜ "top-start"` | `'bottom-end'` |
-|positioningStrategy| Position strategy | `positioning-strategy` | `"absolute" ｜ "fixed"` | `'fixed'` |
-|show| Show dropdown | `show` | `boolean` | `false` |
-|trigger| Define an element that triggers the dropdown. A trigger can either be a string that will be interprated as id attribute or a DOM element. | `trigger` | `HTMLElement ｜ string` | `undefined` |
+|<div className="Api__Table"> <div>adjustDropdownWidthToReferenceWidth</div> <div className="Api__Table Docs__Tags"></div></div>| Adjust dropdown width to the parent width | `adjust-dropdown-width-to-reference-width` | `boolean` | `false` |
+|<div className="Api__Table"> <div>adjustDropdownWidthToReferenceWith</div> <div className="Api__Table Docs__Tags"></div></div>| Adjust dropdown width to the parent width | `adjust-dropdown-width-to-reference-with` | `boolean` | `false` |
+|<div className="Api__Table"> <div>anchor</div> <div className="Api__Table Docs__Tags"></div></div>| Define an anchor element | `anchor` | `HTMLElement ｜ string` | `undefined` |
+|<div className="Api__Table"> <div>closeBehavior</div> <div className="Api__Table Docs__Tags"></div></div>| Close behavior | `close-behavior` | `"both" ｜ "inside" ｜ "outside" ｜ boolean` | `'both'` |
+|<div className="Api__Table"> <div>header</div> <div className="Api__Table Docs__Tags"></div></div>| An optional header shown at the top of the dropdown | `header` | `string` | `undefined` |
+|<div className="Api__Table"> <div>placement</div> <div className="Api__Table Docs__Tags"></div></div>| Placement of the dropdown | `placement` | `"auto" ｜ "auto-end" ｜ "auto-start" ｜ "bottom" ｜ "bottom-end" ｜ "bottom-start" ｜ "left" ｜ "left-end" ｜ "left-start" ｜ "right" ｜ "right-end" ｜ "right-start" ｜ "top" ｜ "top-end" ｜ "top-start"` | `'bottom-end'` |
+|<div className="Api__Table"> <div>positioningStrategy</div> <div className="Api__Table Docs__Tags"></div></div>| Position strategy | `positioning-strategy` | `"absolute" ｜ "fixed"` | `'fixed'` |
+|<div className="Api__Table"> <div>show</div> <div className="Api__Table Docs__Tags"></div></div>| Show dropdown | `show` | `boolean` | `false` |
+|<div className="Api__Table"> <div>trigger</div> <div className="Api__Table Docs__Tags"></div></div>| Define an element that triggers the dropdown. A trigger can either be a string that will be interprated as id attribute or a DOM element. | `trigger` | `HTMLElement ｜ string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-event-list-item/events.md
+++ b/packages/documentation/docs/auto-generated/ix-event-list-item/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|itemClick| Event list item click | `any`
+|<div className="Api__Table"> <div>itemClick</div> <div className="Api__Table Docs__Tags"></div></div>| Event list item click | `any`

--- a/packages/documentation/docs/auto-generated/ix-event-list-item/props.md
+++ b/packages/documentation/docs/auto-generated/ix-event-list-item/props.md
@@ -1,7 +1,7 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|chevron| Show chevron on right side of the event list item | `chevron` | `boolean` | `undefined` |
-|color| Color of the status indicator. Allowed values are all Core UI color names. | `color` | `string` | `undefined` |
-|disabled| Disable event list item | `disabled` | `boolean` | `undefined` |
-|opacity| Opacity of the status indicator. Defaults to 1.0 | `opacity` | `number` | `1` |
-|selected| Show event list item as selected | `selected` | `boolean` | `undefined` |
+|<div className="Api__Table"> <div>chevron</div> <div className="Api__Table Docs__Tags"></div></div>| Show chevron on right side of the event list item | `chevron` | `boolean` | `undefined` |
+|<div className="Api__Table"> <div>color</div> <div className="Api__Table Docs__Tags"></div></div>| Color of the status indicator. Allowed values are all Core UI color names. | `color` | `string` | `undefined` |
+|<div className="Api__Table"> <div>disabled</div> <div className="Api__Table Docs__Tags"></div></div>| Disable event list item | `disabled` | `boolean` | `undefined` |
+|<div className="Api__Table"> <div>opacity</div> <div className="Api__Table Docs__Tags"></div></div>| Opacity of the status indicator. Defaults to 1.0 | `opacity` | `number` | `1` |
+|<div className="Api__Table"> <div>selected</div> <div className="Api__Table Docs__Tags"></div></div>| Show event list item as selected | `selected` | `boolean` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-event-list/props.md
+++ b/packages/documentation/docs/auto-generated/ix-event-list/props.md
@@ -1,6 +1,6 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|animated| Animate state change transitions. Defaults to 'true'. | `animated` | `boolean` | `true` |
-|chevron| Display a chevron icon in list items. Defaults to 'false' | `chevron` | `boolean` | `undefined` |
-|compact| Make event-list items more compact | `compact` | `boolean` | `false` |
-|itemHeight| Determines the height of list items. This can either be one of two predefined sizes ('S' or 'L') or an absolute pixel value. In case a number is supplied it will get converted to rem internally. Defaults to 'S'. | `item-height` | `"L" ｜ "S" ｜ number` | `'S'` |
+|<div className="Api__Table"> <div>animated</div> <div className="Api__Table Docs__Tags"></div></div>| Animate state change transitions. Defaults to 'true'. | `animated` | `boolean` | `true` |
+|<div className="Api__Table"> <div>chevron</div> <div className="Api__Table Docs__Tags"></div></div>| Display a chevron icon in list items. Defaults to 'false' | `chevron` | `boolean` | `undefined` |
+|<div className="Api__Table"> <div>compact</div> <div className="Api__Table Docs__Tags"></div></div>| Make event-list items more compact | `compact` | `boolean` | `false` |
+|<div className="Api__Table"> <div>itemHeight</div> <div className="Api__Table Docs__Tags"></div></div>| Determines the height of list items. This can either be one of two predefined sizes ('S' or 'L') or an absolute pixel value. In case a number is supplied it will get converted to rem internally. Defaults to 'S'. | `item-height` | `"L" ｜ "S" ｜ number` | `'S'` |

--- a/packages/documentation/docs/auto-generated/ix-expanding-search/events.md
+++ b/packages/documentation/docs/auto-generated/ix-expanding-search/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|valueChange| Value changed | `string`
+|<div className="Api__Table"> <div>valueChange</div> <div className="Api__Table Docs__Tags"></div></div>| Value changed | `string`

--- a/packages/documentation/docs/auto-generated/ix-expanding-search/props.md
+++ b/packages/documentation/docs/auto-generated/ix-expanding-search/props.md
@@ -1,5 +1,5 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|icon| Search icon | `icon` | `string` | `'search'` |
-|placeholder| Placeholder text | `placeholder` | `string` | `'Enter text here'` |
-|value| Default value | `value` | `string` | `''` |
+|<div className="Api__Table"> <div>icon</div> <div className="Api__Table Docs__Tags"></div></div>| Search icon | `icon` | `string` | `'search'` |
+|<div className="Api__Table"> <div>placeholder</div> <div className="Api__Table Docs__Tags"></div></div>| Placeholder text | `placeholder` | `string` | `'Enter text here'` |
+|<div className="Api__Table"> <div>value</div> <div className="Api__Table Docs__Tags"></div></div>| Default value | `value` | `string` | `''` |

--- a/packages/documentation/docs/auto-generated/ix-filter-chip/events.md
+++ b/packages/documentation/docs/auto-generated/ix-filter-chip/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|closeClick| Close clicked | `void`
+|<div className="Api__Table"> <div>closeClick</div> <div className="Api__Table Docs__Tags"></div></div>| Close clicked | `void`

--- a/packages/documentation/docs/auto-generated/ix-filter-chip/props.md
+++ b/packages/documentation/docs/auto-generated/ix-filter-chip/props.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|disabled| If true the filter chip will be in disabled state | `disabled` | `boolean` | `false` |
+|<div className="Api__Table"> <div>disabled</div> <div className="Api__Table Docs__Tags"></div></div>| If true the filter chip will be in disabled state | `disabled` | `boolean` | `false` |

--- a/packages/documentation/docs/auto-generated/ix-flip-tile/props.md
+++ b/packages/documentation/docs/auto-generated/ix-flip-tile/props.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|footer| Tmp property name | `footer` | `string` | `undefined` |
-|state| Variation of the Flip | `state` | `FlipTileState.Alarm ｜ FlipTileState.Info ｜ FlipTileState.None ｜ FlipTileState.Primary ｜ FlipTileState.Warning` | `undefined` |
+|<div className="Api__Table"> <div>footer</div> <div className="Api__Table Docs__Tags"></div></div>| Tmp property name | `footer` | `string` | `undefined` |
+|<div className="Api__Table"> <div>state</div> <div className="Api__Table Docs__Tags"></div></div>| Variation of the Flip | `state` | `FlipTileState.Alarm ｜ FlipTileState.Info ｜ FlipTileState.None ｜ FlipTileState.Primary ｜ FlipTileState.Warning` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-group-dropdown-item/props.md
+++ b/packages/documentation/docs/auto-generated/ix-group-dropdown-item/props.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|icon| Group dropdown icon | `icon` | `string` | `undefined` |
-|label| Group dropdown label | `label` | `string` | `undefined` |
+|<div className="Api__Table"> <div>icon</div> <div className="Api__Table Docs__Tags"></div></div>| Group dropdown icon | `icon` | `string` | `undefined` |
+|<div className="Api__Table"> <div>label</div> <div className="Api__Table Docs__Tags"></div></div>| Group dropdown label | `label` | `string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-group-item/events.md
+++ b/packages/documentation/docs/auto-generated/ix-group-item/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|selectedChanged| Selection changed | `HTMLIxGroupItemElement`
+|<div className="Api__Table"> <div>selectedChanged</div> <div className="Api__Table Docs__Tags"></div></div>| Selection changed | `HTMLIxGroupItemElement`

--- a/packages/documentation/docs/auto-generated/ix-group-item/props.md
+++ b/packages/documentation/docs/auto-generated/ix-group-item/props.md
@@ -1,9 +1,9 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|focusable| The elements tabindex attribute will get set accordingly. If true tabindex will be 0, -1 otherwise. | `focusable` | `boolean` | `true` |
-|icon| Group item icon | `icon` | `string` | `undefined` |
-|index| Index | `index` | `number` | `undefined` |
-|secondaryText| Group item secondary text | `secondary-text` | `string` | `undefined` |
-|selected| Show selected state | `selected` | `boolean` | `undefined` |
-|suppressSelection| Supress the selection of the group | `suppress-selection` | `boolean` | `false` |
-|text| Group item text | `text` | `string` | `undefined` |
+|<div className="Api__Table"> <div>focusable</div> <div className="Api__Table Docs__Tags"></div></div>| The elements tabindex attribute will get set accordingly. If true tabindex will be 0, -1 otherwise. | `focusable` | `boolean` | `true` |
+|<div className="Api__Table"> <div>icon</div> <div className="Api__Table Docs__Tags"></div></div>| Group item icon | `icon` | `string` | `undefined` |
+|<div className="Api__Table"> <div>index</div> <div className="Api__Table Docs__Tags"></div></div>| Index | `index` | `number` | `undefined` |
+|<div className="Api__Table"> <div>secondaryText</div> <div className="Api__Table Docs__Tags"></div></div>| Group item secondary text | `secondary-text` | `string` | `undefined` |
+|<div className="Api__Table"> <div>selected</div> <div className="Api__Table Docs__Tags"></div></div>| Show selected state | `selected` | `boolean` | `undefined` |
+|<div className="Api__Table"> <div>suppressSelection</div> <div className="Api__Table Docs__Tags"></div></div>| Supress the selection of the group | `suppress-selection` | `boolean` | `false` |
+|<div className="Api__Table"> <div>text</div> <div className="Api__Table Docs__Tags"></div></div>| Group item text | `text` | `string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-group/events.md
+++ b/packages/documentation/docs/auto-generated/ix-group/events.md
@@ -1,5 +1,5 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|collapsedChanged| Group collapsed | `boolean`
-|selectGroup| Emits when whole group gets selected. | `boolean`
-|selectItem| Emits when group item gets selected. | `number`
+|<div className="Api__Table"> <div>collapsedChanged</div> <div className="Api__Table Docs__Tags"></div></div>| Group collapsed | `boolean`
+|<div className="Api__Table"> <div>selectGroup</div> <div className="Api__Table Docs__Tags"></div></div>| Emits when whole group gets selected. | `boolean`
+|<div className="Api__Table"> <div>selectItem</div> <div className="Api__Table Docs__Tags"></div></div>| Emits when group item gets selected. | `number`

--- a/packages/documentation/docs/auto-generated/ix-group/props.md
+++ b/packages/documentation/docs/auto-generated/ix-group/props.md
@@ -1,9 +1,9 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|collapsed| Whether the group is collapsed or expanded. Defaults to true. | `collapsed` | `boolean` | `true` |
-|expandOnHeaderClick| Expand the group if the header is clicked | `expand-on-header-click` | `boolean` | `false` |
-|header| Group header | `header` | `string` | `undefined` |
-|index| The index of the selected group entry. If undefined no group item is selected. | `index` | `number` | `undefined` |
-|selected| Whether the group is selected. | `selected` | `boolean` | `undefined` |
-|subHeader| Group header subtitle | `sub-header` | `string` | `undefined` |
-|suppressHeaderSelection| Prevent header from being selectable | `suppress-header-selection` | `boolean` | `false` |
+|<div className="Api__Table"> <div>collapsed</div> <div className="Api__Table Docs__Tags"></div></div>| Whether the group is collapsed or expanded. Defaults to true. | `collapsed` | `boolean` | `true` |
+|<div className="Api__Table"> <div>expandOnHeaderClick</div> <div className="Api__Table Docs__Tags"></div></div>| Expand the group if the header is clicked | `expand-on-header-click` | `boolean` | `false` |
+|<div className="Api__Table"> <div>header</div> <div className="Api__Table Docs__Tags"></div></div>| Group header | `header` | `string` | `undefined` |
+|<div className="Api__Table"> <div>index</div> <div className="Api__Table Docs__Tags"></div></div>| The index of the selected group entry. If undefined no group item is selected. | `index` | `number` | `undefined` |
+|<div className="Api__Table"> <div>selected</div> <div className="Api__Table Docs__Tags"></div></div>| Whether the group is selected. | `selected` | `boolean` | `undefined` |
+|<div className="Api__Table"> <div>subHeader</div> <div className="Api__Table Docs__Tags"></div></div>| Group header subtitle | `sub-header` | `string` | `undefined` |
+|<div className="Api__Table"> <div>suppressHeaderSelection</div> <div className="Api__Table Docs__Tags"></div></div>| Prevent header from being selectable | `suppress-header-selection` | `boolean` | `false` |

--- a/packages/documentation/docs/auto-generated/ix-icon-button/props.md
+++ b/packages/documentation/docs/auto-generated/ix-icon-button/props.md
@@ -1,13 +1,13 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|color| Color of icon in  button | `color` | `string` | `undefined` |
-|disabled| Disabled | `disabled` | `boolean` | `false` |
-|ghost| Button invisible | `ghost` | `boolean` | `undefined` |
-|icon| Button icon | `icon` | `string` | `undefined` |
-|invisible| Button invisible | `invisible` | `boolean` | `undefined` |
-|outline| Button outline | `outline` | `boolean` | `undefined` |
-|oval| Button in oval shape | `oval` | `boolean` | `undefined` |
-|selected| Selected state only working with outline or invisible | `selected` | `boolean` | `false` |
-|size| Size of icon in button | `size` | `"12" ｜ "16" ｜ "24" ｜ "32"` | `'24'` |
-|type| Type of the button | `type` | `"button" ｜ "submit"` | `'button'` |
-|variant| Variant of button | `variant` | `"Primary" ｜ "Secondary"` | `'Secondary'` |
+|<div className="Api__Table"> <div>color</div> <div className="Api__Table Docs__Tags"></div></div>| Color of icon in  button | `color` | `string` | `undefined` |
+|<div className="Api__Table"> <div>disabled</div> <div className="Api__Table Docs__Tags"></div></div>| Disabled | `disabled` | `boolean` | `false` |
+|<div className="Api__Table"> <div>ghost</div> <div className="Api__Table Docs__Tags"></div></div>| Button invisible | `ghost` | `boolean` | `undefined` |
+|<div className="Api__Table"> <div>icon</div> <div className="Api__Table Docs__Tags"></div></div>| Button icon | `icon` | `string` | `undefined` |
+|<div className="Api__Table"> <div>invisible</div> <div className="Api__Table Docs__Tags"></div></div>| Button invisible | `invisible` | `boolean` | `undefined` |
+|<div className="Api__Table"> <div>outline</div> <div className="Api__Table Docs__Tags"></div></div>| Button outline | `outline` | `boolean` | `undefined` |
+|<div className="Api__Table"> <div>oval</div> <div className="Api__Table Docs__Tags"></div></div>| Button in oval shape | `oval` | `boolean` | `undefined` |
+|<div className="Api__Table"> <div>selected</div> <div className="Api__Table Docs__Tags"></div></div>| Selected state only working with outline or invisible | `selected` | `boolean` | `false` |
+|<div className="Api__Table"> <div>size</div> <div className="Api__Table Docs__Tags"></div></div>| Size of icon in button | `size` | `"12" ｜ "16" ｜ "24" ｜ "32"` | `'24'` |
+|<div className="Api__Table"> <div>type</div> <div className="Api__Table Docs__Tags"></div></div>| Type of the button | `type` | `"button" ｜ "submit"` | `'button'` |
+|<div className="Api__Table"> <div>variant</div> <div className="Api__Table Docs__Tags"></div></div>| Variant of button | `variant` | `"Primary" ｜ "Secondary"` | `'Secondary'` |

--- a/packages/documentation/docs/auto-generated/ix-icon/props.md
+++ b/packages/documentation/docs/auto-generated/ix-icon/props.md
@@ -1,5 +1,5 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|color| Color of the icon | `color` | `string` | `undefined` |
-|name| Use one of our defined icon names e.g. `copy`. | `name` | `string` | `undefined` |
-|size| Size of the icon | `size` | `"12" ｜ "16" ｜ "24" ｜ "32"` | `undefined` |
+|<div className="Api__Table"> <div>color</div> <div className="Api__Table Docs__Tags"></div></div>| Color of the icon | `color` | `string` | `undefined` |
+|<div className="Api__Table"> <div>name</div> <div className="Api__Table Docs__Tags"></div></div>| Use one of our defined icon names e.g. `copy`. | `name` | `string` | `undefined` |
+|<div className="Api__Table"> <div>size</div> <div className="Api__Table Docs__Tags"></div></div>| Size of the icon | `size` | `"12" ｜ "16" ｜ "24" ｜ "32"` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-kpi/props.md
+++ b/packages/documentation/docs/auto-generated/ix-kpi/props.md
@@ -1,7 +1,7 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|label|  | `label` | `string` | `undefined` |
-|orientation|  | `orientation` | `"horizontal" ｜ "vertical"` | `'horizontal'` |
-|state|  | `state` | `"alarm" ｜ "neutral" ｜ "warning"` | `'neutral'` |
-|unit|  | `unit` | `string` | `undefined` |
-|value|  | `value` | `number ｜ string` | `undefined` |
+|<div className="Api__Table"> <div>label</div> <div className="Api__Table Docs__Tags"></div></div>|  | `label` | `string` | `undefined` |
+|<div className="Api__Table"> <div>orientation</div> <div className="Api__Table Docs__Tags"></div></div>|  | `orientation` | `"horizontal" ｜ "vertical"` | `'horizontal'` |
+|<div className="Api__Table"> <div>state</div> <div className="Api__Table Docs__Tags"></div></div>|  | `state` | `"alarm" ｜ "neutral" ｜ "warning"` | `'neutral'` |
+|<div className="Api__Table"> <div>unit</div> <div className="Api__Table Docs__Tags"></div></div>|  | `unit` | `string` | `undefined` |
+|<div className="Api__Table"> <div>value</div> <div className="Api__Table Docs__Tags"></div></div>|  | `value` | `number ｜ string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-map-navigation-overlay/events.md
+++ b/packages/documentation/docs/auto-generated/ix-map-navigation-overlay/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|closeClick| Event closed | `any`
+|<div className="Api__Table"> <div>closeClick</div> <div className="Api__Table Docs__Tags"></div></div>| Event closed | `any`

--- a/packages/documentation/docs/auto-generated/ix-map-navigation-overlay/props.md
+++ b/packages/documentation/docs/auto-generated/ix-map-navigation-overlay/props.md
@@ -1,5 +1,5 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|color| Color of icon | `color` | `string` | `undefined` |
-|icon| Icon of overlay | `icon` | `string` | `undefined` |
-|name| Title of overlay | `name` | `string` | `undefined` |
+|<div className="Api__Table"> <div>color</div> <div className="Api__Table Docs__Tags"></div></div>| Color of icon | `color` | `string` | `undefined` |
+|<div className="Api__Table"> <div>icon</div> <div className="Api__Table Docs__Tags"></div></div>| Icon of overlay | `icon` | `string` | `undefined` |
+|<div className="Api__Table"> <div>name</div> <div className="Api__Table Docs__Tags"></div></div>| Title of overlay | `name` | `string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-map-navigation/events.md
+++ b/packages/documentation/docs/auto-generated/ix-map-navigation/events.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|contextMenuClick| Context menu clicked | `void`
-|navigationToggled| Navigation toggled | `boolean`
+|<div className="Api__Table"> <div>contextMenuClick</div> <div className="Api__Table Docs__Tags"></div></div>| Context menu clicked | `void`
+|<div className="Api__Table"> <div>navigationToggled</div> <div className="Api__Table Docs__Tags"></div></div>| Navigation toggled | `boolean`

--- a/packages/documentation/docs/auto-generated/ix-map-navigation/props.md
+++ b/packages/documentation/docs/auto-generated/ix-map-navigation/props.md
@@ -1,5 +1,5 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|applicationName| Application name | `application-name` | `string` | `undefined` |
-|hideContextMenu| Hide the sidebar context menu button when set to true | `hide-context-menu` | `boolean` | `true` |
-|navigationTitle| Navigation title | `navigation-title` | `string` | `undefined` |
+|<div className="Api__Table"> <div>applicationName</div> <div className="Api__Table Docs__Tags"></div></div>| Application name | `application-name` | `string` | `undefined` |
+|<div className="Api__Table"> <div>hideContextMenu</div> <div className="Api__Table Docs__Tags"></div></div>| Hide the sidebar context menu button when set to true | `hide-context-menu` | `boolean` | `true` |
+|<div className="Api__Table"> <div>navigationTitle</div> <div className="Api__Table Docs__Tags"></div></div>| Navigation title | `navigation-title` | `string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-menu-about-item/props.md
+++ b/packages/documentation/docs/auto-generated/ix-menu-about-item/props.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|label| About Item label | `label` | `string` | `undefined` |
+|<div className="Api__Table"> <div>label</div> <div className="Api__Table Docs__Tags"></div></div>| About Item label | `label` | `string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-menu-about-news/events.md
+++ b/packages/documentation/docs/auto-generated/ix-menu-about-news/events.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|closePopover| Popover closed | `void`
-|showMore| Show More button is pressed | `MouseEvent`
+|<div className="Api__Table"> <div>closePopover</div> <div className="Api__Table Docs__Tags"></div></div>| Popover closed | `void`
+|<div className="Api__Table"> <div>showMore</div> <div className="Api__Table Docs__Tags"></div></div>| Show More button is pressed | `MouseEvent`

--- a/packages/documentation/docs/auto-generated/ix-menu-about-news/props.md
+++ b/packages/documentation/docs/auto-generated/ix-menu-about-news/props.md
@@ -1,8 +1,8 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|aboutItemLabel| Subtitle of the about news | `about-item-label` | `string` | `undefined` |
-|expanded| Internal | `expanded` | `boolean` | `false` |
-|i18nShowMore|  | `i-1-8n-show-more` | `string` | `'Show more'` |
-|label| Title of the about news | `label` | `string` | `undefined` |
-|offsetBottom| Bottom offset | `offset-bottom` | `number` | `0` |
-|show| Show about news | `show` | `boolean` | `false` |
+|<div className="Api__Table"> <div>aboutItemLabel</div> <div className="Api__Table Docs__Tags"></div></div>| Subtitle of the about news | `about-item-label` | `string` | `undefined` |
+|<div className="Api__Table"> <div>expanded</div> <div className="Api__Table Docs__Tags"></div></div>| Internal | `expanded` | `boolean` | `false` |
+|<div className="Api__Table"> <div>i18nShowMore</div> <div className="Api__Table Docs__Tags"></div></div>|  | `i-1-8n-show-more` | `string` | `'Show more'` |
+|<div className="Api__Table"> <div>label</div> <div className="Api__Table Docs__Tags"></div></div>| Title of the about news | `label` | `string` | `undefined` |
+|<div className="Api__Table"> <div>offsetBottom</div> <div className="Api__Table Docs__Tags"></div></div>| Bottom offset | `offset-bottom` | `number` | `0` |
+|<div className="Api__Table"> <div>show</div> <div className="Api__Table Docs__Tags"></div></div>| Show about news | `show` | `boolean` | `false` |

--- a/packages/documentation/docs/auto-generated/ix-menu-about/events.md
+++ b/packages/documentation/docs/auto-generated/ix-menu-about/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|close| About and Legal closed | `MouseEvent`
+|<div className="Api__Table"> <div>close</div> <div className="Api__Table Docs__Tags"></div></div>| About and Legal closed | `MouseEvent`

--- a/packages/documentation/docs/auto-generated/ix-menu-about/props.md
+++ b/packages/documentation/docs/auto-generated/ix-menu-about/props.md
@@ -1,5 +1,5 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|activeTabLabel| Active tab | `active-tab-label` | `string` | `undefined` |
-|label| Label of first tab | `label` | `string` | `'About & legal information'` |
-|show| Internal | `show` | `boolean` | `false` |
+|<div className="Api__Table"> <div>activeTabLabel</div> <div className="Api__Table Docs__Tags"></div></div>| Active tab | `active-tab-label` | `string` | `undefined` |
+|<div className="Api__Table"> <div>label</div> <div className="Api__Table Docs__Tags"></div></div>| Label of first tab | `label` | `string` | `'About & legal information'` |
+|<div className="Api__Table"> <div>show</div> <div className="Api__Table Docs__Tags"></div></div>| Internal | `show` | `boolean` | `false` |

--- a/packages/documentation/docs/auto-generated/ix-menu-avatar-item/events.md
+++ b/packages/documentation/docs/auto-generated/ix-menu-avatar-item/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|itemClick| Avatar dropdown item clicked | `MouseEvent`
+|<div className="Api__Table"> <div>itemClick</div> <div className="Api__Table Docs__Tags"></div></div>| Avatar dropdown item clicked | `MouseEvent`

--- a/packages/documentation/docs/auto-generated/ix-menu-avatar-item/props.md
+++ b/packages/documentation/docs/auto-generated/ix-menu-avatar-item/props.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|icon| Avatar dropdown icon | `icon` | `string` | `undefined` |
-|label| Avatar dropdown label | `label` | `string` | `undefined` |
+|<div className="Api__Table"> <div>icon</div> <div className="Api__Table Docs__Tags"></div></div>| Avatar dropdown icon | `icon` | `string` | `undefined` |
+|<div className="Api__Table"> <div>label</div> <div className="Api__Table Docs__Tags"></div></div>| Avatar dropdown label | `label` | `string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-menu-avatar/events.md
+++ b/packages/documentation/docs/auto-generated/ix-menu-avatar/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|logoutClick| Logout click | `any`
+|<div className="Api__Table"> <div>logoutClick</div> <div className="Api__Table Docs__Tags"></div></div>| Logout click | `any`

--- a/packages/documentation/docs/auto-generated/ix-menu-avatar/props.md
+++ b/packages/documentation/docs/auto-generated/ix-menu-avatar/props.md
@@ -1,5 +1,5 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|bottom| Second line of text | `bottom` | `string` | `undefined` |
-|i18nLogout|  | `i-1-8n-logout` | `string` | `'Logout'` |
-|top| First line of text | `top` | `string` | `undefined` |
+|<div className="Api__Table"> <div>bottom</div> <div className="Api__Table Docs__Tags"></div></div>| Second line of text | `bottom` | `string` | `undefined` |
+|<div className="Api__Table"> <div>i18nLogout</div> <div className="Api__Table Docs__Tags"></div></div>|  | `i-1-8n-logout` | `string` | `'Logout'` |
+|<div className="Api__Table"> <div>top</div> <div className="Api__Table Docs__Tags"></div></div>| First line of text | `top` | `string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-menu-item/props.md
+++ b/packages/documentation/docs/auto-generated/ix-menu-item/props.md
@@ -1,8 +1,8 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|active| State to display active | `active` | `boolean` | `undefined` |
-|bottom| Place tab on bottom | `bottom` | `boolean` | `false` |
-|disabled| Disable tab and remove event handlers | `disabled` | `boolean` | `undefined` |
-|home| Move the Tab to a top position. | `home` | `boolean` | `false` |
-|notifications| Show notification cound on tab | `notifications` | `number` | `undefined` |
-|tabIcon| Icon name from @siemens/ix-icons | `tab-icon` | `string` | `'document'` |
+|<div className="Api__Table"> <div>active</div> <div className="Api__Table Docs__Tags"></div></div>| State to display active | `active` | `boolean` | `undefined` |
+|<div className="Api__Table"> <div>bottom</div> <div className="Api__Table Docs__Tags"></div></div>| Place tab on bottom | `bottom` | `boolean` | `false` |
+|<div className="Api__Table"> <div>disabled</div> <div className="Api__Table Docs__Tags"></div></div>| Disable tab and remove event handlers | `disabled` | `boolean` | `undefined` |
+|<div className="Api__Table"> <div>home</div> <div className="Api__Table Docs__Tags"></div></div>| Move the Tab to a top position. | `home` | `boolean` | `false` |
+|<div className="Api__Table"> <div>notifications</div> <div className="Api__Table Docs__Tags"></div></div>| Show notification cound on tab | `notifications` | `number` | `undefined` |
+|<div className="Api__Table"> <div>tabIcon</div> <div className="Api__Table Docs__Tags"></div></div>| Icon name from @siemens/ix-icons | `tab-icon` | `string` | `'document'` |

--- a/packages/documentation/docs/auto-generated/ix-menu-settings-item/props.md
+++ b/packages/documentation/docs/auto-generated/ix-menu-settings-item/props.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|label| Label | `label` | `string` | `undefined` |
+|<div className="Api__Table"> <div>label</div> <div className="Api__Table Docs__Tags"></div></div>| Label | `label` | `string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-menu-settings/events.md
+++ b/packages/documentation/docs/auto-generated/ix-menu-settings/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|close| Popover closed | `MouseEvent`
+|<div className="Api__Table"> <div>close</div> <div className="Api__Table Docs__Tags"></div></div>| Popover closed | `MouseEvent`

--- a/packages/documentation/docs/auto-generated/ix-menu-settings/props.md
+++ b/packages/documentation/docs/auto-generated/ix-menu-settings/props.md
@@ -1,5 +1,5 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|activeTabLabel| active tab | `active-tab-label` | `string` | `undefined` |
-|label| Label | `label` | `string` | `'Settings'` |
-|show| Internal | `show` | `boolean` | `false` |
+|<div className="Api__Table"> <div>activeTabLabel</div> <div className="Api__Table Docs__Tags"></div></div>| active tab | `active-tab-label` | `string` | `undefined` |
+|<div className="Api__Table"> <div>label</div> <div className="Api__Table Docs__Tags"></div></div>| Label | `label` | `string` | `'Settings'` |
+|<div className="Api__Table"> <div>show</div> <div className="Api__Table Docs__Tags"></div></div>| Internal | `show` | `boolean` | `false` |

--- a/packages/documentation/docs/auto-generated/ix-menu/events.md
+++ b/packages/documentation/docs/auto-generated/ix-menu/events.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|expandChange| Menu expanded | `boolean`
-|mapExpandChange| Map Sidebar expanded | `boolean`
+|<div className="Api__Table"> <div>expandChange</div> <div className="Api__Table Docs__Tags"></div></div>| Menu expanded | `boolean`
+|<div className="Api__Table"> <div>mapExpandChange</div> <div className="Api__Table Docs__Tags"></div></div>| Map Sidebar expanded | `boolean`

--- a/packages/documentation/docs/auto-generated/ix-menu/props.md
+++ b/packages/documentation/docs/auto-generated/ix-menu/props.md
@@ -1,17 +1,17 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|applicationDescription| Should only be set if you use ix-menu standalone | `application-description` | `string` | `''` |
-|applicationName| Should only be set if you use ix-menu standalone | `application-name` | `string` | `undefined` |
-|enableMapExpand| Internal | `enable-map-expand` | `boolean` | `false` |
-|enableSettings| Is settings tab is visible | `enable-settings` | `boolean` | `true` |
-|enableToggleTheme| Show toggle between light and dark variant. Only if the provided theme have implemented both! | `enable-toggle-theme` | `boolean` | `false` |
-|expand| Expand menu | `expand` | `boolean` | `false` |
-|i18nCollapse|  | `i-1-8n-collapse` | `string` | `'Collapse'` |
-|i18nExpand|  | `i-1-8n-expand` | `string` | `' Expand'` |
-|i18nLegal|  | `i-1-8n-legal` | `string` | `'About & legal information'` |
-|i18nMore|  | `i-1-8n-more` | `string` | `'More…'` |
-|i18nSettings|  | `i-1-8n-settings` | `string` | `'Settings'` |
-|i18nToggleTheme|  | `i-1-8n-toggle-theme` | `string` | `'Toggle theme'` |
-|maxVisibleMenuItems| Maximum number of menu items to show in case enough vertical space is available. Extra menu items will be collapsed to 'show more' menu item. | `max-visible-menu-items` | `number` | `9` |
-|showAbout| Is about tab visible | `show-about` | `boolean` | `false` |
-|showSettings| Is settings tab visible | `show-settings` | `boolean` | `false` |
+|<div className="Api__Table"> <div>applicationDescription</div> <div className="Api__Table Docs__Tags"></div></div>| Should only be set if you use ix-menu standalone | `application-description` | `string` | `''` |
+|<div className="Api__Table"> <div>applicationName</div> <div className="Api__Table Docs__Tags"></div></div>| Should only be set if you use ix-menu standalone | `application-name` | `string` | `undefined` |
+|<div className="Api__Table"> <div>enableMapExpand</div> <div className="Api__Table Docs__Tags"></div></div>| Internal | `enable-map-expand` | `boolean` | `false` |
+|<div className="Api__Table"> <div>enableSettings</div> <div className="Api__Table Docs__Tags"></div></div>| Is settings tab is visible | `enable-settings` | `boolean` | `true` |
+|<div className="Api__Table"> <div>enableToggleTheme</div> <div className="Api__Table Docs__Tags"></div></div>| Show toggle between light and dark variant. Only if the provided theme have implemented both! | `enable-toggle-theme` | `boolean` | `false` |
+|<div className="Api__Table"> <div>expand</div> <div className="Api__Table Docs__Tags"></div></div>| Expand menu | `expand` | `boolean` | `false` |
+|<div className="Api__Table"> <div>i18nCollapse</div> <div className="Api__Table Docs__Tags"></div></div>|  | `i-1-8n-collapse` | `string` | `'Collapse'` |
+|<div className="Api__Table"> <div>i18nExpand</div> <div className="Api__Table Docs__Tags"></div></div>|  | `i-1-8n-expand` | `string` | `' Expand'` |
+|<div className="Api__Table"> <div>i18nLegal</div> <div className="Api__Table Docs__Tags"></div></div>|  | `i-1-8n-legal` | `string` | `'About & legal information'` |
+|<div className="Api__Table"> <div>i18nMore</div> <div className="Api__Table Docs__Tags"></div></div>|  | `i-1-8n-more` | `string` | `'More…'` |
+|<div className="Api__Table"> <div>i18nSettings</div> <div className="Api__Table Docs__Tags"></div></div>|  | `i-1-8n-settings` | `string` | `'Settings'` |
+|<div className="Api__Table"> <div>i18nToggleTheme</div> <div className="Api__Table Docs__Tags"></div></div>|  | `i-1-8n-toggle-theme` | `string` | `'Toggle theme'` |
+|<div className="Api__Table"> <div>maxVisibleMenuItems</div> <div className="Api__Table Docs__Tags"></div></div>| Maximum number of menu items to show in case enough vertical space is available. Extra menu items will be collapsed to 'show more' menu item. | `max-visible-menu-items` | `number` | `9` |
+|<div className="Api__Table"> <div>showAbout</div> <div className="Api__Table Docs__Tags"></div></div>| Is about tab visible | `show-about` | `boolean` | `false` |
+|<div className="Api__Table"> <div>showSettings</div> <div className="Api__Table Docs__Tags"></div></div>| Is settings tab visible | `show-settings` | `boolean` | `false` |

--- a/packages/documentation/docs/auto-generated/ix-message-bar/events.md
+++ b/packages/documentation/docs/auto-generated/ix-message-bar/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|closedChange| An event emitted when the close button is clicked | `any`
+|<div className="Api__Table"> <div>closedChange</div> <div className="Api__Table Docs__Tags"></div></div>| An event emitted when the close button is clicked | `any`

--- a/packages/documentation/docs/auto-generated/ix-message-bar/props.md
+++ b/packages/documentation/docs/auto-generated/ix-message-bar/props.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|dismissible| If true, close button is enabled and alert can be dismissed by the user | `dismissible` | `boolean` | `true` |
-|type| Specifies the type of the alert. | `type` | `"danger" ｜ "info" ｜ "warning"` | `'info'` |
+|<div className="Api__Table"> <div>dismissible</div> <div className="Api__Table Docs__Tags"></div></div>| If true, close button is enabled and alert can be dismissed by the user | `dismissible` | `boolean` | `true` |
+|<div className="Api__Table"> <div>type</div> <div className="Api__Table Docs__Tags"></div></div>| Specifies the type of the alert. | `type` | `"danger" ｜ "info" ｜ "warning"` | `'info'` |

--- a/packages/documentation/docs/auto-generated/ix-modal/events.md
+++ b/packages/documentation/docs/auto-generated/ix-modal/events.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|closed| Modal closed | `any`
-|dismissed| Modal dismissed | `any`
+|<div className="Api__Table"> <div>closed</div> <div className="Api__Table Docs__Tags"></div></div>| Modal closed | `any`
+|<div className="Api__Table"> <div>dismissed</div> <div className="Api__Table Docs__Tags"></div></div>| Modal dismissed | `any`

--- a/packages/documentation/docs/auto-generated/ix-modal/props.md
+++ b/packages/documentation/docs/auto-generated/ix-modal/props.md
@@ -1,18 +1,18 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|animation| Should the modal be animtated | `animation` | `boolean` | `true` |
-|ariaDescribedBy|  | `aria-described-by` | `string` | `undefined` |
-|ariaLabelledBy|  | `aria-labelled-by` | `string` | `'modal-title'` |
-|backdrop| Adds a dimming layer to the modal. This should only be used when it it necessary to focus the user's attention to the dialog content (e.g. errors, warnings, complex tasks). | `backdrop` | `"static" ｜ boolean` | `true` |
-|backdropClass| Backdrop class | `backdrop-class` | `string` | `undefined` |
-|beforeDismiss| BeforeDismiss callback | `undefined` | `(reason?: any) => boolean ｜ Promise<boolean>` | `undefined` |
-|centered| Centered modal | `centered` | `boolean` | `false` |
-|content| Content of modal | `content` | `HTMLElement ｜ string` | `undefined` |
-|headerTitle| Header title | `header-title` | `string` | `undefined` |
-|icon| Optional icon displayed next to the title | `icon` | `string` | `undefined` |
-|iconColor| Color of the header {@link icon} | `icon-color` | `"color-alarm" ｜ "color-info" ｜ "color-std-text" ｜ "color-success" ｜ "color-warning"` | `'color-std-text'` |
-|keyboard| ESC close modal dialog | `keyboard` | `boolean` | `true` |
-|modalDialogClass| Modal dialog class | `modal-dialog-class` | `string` | `undefined` |
-|scrollable| Modal scollable | `scrollable` | `boolean` | `true` |
-|size| Modal size | `size` | `"lg" ｜ "sm" ｜ "xl"` | `'sm'` |
-|windowClass| Window class | `window-class` | `string` | `undefined` |
+|<div className="Api__Table"> <div>animation</div> <div className="Api__Table Docs__Tags"></div></div>| Should the modal be animtated | `animation` | `boolean` | `true` |
+|<div className="Api__Table"> <div>ariaDescribedBy</div> <div className="Api__Table Docs__Tags"></div></div>|  | `aria-described-by` | `string` | `undefined` |
+|<div className="Api__Table"> <div>ariaLabelledBy</div> <div className="Api__Table Docs__Tags"></div></div>|  | `aria-labelled-by` | `string` | `'modal-title'` |
+|<div className="Api__Table"> <div>backdrop</div> <div className="Api__Table Docs__Tags"></div></div>| Adds a dimming layer to the modal. This should only be used when it it necessary to focus the user's attention to the dialog content (e.g. errors, warnings, complex tasks). | `backdrop` | `"static" ｜ boolean` | `true` |
+|<div className="Api__Table"> <div>backdropClass</div> <div className="Api__Table Docs__Tags"></div></div>| Backdrop class | `backdrop-class` | `string` | `undefined` |
+|<div className="Api__Table"> <div>beforeDismiss</div> <div className="Api__Table Docs__Tags"></div></div>| BeforeDismiss callback | `undefined` | `(reason?: any) => boolean ｜ Promise<boolean>` | `undefined` |
+|<div className="Api__Table"> <div>centered</div> <div className="Api__Table Docs__Tags"></div></div>| Centered modal | `centered` | `boolean` | `false` |
+|<div className="Api__Table"> <div>content</div> <div className="Api__Table Docs__Tags"></div></div>| Content of modal | `content` | `HTMLElement ｜ string` | `undefined` |
+|<div className="Api__Table"> <div>headerTitle</div> <div className="Api__Table Docs__Tags"></div></div>| Header title | `header-title` | `string` | `undefined` |
+|<div className="Api__Table"> <div>icon</div> <div className="Api__Table Docs__Tags"></div></div>| Optional icon displayed next to the title | `icon` | `string` | `undefined` |
+|<div className="Api__Table"> <div>iconColor</div> <div className="Api__Table Docs__Tags"></div></div>| Color of the header {@link icon} | `icon-color` | `"color-alarm" ｜ "color-info" ｜ "color-std-text" ｜ "color-success" ｜ "color-warning"` | `'color-std-text'` |
+|<div className="Api__Table"> <div>keyboard</div> <div className="Api__Table Docs__Tags"></div></div>| ESC close modal dialog | `keyboard` | `boolean` | `true` |
+|<div className="Api__Table"> <div>modalDialogClass</div> <div className="Api__Table Docs__Tags"></div></div>| Modal dialog class | `modal-dialog-class` | `string` | `undefined` |
+|<div className="Api__Table"> <div>scrollable</div> <div className="Api__Table Docs__Tags"></div></div>| Modal scollable | `scrollable` | `boolean` | `true` |
+|<div className="Api__Table"> <div>size</div> <div className="Api__Table Docs__Tags"></div></div>| Modal size | `size` | `"lg" ｜ "sm" ｜ "xl"` | `'sm'` |
+|<div className="Api__Table"> <div>windowClass</div> <div className="Api__Table Docs__Tags"></div></div>| Window class | `window-class` | `string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-pill/props.md
+++ b/packages/documentation/docs/auto-generated/ix-pill/props.md
@@ -1,8 +1,8 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|alignLeft| Align pill content left | `align-left` | `boolean` | `false` |
-|background| Custom color for pill. Only working for `variant='custom'` | `background` | `string` | `undefined` |
-|color| Custom font color for pill. Only working for `variant='custom'` | `color` | `string` | `undefined` |
-|icon| Show icon | `icon` | `string` | `undefined` |
-|outline| Show pill as outline | `outline` | `boolean` | `false` |
-|variant| Pill variant | `variant` | `"alarm" ｜ "critical" ｜ "custom" ｜ "info" ｜ "neutral" ｜ "primary" ｜ "success" ｜ "warning"` | `'primary'` |
+|<div className="Api__Table"> <div>alignLeft</div> <div className="Api__Table Docs__Tags"></div></div>| Align pill content left | `align-left` | `boolean` | `false` |
+|<div className="Api__Table"> <div>background</div> <div className="Api__Table Docs__Tags"></div></div>| Custom color for pill. Only working for `variant='custom'` | `background` | `string` | `undefined` |
+|<div className="Api__Table"> <div>color</div> <div className="Api__Table Docs__Tags"></div></div>| Custom font color for pill. Only working for `variant='custom'` | `color` | `string` | `undefined` |
+|<div className="Api__Table"> <div>icon</div> <div className="Api__Table Docs__Tags"></div></div>| Show icon | `icon` | `string` | `undefined` |
+|<div className="Api__Table"> <div>outline</div> <div className="Api__Table Docs__Tags"></div></div>| Show pill as outline | `outline` | `boolean` | `false` |
+|<div className="Api__Table"> <div>variant</div> <div className="Api__Table Docs__Tags"></div></div>| Pill variant | `variant` | `"alarm" ｜ "critical" ｜ "custom" ｜ "info" ｜ "neutral" ｜ "primary" ｜ "success" ｜ "warning"` | `'primary'` |

--- a/packages/documentation/docs/auto-generated/ix-select-item/events.md
+++ b/packages/documentation/docs/auto-generated/ix-select-item/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|itemClick| Item clicked | `string`
+|<div className="Api__Table"> <div>itemClick</div> <div className="Api__Table Docs__Tags"></div></div>| Item clicked | `string`

--- a/packages/documentation/docs/auto-generated/ix-select-item/props.md
+++ b/packages/documentation/docs/auto-generated/ix-select-item/props.md
@@ -1,6 +1,6 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|hover| ***Internal*** | `hover` | `boolean` | `false` |
-|label| Displayed name of the item | `label` | `string` | `undefined` |
-|selected| Whether the item is selected. | `selected` | `boolean` | `false` |
-|value| Item value | `value` | `any` | `undefined` |
+|<div className="Api__Table"> <div>hover</div> <div className="Api__Table Docs__Tags"></div></div>| ***Internal*** | `hover` | `boolean` | `false` |
+|<div className="Api__Table"> <div>label</div> <div className="Api__Table Docs__Tags"></div></div>| Displayed name of the item | `label` | `string` | `undefined` |
+|<div className="Api__Table"> <div>selected</div> <div className="Api__Table Docs__Tags"></div></div>| Whether the item is selected. | `selected` | `boolean` | `false` |
+|<div className="Api__Table"> <div>value</div> <div className="Api__Table Docs__Tags"></div></div>| Item value | `value` | `any` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-select/events.md
+++ b/packages/documentation/docs/auto-generated/ix-select/events.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|addItem| Item added to selection | `string`
-|itemSelectionChange| Item selection changed | `string | string[]`
+|<div className="Api__Table"> <div>addItem</div> <div className="Api__Table Docs__Tags"></div></div>| Item added to selection | `string`
+|<div className="Api__Table"> <div>itemSelectionChange</div> <div className="Api__Table Docs__Tags"></div></div>| Item selection changed | `string | string[]`

--- a/packages/documentation/docs/auto-generated/ix-select/props.md
+++ b/packages/documentation/docs/auto-generated/ix-select/props.md
@@ -1,11 +1,11 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|allowClear| Show clear button | `allow-clear` | `boolean` | `false` |
-|disabled| If true the select will be in disabled state | `disabled` | `boolean` | `false` |
-|editable| Select is extendable | `editable` | `boolean` | `false` |
-|i18nPlaceholder| Input field placeholder | `i-1-8n-placeholder` | `string` | `'Select an option'` |
-|i18nPlaceholderEditable| Input field placeholder for editable select | `i-1-8n-placeholder-editable` | `string` | `'Type of select option'` |
-|i18nSelectListHeader| Select list header | `i-1-8n-select-list-header` | `string` | `'Please select an option'` |
-|mode| Selection mode | `mode` | `"multiple" ｜ "single"` | `'single'` |
-|readonly| If true the select will be in readonly mode | `readonly` | `boolean` | `false` |
-|selectedIndices| Indices of selected items | `selected-indices` | `string ｜ string[]` | `[]` |
+|<div className="Api__Table"> <div>allowClear</div> <div className="Api__Table Docs__Tags"></div></div>| Show clear button | `allow-clear` | `boolean` | `false` |
+|<div className="Api__Table"> <div>disabled</div> <div className="Api__Table Docs__Tags"></div></div>| If true the select will be in disabled state | `disabled` | `boolean` | `false` |
+|<div className="Api__Table"> <div>editable</div> <div className="Api__Table Docs__Tags"></div></div>| Select is extendable | `editable` | `boolean` | `false` |
+|<div className="Api__Table"> <div>i18nPlaceholder</div> <div className="Api__Table Docs__Tags"></div></div>| Input field placeholder | `i-1-8n-placeholder` | `string` | `'Select an option'` |
+|<div className="Api__Table"> <div>i18nPlaceholderEditable</div> <div className="Api__Table Docs__Tags"></div></div>| Input field placeholder for editable select | `i-1-8n-placeholder-editable` | `string` | `'Type of select option'` |
+|<div className="Api__Table"> <div>i18nSelectListHeader</div> <div className="Api__Table Docs__Tags"></div></div>| Select list header | `i-1-8n-select-list-header` | `string` | `'Please select an option'` |
+|<div className="Api__Table"> <div>mode</div> <div className="Api__Table Docs__Tags"></div></div>| Selection mode | `mode` | `"multiple" ｜ "single"` | `'single'` |
+|<div className="Api__Table"> <div>readonly</div> <div className="Api__Table Docs__Tags"></div></div>| If true the select will be in readonly mode | `readonly` | `boolean` | `false` |
+|<div className="Api__Table"> <div>selectedIndices</div> <div className="Api__Table Docs__Tags"></div></div>| Indices of selected items | `selected-indices` | `string ｜ string[]` | `[]` |

--- a/packages/documentation/docs/auto-generated/ix-spinner/props.md
+++ b/packages/documentation/docs/auto-generated/ix-spinner/props.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|size| Size of spinner | `size` | `"large" ｜ "medium"` | `'medium'` |
-|variant| Variant of spinner | `variant` | `"primary" ｜ "secondary" ｜ "sencodary"` | `'secondary'` |
+|<div className="Api__Table"> <div>size</div> <div className="Api__Table Docs__Tags"></div></div>| Size of spinner | `size` | `"large" ｜ "medium"` | `'medium'` |
+|<div className="Api__Table"> <div>variant</div> <div className="Api__Table Docs__Tags"></div></div>| Variant of spinner | `variant` | `"primary" ｜ "secondary" ｜ "sencodary"` | `'secondary'` |

--- a/packages/documentation/docs/auto-generated/ix-split-button-item/events.md
+++ b/packages/documentation/docs/auto-generated/ix-split-button-item/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|itemClick| Dropdown item clicked | `MouseEvent`
+|<div className="Api__Table"> <div>itemClick</div> <div className="Api__Table Docs__Tags"></div></div>| Dropdown item clicked | `MouseEvent`

--- a/packages/documentation/docs/auto-generated/ix-split-button-item/props.md
+++ b/packages/documentation/docs/auto-generated/ix-split-button-item/props.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|icon| Dropdown icon | `icon` | `string` | `undefined` |
-|label| Dropdown label | `label` | `string` | `undefined` |
+|<div className="Api__Table"> <div>icon</div> <div className="Api__Table Docs__Tags"></div></div>| Dropdown icon | `icon` | `string` | `undefined` |
+|<div className="Api__Table"> <div>label</div> <div className="Api__Table Docs__Tags"></div></div>| Dropdown label | `label` | `string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-split-button/events.md
+++ b/packages/documentation/docs/auto-generated/ix-split-button/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|buttonClick| Button clicked | `MouseEvent`
+|<div className="Api__Table"> <div>buttonClick</div> <div className="Api__Table Docs__Tags"></div></div>| Button clicked | `MouseEvent`

--- a/packages/documentation/docs/auto-generated/ix-split-button/props.md
+++ b/packages/documentation/docs/auto-generated/ix-split-button/props.md
@@ -1,11 +1,11 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|disabled| Disabled | `disabled` | `boolean` | `false` |
-|ghost| Button invisible | `ghost` | `boolean` | `false` |
-|icon| Button icon | `icon` | `string` | `''` |
-|invisible| Button invisible | `invisible` | `boolean` | `false` |
-|label| Button label | `label` | `string` | `undefined` |
-|outline| Button outline variant | `outline` | `boolean` | `false` |
-|placement| Placement of the dropdown | `placement` | `"auto" ｜ "auto-end" ｜ "auto-start" ｜ "bottom" ｜ "bottom-end" ｜ "bottom-start" ｜ "left" ｜ "left-end" ｜ "left-start" ｜ "right" ｜ "right-end" ｜ "right-start" ｜ "top" ｜ "top-end" ｜ "top-start"` | `'bottom-start'` |
-|splitIcon| Splitbutton icon | `split-icon` | `string` | `'context-menu'` |
-|variant| Color variant of button | `variant` | `"Primary" ｜ "Secondary"` | `'Primary'` |
+|<div className="Api__Table"> <div>disabled</div> <div className="Api__Table Docs__Tags"></div></div>| Disabled | `disabled` | `boolean` | `false` |
+|<div className="Api__Table"> <div>ghost</div> <div className="Api__Table Docs__Tags"></div></div>| Button invisible | `ghost` | `boolean` | `false` |
+|<div className="Api__Table"> <div>icon</div> <div className="Api__Table Docs__Tags"></div></div>| Button icon | `icon` | `string` | `''` |
+|<div className="Api__Table"> <div>invisible</div> <div className="Api__Table Docs__Tags"></div></div>| Button invisible | `invisible` | `boolean` | `false` |
+|<div className="Api__Table"> <div>label</div> <div className="Api__Table Docs__Tags"></div></div>| Button label | `label` | `string` | `undefined` |
+|<div className="Api__Table"> <div>outline</div> <div className="Api__Table Docs__Tags"></div></div>| Button outline variant | `outline` | `boolean` | `false` |
+|<div className="Api__Table"> <div>placement</div> <div className="Api__Table Docs__Tags"></div></div>| Placement of the dropdown | `placement` | `"auto" ｜ "auto-end" ｜ "auto-start" ｜ "bottom" ｜ "bottom-end" ｜ "bottom-start" ｜ "left" ｜ "left-end" ｜ "left-start" ｜ "right" ｜ "right-end" ｜ "right-start" ｜ "top" ｜ "top-end" ｜ "top-start"` | `'bottom-start'` |
+|<div className="Api__Table"> <div>splitIcon</div> <div className="Api__Table Docs__Tags"></div></div>| Splitbutton icon | `split-icon` | `string` | `'context-menu'` |
+|<div className="Api__Table"> <div>variant</div> <div className="Api__Table Docs__Tags"></div></div>| Color variant of button | `variant` | `"Primary" ｜ "Secondary"` | `'Primary'` |

--- a/packages/documentation/docs/auto-generated/ix-tab-item/props.md
+++ b/packages/documentation/docs/auto-generated/ix-tab-item/props.md
@@ -1,10 +1,10 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|counter| Set counter value | `counter` | `number` | `undefined` |
-|disabled| Set disabled tab | `disabled` | `boolean` | `false` |
-|icon| Set icon only tab | `icon` | `boolean` | `false` |
-|layout| Set layout width style | `layout` | `"auto" ｜ "stretched"` | `'auto'` |
-|placement| Set selected placement | `placement` | `"bottom" ｜ "top"` | `'bottom'` |
-|rounded| Set rounded tab | `rounded` | `boolean` | `false` |
-|selected| Set selected tab | `selected` | `boolean` | `false` |
-|small| Set small size tab | `small` | `boolean` | `false` |
+|<div className="Api__Table"> <div>counter</div> <div className="Api__Table Docs__Tags"></div></div>| Set counter value | `counter` | `number` | `undefined` |
+|<div className="Api__Table"> <div>disabled</div> <div className="Api__Table Docs__Tags"></div></div>| Set disabled tab | `disabled` | `boolean` | `false` |
+|<div className="Api__Table"> <div>icon</div> <div className="Api__Table Docs__Tags"></div></div>| Set icon only tab | `icon` | `boolean` | `false` |
+|<div className="Api__Table"> <div>layout</div> <div className="Api__Table Docs__Tags"></div></div>| Set layout width style | `layout` | `"auto" ｜ "stretched"` | `'auto'` |
+|<div className="Api__Table"> <div>placement</div> <div className="Api__Table Docs__Tags"></div></div>| Set selected placement | `placement` | `"bottom" ｜ "top"` | `'bottom'` |
+|<div className="Api__Table"> <div>rounded</div> <div className="Api__Table Docs__Tags"></div></div>| Set rounded tab | `rounded` | `boolean` | `false` |
+|<div className="Api__Table"> <div>selected</div> <div className="Api__Table Docs__Tags"></div></div>| Set selected tab | `selected` | `boolean` | `false` |
+|<div className="Api__Table"> <div>small</div> <div className="Api__Table Docs__Tags"></div></div>| Set small size tab | `small` | `boolean` | `false` |

--- a/packages/documentation/docs/auto-generated/ix-tabs/props.md
+++ b/packages/documentation/docs/auto-generated/ix-tabs/props.md
@@ -1,7 +1,7 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|layout| Set layout width style | `layout` | `"auto" ｜ "stretched"` | `'auto'` |
-|placement| Set placement style | `placement` | `"bottom" ｜ "top"` | `'bottom'` |
-|rounded| Set rounded tabs | `rounded` | `boolean` | `false` |
-|selected| Set default selected tab by index | `selected` | `number` | `0` |
-|small| Set tab items to small size | `small` | `boolean` | `false` |
+|<div className="Api__Table"> <div>layout</div> <div className="Api__Table Docs__Tags"></div></div>| Set layout width style | `layout` | `"auto" ｜ "stretched"` | `'auto'` |
+|<div className="Api__Table"> <div>placement</div> <div className="Api__Table Docs__Tags"></div></div>| Set placement style | `placement` | `"bottom" ｜ "top"` | `'bottom'` |
+|<div className="Api__Table"> <div>rounded</div> <div className="Api__Table Docs__Tags"></div></div>| Set rounded tabs | `rounded` | `boolean` | `false` |
+|<div className="Api__Table"> <div>selected</div> <div className="Api__Table Docs__Tags"></div></div>| Set default selected tab by index | `selected` | `number` | `0` |
+|<div className="Api__Table"> <div>small</div> <div className="Api__Table Docs__Tags"></div></div>| Set tab items to small size | `small` | `boolean` | `false` |

--- a/packages/documentation/docs/auto-generated/ix-tile/props.md
+++ b/packages/documentation/docs/auto-generated/ix-tile/props.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|size| Size of the tile - one of 'small', 'medium' or 'large' | `size` | `"big" ｜ "medium" ｜ "small"` | `'medium'` |
+|<div className="Api__Table"> <div>size</div> <div className="Api__Table Docs__Tags"></div></div>| Size of the tile - one of 'small', 'medium' or 'large' | `size` | `"big" ｜ "medium" ｜ "small"` | `'medium'` |

--- a/packages/documentation/docs/auto-generated/ix-time-picker/events.md
+++ b/packages/documentation/docs/auto-generated/ix-time-picker/events.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|done| Time event | `string`
-|timeChange| Time change event | `string`
+|<div className="Api__Table"> <div>done</div> <div className="Api__Table Docs__Tags"></div></div>| Time event | `string`
+|<div className="Api__Table"> <div>timeChange</div> <div className="Api__Table Docs__Tags"></div></div>| Time change event | `string`

--- a/packages/documentation/docs/auto-generated/ix-time-picker/props.md
+++ b/packages/documentation/docs/auto-generated/ix-time-picker/props.md
@@ -1,8 +1,8 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|corners| Set corners style | `corners` | `"left" ｜ "right" ｜ "rounded"` | `'rounded'` |
-|individual| set styles | `individual` | `boolean` | `true` |
-|showHour| Show Hour Input | `show-hour` | `boolean` | `false` |
-|showMinutes| Show Minutes Input | `show-minutes` | `boolean` | `false` |
-|showSeconds| Show Seconds Input | `show-seconds` | `boolean` | `false` |
-|showTimeReference| Show Time Reference Input | `show-time-reference` | `boolean` | `false` |
+|<div className="Api__Table"> <div>corners</div> <div className="Api__Table Docs__Tags"></div></div>| Set corners style | `corners` | `"left" ｜ "right" ｜ "rounded"` | `'rounded'` |
+|<div className="Api__Table"> <div>individual</div> <div className="Api__Table Docs__Tags"></div></div>| set styles | `individual` | `boolean` | `true` |
+|<div className="Api__Table"> <div>showHour</div> <div className="Api__Table Docs__Tags"></div></div>| Show Hour Input | `show-hour` | `boolean` | `false` |
+|<div className="Api__Table"> <div>showMinutes</div> <div className="Api__Table Docs__Tags"></div></div>| Show Minutes Input | `show-minutes` | `boolean` | `false` |
+|<div className="Api__Table"> <div>showSeconds</div> <div className="Api__Table Docs__Tags"></div></div>| Show Seconds Input | `show-seconds` | `boolean` | `false` |
+|<div className="Api__Table"> <div>showTimeReference</div> <div className="Api__Table Docs__Tags"></div></div>| Show Time Reference Input | `show-time-reference` | `boolean` | `false` |

--- a/packages/documentation/docs/auto-generated/ix-toast-container/props.md
+++ b/packages/documentation/docs/auto-generated/ix-toast-container/props.md
@@ -1,5 +1,5 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|containerClass|  | `container-class` | `string` | `'toast-container'` |
-|containerId|  | `container-id` | `string` | `'toast-container'` |
-|position|  | `position` | `string` | `'bottom-right'` |
+|<div className="Api__Table"> <div>containerClass</div> <div className="Api__Table Docs__Tags"></div></div>|  | `container-class` | `string` | `'toast-container'` |
+|<div className="Api__Table"> <div>containerId</div> <div className="Api__Table Docs__Tags"></div></div>|  | `container-id` | `string` | `'toast-container'` |
+|<div className="Api__Table"> <div>position</div> <div className="Api__Table Docs__Tags"></div></div>|  | `position` | `string` | `'bottom-right'` |

--- a/packages/documentation/docs/auto-generated/ix-toast/events.md
+++ b/packages/documentation/docs/auto-generated/ix-toast/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|closeToast| Toast closed | `any`
+|<div className="Api__Table"> <div>closeToast</div> <div className="Api__Table Docs__Tags"></div></div>| Toast closed | `any`

--- a/packages/documentation/docs/auto-generated/ix-toast/props.md
+++ b/packages/documentation/docs/auto-generated/ix-toast/props.md
@@ -1,8 +1,8 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|autoClose| Autoclose behavior | `auto-close` | `boolean` | `true` |
-|autoCloseDelay| Autoclose title after delay | `auto-close-delay` | `number` | `5000` |
-|icon| Icon of toast | `icon` | `string` | `undefined` |
-|iconColor| Icon color of toast | `icon-color` | `string` | `undefined` |
-|toastTitle| Toast title | `toast-title` | `string` | `undefined` |
-|type| Toast type | `type` | `"error" ｜ "info" ｜ "success" ｜ "warning"` | `'info'` |
+|<div className="Api__Table"> <div>autoClose</div> <div className="Api__Table Docs__Tags"></div></div>| Autoclose behavior | `auto-close` | `boolean` | `true` |
+|<div className="Api__Table"> <div>autoCloseDelay</div> <div className="Api__Table Docs__Tags"></div></div>| Autoclose title after delay | `auto-close-delay` | `number` | `5000` |
+|<div className="Api__Table"> <div>icon</div> <div className="Api__Table Docs__Tags"></div></div>| Icon of toast | `icon` | `string` | `undefined` |
+|<div className="Api__Table"> <div>iconColor</div> <div className="Api__Table Docs__Tags"></div></div>| Icon color of toast | `icon-color` | `string` | `undefined` |
+|<div className="Api__Table"> <div>toastTitle</div> <div className="Api__Table Docs__Tags"></div></div>| Toast title | `toast-title` | `string` | `undefined` |
+|<div className="Api__Table"> <div>type</div> <div className="Api__Table Docs__Tags"></div></div>| Toast type | `type` | `"error" ｜ "info" ｜ "success" ｜ "warning"` | `'info'` |

--- a/packages/documentation/docs/auto-generated/ix-toggle/events.md
+++ b/packages/documentation/docs/auto-generated/ix-toggle/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|checkedChange| An event will be dispatched each time the slide-toggle changes its value. | `boolean`
+|<div className="Api__Table"> <div>checkedChange</div> <div className="Api__Table Docs__Tags"></div></div>| An event will be dispatched each time the slide-toggle changes its value. | `boolean`

--- a/packages/documentation/docs/auto-generated/ix-toggle/props.md
+++ b/packages/documentation/docs/auto-generated/ix-toggle/props.md
@@ -1,10 +1,10 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|checked| Whether the slide-toggle element is checked or not. | `checked` | `boolean` | `false` |
-|color| Basic and status colors from color palette | `color` | `string` | `'accent'` |
-|disabled| Whether the slide-toggle element is disabled or not. | `disabled` | `boolean` | `false` |
-|hideText| Hide `on` and `off` text | `hide-text` | `boolean` | `false` |
-|indeterminate| If true the control is in indeterminate state | `indeterminate` | `boolean` | `false` |
-|textIndeterminate| Text for indeterminate state | `text-indeterminate` | `string` | `'Mixed'` |
-|textOff| Text for off state | `text-off` | `string` | `'Off'` |
-|textOn| Text for on state | `text-on` | `string` | `'On'` |
+|<div className="Api__Table"> <div>checked</div> <div className="Api__Table Docs__Tags"></div></div>| Whether the slide-toggle element is checked or not. | `checked` | `boolean` | `false` |
+|<div className="Api__Table"> <div>color</div> <div className="Api__Table Docs__Tags"></div></div>| Basic and status colors from color palette | `color` | `string` | `'accent'` |
+|<div className="Api__Table"> <div>disabled</div> <div className="Api__Table Docs__Tags"></div></div>| Whether the slide-toggle element is disabled or not. | `disabled` | `boolean` | `false` |
+|<div className="Api__Table"> <div>hideText</div> <div className="Api__Table Docs__Tags"></div></div>| Hide `on` and `off` text | `hide-text` | `boolean` | `false` |
+|<div className="Api__Table"> <div>indeterminate</div> <div className="Api__Table Docs__Tags"></div></div>| If true the control is in indeterminate state | `indeterminate` | `boolean` | `false` |
+|<div className="Api__Table"> <div>textIndeterminate</div> <div className="Api__Table Docs__Tags"></div></div>| Text for indeterminate state | `text-indeterminate` | `string` | `'Mixed'` |
+|<div className="Api__Table"> <div>textOff</div> <div className="Api__Table Docs__Tags"></div></div>| Text for off state | `text-off` | `string` | `'Off'` |
+|<div className="Api__Table"> <div>textOn</div> <div className="Api__Table Docs__Tags"></div></div>| Text for on state | `text-on` | `string` | `'On'` |

--- a/packages/documentation/docs/auto-generated/ix-tree-item/events.md
+++ b/packages/documentation/docs/auto-generated/ix-tree-item/events.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|itemClick| Clicked | `void`
-|toggle| Expand/Collapsed toggled | `void`
+|<div className="Api__Table"> <div>itemClick</div> <div className="Api__Table Docs__Tags"></div></div>| Clicked | `void`
+|<div className="Api__Table"> <div>toggle</div> <div className="Api__Table Docs__Tags"></div></div>| Expand/Collapsed toggled | `void`

--- a/packages/documentation/docs/auto-generated/ix-tree-item/props.md
+++ b/packages/documentation/docs/auto-generated/ix-tree-item/props.md
@@ -1,5 +1,5 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|context| Context | `undefined` | `TreeItemContext` | `undefined` |
-|hasChildren| Has tree item children | `has-children` | `boolean` | `undefined` |
-|text| Text | `text` | `string` | `undefined` |
+|<div className="Api__Table"> <div>context</div> <div className="Api__Table Docs__Tags"></div></div>| Context | `undefined` | `TreeItemContext` | `undefined` |
+|<div className="Api__Table"> <div>hasChildren</div> <div className="Api__Table Docs__Tags"></div></div>| Has tree item children | `has-children` | `boolean` | `undefined` |
+|<div className="Api__Table"> <div>text</div> <div className="Api__Table Docs__Tags"></div></div>| Text | `text` | `string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-tree/events.md
+++ b/packages/documentation/docs/auto-generated/ix-tree/events.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|contextChange| Context changed | `{ [x: string]: TreeItemContext; }`
-|nodeRemoved| Emits removed nodes | `any`
+|<div className="Api__Table"> <div>contextChange</div> <div className="Api__Table Docs__Tags"></div></div>| Context changed | `{ [x: string]: TreeItemContext; }`
+|<div className="Api__Table"> <div>nodeRemoved</div> <div className="Api__Table Docs__Tags"></div></div>| Emits removed nodes | `any`

--- a/packages/documentation/docs/auto-generated/ix-tree/props.md
+++ b/packages/documentation/docs/auto-generated/ix-tree/props.md
@@ -1,6 +1,6 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|context| Selection and collapsed state management | `undefined` | `{ [x: string]: TreeItemContext; }` | `{}` |
-|model| Tree modal | `undefined` | `{ [x: string]: TreeItem<any>; }` | `undefined` |
-|renderItem| Render function of tree items | `undefined` | `<T = any>(index: number, data: T, dataList: T[], context: TreeContext, update: (callback: UpdateCallback) => void) => HTMLElement` | `undefined` |
-|root| Initial root element will not be rendered | `root` | `string` | `undefined` |
+|<div className="Api__Table"> <div>context</div> <div className="Api__Table Docs__Tags"></div></div>| Selection and collapsed state management | `undefined` | `{ [x: string]: TreeItemContext; }` | `{}` |
+|<div className="Api__Table"> <div>model</div> <div className="Api__Table Docs__Tags"></div></div>| Tree modal | `undefined` | `{ [x: string]: TreeItem<any>; }` | `undefined` |
+|<div className="Api__Table"> <div>renderItem</div> <div className="Api__Table Docs__Tags"></div></div>| Render function of tree items | `undefined` | `<T = any>(index: number, data: T, dataList: T[], context: TreeContext, update: (callback: UpdateCallback) => void) => HTMLElement` | `undefined` |
+|<div className="Api__Table"> <div>root</div> <div className="Api__Table Docs__Tags"></div></div>| Initial root element will not be rendered | `root` | `string` | `undefined` |

--- a/packages/documentation/docs/auto-generated/ix-upload/events.md
+++ b/packages/documentation/docs/auto-generated/ix-upload/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|filesChanged| You get an array of Files after drop-action or browse action is finished | `File[]`
+|<div className="Api__Table"> <div>filesChanged</div> <div className="Api__Table Docs__Tags"></div></div>| You get an array of Files after drop-action or browse action is finished | `File[]`

--- a/packages/documentation/docs/auto-generated/ix-upload/props.md
+++ b/packages/documentation/docs/auto-generated/ix-upload/props.md
@@ -1,13 +1,13 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|accept| The accept attribute specifies the types of files that the server accepts (that can be submitted through a file upload). [accept]{@link https ://www.w3schools.com/tags/att_input_accept.asp} | `accept` | `string` | `undefined` |
-|disabled| Disable all input events | `disabled` | `boolean` | `false` |
-|i18nUploadDisabled| Text for disabled state | `i-1-8n-upload-disabled` | `string` | `'File upload currently not possible.'` |
-|i18nUploadFile| Label for upload file button | `i-1-8n-upload-file` | `string` | `'Upload file…'` |
-|loadingText| Will be used by state = UploadFileState.LOADING | `loading-text` | `string` | `'Checking files…'` |
-|multiline| Whether the text should wrap to more than one line | `multiline` | `boolean` | `false` |
-|multiple| If multiple is true the user can drop or select multiple files | `multiple` | `boolean` | `false` |
-|selectFileText| Will be used by state = UploadFileState.SELECT_FILE | `select-file-text` | `string` | `'+ Drag files here or…'` |
-|state| After a file is uploaded you can set the upload component to a defined state | `state` | `UploadFileState.LOADING ｜ UploadFileState.SELECT_FILE ｜ UploadFileState.UPLOAD_FAILED ｜ UploadFileState.UPLOAD_SUCCESSED` | `UploadFileState.SELECT_FILE` |
-|uploadFailedText| Will be used by state = UploadFileState.UPLOAD_FAILED | `upload-failed-text` | `string` | `'Upload failed. Please try again.'` |
-|uploadSuccessText| Will be used by state = UploadFileState.UPLOAD_SUCCESSED | `upload-success-text` | `string` | `'Upload successful'` |
+|<div className="Api__Table"> <div>accept</div> <div className="Api__Table Docs__Tags"></div></div>| The accept attribute specifies the types of files that the server accepts (that can be submitted through a file upload). [accept]{@link https ://www.w3schools.com/tags/att_input_accept.asp} | `accept` | `string` | `undefined` |
+|<div className="Api__Table"> <div>disabled</div> <div className="Api__Table Docs__Tags"></div></div>| Disable all input events | `disabled` | `boolean` | `false` |
+|<div className="Api__Table"> <div>i18nUploadDisabled</div> <div className="Api__Table Docs__Tags"></div></div>| Text for disabled state | `i-1-8n-upload-disabled` | `string` | `'File upload currently not possible.'` |
+|<div className="Api__Table"> <div>i18nUploadFile</div> <div className="Api__Table Docs__Tags"></div></div>| Label for upload file button | `i-1-8n-upload-file` | `string` | `'Upload file…'` |
+|<div className="Api__Table"> <div>loadingText</div> <div className="Api__Table Docs__Tags"></div></div>| Will be used by state = UploadFileState.LOADING | `loading-text` | `string` | `'Checking files…'` |
+|<div className="Api__Table"> <div>multiline</div> <div className="Api__Table Docs__Tags"></div></div>| Whether the text should wrap to more than one line | `multiline` | `boolean` | `false` |
+|<div className="Api__Table"> <div>multiple</div> <div className="Api__Table Docs__Tags"></div></div>| If multiple is true the user can drop or select multiple files | `multiple` | `boolean` | `false` |
+|<div className="Api__Table"> <div>selectFileText</div> <div className="Api__Table Docs__Tags"></div></div>| Will be used by state = UploadFileState.SELECT_FILE | `select-file-text` | `string` | `'+ Drag files here or…'` |
+|<div className="Api__Table"> <div>state</div> <div className="Api__Table Docs__Tags"></div></div>| After a file is uploaded you can set the upload component to a defined state | `state` | `UploadFileState.LOADING ｜ UploadFileState.SELECT_FILE ｜ UploadFileState.UPLOAD_FAILED ｜ UploadFileState.UPLOAD_SUCCESSED` | `UploadFileState.SELECT_FILE` |
+|<div className="Api__Table"> <div>uploadFailedText</div> <div className="Api__Table Docs__Tags"></div></div>| Will be used by state = UploadFileState.UPLOAD_FAILED | `upload-failed-text` | `string` | `'Upload failed. Please try again.'` |
+|<div className="Api__Table"> <div>uploadSuccessText</div> <div className="Api__Table Docs__Tags"></div></div>| Will be used by state = UploadFileState.UPLOAD_SUCCESSED | `upload-success-text` | `string` | `'Upload successful'` |

--- a/packages/documentation/docs/auto-generated/ix-validation-tooltip/props.md
+++ b/packages/documentation/docs/auto-generated/ix-validation-tooltip/props.md
@@ -1,4 +1,4 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|message| Message of the tooltip | `message` | `string` | `undefined` |
-|placement| Placement of the tooltip | `placement` | `"auto" ｜ "auto-end" ｜ "auto-start" ｜ "bottom" ｜ "bottom-end" ｜ "bottom-start" ｜ "left" ｜ "left-end" ｜ "left-start" ｜ "right" ｜ "right-end" ｜ "right-start" ｜ "top" ｜ "top-end" ｜ "top-start"` | `'top'` |
+|<div className="Api__Table"> <div>message</div> <div className="Api__Table Docs__Tags"></div></div>| Message of the tooltip | `message` | `string` | `undefined` |
+|<div className="Api__Table"> <div>placement</div> <div className="Api__Table Docs__Tags"></div></div>| Placement of the tooltip | `placement` | `"auto" ｜ "auto-end" ｜ "auto-start" ｜ "bottom" ｜ "bottom-end" ｜ "bottom-start" ｜ "left" ｜ "left-end" ｜ "left-start" ｜ "right" ｜ "right-end" ｜ "right-start" ｜ "top" ｜ "top-end" ｜ "top-start"` | `'top'` |

--- a/packages/documentation/docs/auto-generated/ix-workflow-step/props.md
+++ b/packages/documentation/docs/auto-generated/ix-workflow-step/props.md
@@ -1,8 +1,8 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|clickable| Activate navigation click | `clickable` | `boolean` | `false` |
-|disabled| Set disabled | `disabled` | `boolean` | `false` |
-|position| Activate navigation click | `position` | `"first" ｜ "last" ｜ "undefined"` | `'undefined'` |
-|selected| Set selected | `selected` | `boolean` | `false` |
-|status| Set status | `status` | `"done" ｜ "error" ｜ "open" ｜ "success" ｜ "warning"` | `'open'` |
-|vertical| Select orientation | `vertical` | `boolean` | `false` |
+|<div className="Api__Table"> <div>clickable</div> <div className="Api__Table Docs__Tags"></div></div>| Activate navigation click | `clickable` | `boolean` | `false` |
+|<div className="Api__Table"> <div>disabled</div> <div className="Api__Table Docs__Tags"></div></div>| Set disabled | `disabled` | `boolean` | `false` |
+|<div className="Api__Table"> <div>position</div> <div className="Api__Table Docs__Tags"></div></div>| Activate navigation click | `position` | `"first" ｜ "last" ｜ "undefined"` | `'undefined'` |
+|<div className="Api__Table"> <div>selected</div> <div className="Api__Table Docs__Tags"></div></div>| Set selected | `selected` | `boolean` | `false` |
+|<div className="Api__Table"> <div>status</div> <div className="Api__Table Docs__Tags"></div></div>| Set status | `status` | `"done" ｜ "error" ｜ "open" ｜ "success" ｜ "warning"` | `'open'` |
+|<div className="Api__Table"> <div>vertical</div> <div className="Api__Table Docs__Tags"></div></div>| Select orientation | `vertical` | `boolean` | `false` |

--- a/packages/documentation/docs/auto-generated/ix-workflow-steps/events.md
+++ b/packages/documentation/docs/auto-generated/ix-workflow-steps/events.md
@@ -1,3 +1,3 @@
 | Name       | Description                   | Attribute        | Detail |
 |------------|-------------------------------|------------------|--------|
-|stepSelected| On step selected event | `number`
+|<div className="Api__Table"> <div>stepSelected</div> <div className="Api__Table Docs__Tags"></div></div>| On step selected event | `number`

--- a/packages/documentation/docs/auto-generated/ix-workflow-steps/props.md
+++ b/packages/documentation/docs/auto-generated/ix-workflow-steps/props.md
@@ -1,6 +1,6 @@
 | Name       | Description                   | Attribute        | Type                                      | Default             |
 |------------|-------------------------------|------------------|-------------------------------------------|---------------------|
-|clickable| Activate navigation click | `clickable` | `boolean` | `false` |
-|linear| Select linear mode | `linear` | `boolean` | `false` |
-|selectedIndex| Activate navigation click | `selected-index` | `number` | `0` |
-|vertical| Select orientation | `vertical` | `boolean` | `false` |
+|<div className="Api__Table"> <div>clickable</div> <div className="Api__Table Docs__Tags"></div></div>| Activate navigation click | `clickable` | `boolean` | `false` |
+|<div className="Api__Table"> <div>linear</div> <div className="Api__Table Docs__Tags"></div></div>| Select linear mode | `linear` | `boolean` | `false` |
+|<div className="Api__Table"> <div>selectedIndex</div> <div className="Api__Table Docs__Tags"></div></div>| Activate navigation click | `selected-index` | `number` | `0` |
+|<div className="Api__Table"> <div>vertical</div> <div className="Api__Table Docs__Tags"></div></div>| Select orientation | `vertical` | `boolean` | `false` |

--- a/packages/documentation/docusaurus.config.js
+++ b/packages/documentation/docusaurus.config.js
@@ -32,6 +32,7 @@ const customCss = [
   ...libCss,
   require.resolve('./src/css/custom.css'),
   require.resolve('./src/css/search.css'),
+  require.resolve('./src/css/api-table.css'),
 ];
 
 const baseUrl = process.env.BASE_URL || '/';

--- a/packages/documentation/scripts/docs-tags.mjs
+++ b/packages/documentation/scripts/docs-tags.mjs
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ *
+ * @param {string} name
+ * @param {Array<{ name: string, text: string }>} docsTags
+ * @returns
+ */
+export function appendDocsTags(name, docsTags) {
+  let value = name;
+  docsTags.forEach((docsTag) => {
+    if (docsTag.name === 'since') {
+      value += `<span className="Api__Table Docs__Tag">Since: ${docsTag.text}</span>`;
+    }
+  });
+  return value;
+}

--- a/packages/documentation/src/css/api-table.css
+++ b/packages/documentation/src/css/api-table.css
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.Api__Table .Name {
+  display: flex;
+  flex-direction: column;
+}
+
+.Api__Table .Docs__Tags {
+  margin-top: 0.15rem;
+}
+
+.Api__Table .Docs__Tag {
+  font-size: 12px;
+  background-color: var(--theme-color-primary);
+  border-radius: 2px;
+  padding: 0.15rem 0.25rem;
+  margin-right: 0.15rem;
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/siemens/ix) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test` and `yarn visual-regression` (docker needed)).
  5. Format your code with [prettier](https://github.com/prettier/prettier).
  6. Make sure your code lints.

-->

## Summary

Add docs-tags to component api table. This feature is necessary, because if we create a next minor version the api description will be changed, but it is not intended to generate a complete new docusaurus version.

Currently implemented is `since` with the following js docs style

```javascript
  /**
   * Label of blind
   *
   * @since 99.11.00
   */
  @Prop() label: string;

  /**
   * Collapsed state changed
   *
   * @since 22.33.11
   */
  @Event() collapsedChange: EventEmitter<boolean>;
```

this will be generated to:

<img width="832" alt="image" src="https://user-images.githubusercontent.com/2144313/196877379-e8deca33-e287-476c-ac7f-62339a8acca7.png">
