### PR TITLE
fix(core): eol uniformization

### DIFF
--- a/packages/core/stencil.config.ts
+++ b/packages/core/stencil.config.ts
@@ -194,7 +194,7 @@ export const config: Config = {
 
         fs.writeFileSync(
           'component-doc.json',
-          JSON.stringify(docs, undefined, 2)
+          JSON.stringify(docs, undefined, 2).replace(/(?:\\[r])+/g, '')
         );
       },
     },


### PR DESCRIPTION
## Summary

When running **build** for the _@siemens/ix_ package the file **component-doc.json** generates its content _eol_ based on the users system.
To uniformize the content from win/unix systems i added a search replace "\r" -> ""

## How did you test this change?

Runned the build command on both unix & win systems and the output is the same