### PR TITLE
fix(core): button group borders

### DIFF
--- a/packages/core/scss/components/_button-group.scss
+++ b/packages/core/scss/components/_button-group.scss
@@ -11,6 +11,7 @@
   ix-button:first-child .btn {
     border-top-right-radius: 0px;
     border-bottom-right-radius: 0px;
+    border-right: 0px;
   }
 
   ix-button:last-child .btn {
@@ -20,5 +21,6 @@
 
   ix-button:not(:first-child):not(:last-child) .btn {
     border-radius: 0px;
+    border-right: 0px;
   }
 }


### PR DESCRIPTION
## Summary

Now when in a group, every button doesnt have a right border exepect the last one.

Fix #151 

## How did you test this change?

Tested locally
