### PR TITLE
chore: move `.gitignore` rules to packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,7 +130,6 @@ Thumbs.db
 /build
 
 # Generated files
-.docusaurus
 .cache-loader
 
 # Misc
@@ -152,16 +151,3 @@ packages/*/www/
 packages/*/loader/
 packages/*/dist-transpiled/
 packages/*/build/
-
-###
-# @siemens/html-test-app
-###
-
-packages/html-test-app/src/public/additional-theme
-
-###
-# documentation
-###
-
-packages/documentation/static/webcomponent-examples/*
-!packages/documentation/static/versioned_examples/*/webcomponent-examples

--- a/packages/documentation/.gitignore
+++ b/packages/documentation/.gitignore
@@ -1,0 +1,2 @@
+/.docusaurus
+/static/webcomponent-examples/

--- a/packages/html-test-app/.gitignore
+++ b/packages/html-test-app/.gitignore
@@ -1,0 +1,1 @@
+/src/public/additional-theme/


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/siemens/ix) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test` and `yarn visual-regression` (docker needed)).
  5. Format your code with [prettier](https://github.com/prettier/prettier).
  6. Make sure your code lints.

-->

## Summary

I've moved some `.gitignore` rules into package-local `.gitignore` files which IMO makes keeping track of the relevant rules easier than managing them globally.

Just one question: It seems `packages/documentation/static/versioned_examples/` is populated ever. Is that right? The `.gitignore` rule

```gitignore
!packages/documentation/static/versioned_examples/*/webcomponent-examples
```
since none of its parent directories was excluded, so there's no need to _include_ this specific subpath again.

## How did you test this change?

Nothing to test here.
