### PR TITLE
fix(core/select): observer child label change

### DIFF
--- a/packages/core/src/components/select/select.tsx
+++ b/packages/core/src/components/select/select.tsx
@@ -84,23 +84,20 @@ export class Select {
   @Event() addItem: EventEmitter<string>;
 
   @State() dropdownShow = false;
-
   @State() value: string[];
-
   @State() dropdownWrapperRef!: HTMLElement;
   @State() dropdownAnchor!: HTMLElement;
+  @State() isDropdownEmpty = false;
+  @State() hasFocus = false;
+  @State() navigationItem: HTMLIxSelectItemElement;
+  @State() inputFilterText: string;
+  @State() inputValue: string;
 
   private inputRef!: HTMLInputElement;
   private dropdownRef!: HTMLIxDropdownElement;
   private addItemRef!: HTMLDivElement;
 
-  @State() isDropdownEmpty = false;
-
-  @State() hasFocus = false;
-
-  @State() navigationItem: HTMLIxSelectItemElement;
-
-  @State() inputText: string;
+  private labelMutationObserver: MutationObserver;
 
   get items() {
     return Array.from(this.hostElement.querySelectorAll('ix-select-item'));
@@ -143,7 +140,7 @@ export class Select {
     this.emitItemClick(newId);
   }
 
-  @Watch('inputText')
+  @Watch('inputFilterText')
   watchInputText(newValue: string) {
     if (!this.editable) {
       return;
@@ -191,6 +188,13 @@ export class Select {
     });
 
     this.value = this.selectedItems.map((item) => item.label);
+
+    if (this.isSingleMode) {
+      this.inputValue = this.value?.length ? this.value[0] : null;
+      return;
+    }
+
+    this.inputValue = null;
   }
 
   componentWillLoad() {
@@ -200,6 +204,27 @@ export class Select {
           ? this.selectedIndices
           : [this.selectedIndices]
       );
+    }
+  }
+
+  componentDidLoad() {
+    this.labelMutationObserver = new MutationObserver(() => {
+      this.selectValue(
+        Array.isArray(this.selectedIndices)
+          ? this.selectedIndices
+          : [this.selectedIndices]
+      );
+    });
+    this.labelMutationObserver.observe(this.hostElement, {
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['label'],
+    });
+  }
+
+  disconnectedCallback() {
+    if (this.labelMutationObserver) {
+      this.labelMutationObserver.disconnect();
     }
   }
 
@@ -243,8 +268,8 @@ export class Select {
   }
 
   private async onEnterNavigation() {
-    if (this.editable && !this.itemExists(this.inputText)) {
-      this.emitAddItem(this.inputText);
+    if (this.editable && !this.itemExists(this.inputFilterText)) {
+      this.emitAddItem(this.inputFilterText);
       this.navigationItem = this.items[this.items.length - 1];
     }
 
@@ -282,11 +307,13 @@ export class Select {
   }
 
   private filterItemsWithTypeahead() {
-    this.inputText = this.inputRef.value;
-    if (this.inputText) {
+    this.inputFilterText = this.inputRef.value;
+    if (this.inputFilterText) {
       this.items.forEach((item) => {
         item.classList.remove('d-none');
-        if (!item.label.toLowerCase().includes(this.inputText.toLowerCase())) {
+        if (
+          !item.label.toLowerCase().includes(this.inputFilterText.toLowerCase())
+        ) {
           item.classList.add('d-none');
         }
       });
@@ -306,7 +333,7 @@ export class Select {
 
   private clearInput() {
     this.inputRef.value = '';
-    this.inputText = '';
+    this.inputFilterText = '';
   }
 
   private clear() {
@@ -314,13 +341,6 @@ export class Select {
     this.value = [];
     this.selectedIndices = [];
     this.itemSelectionChange.emit(null);
-  }
-
-  private getInputValue() {
-    if (this.isSingleMode) {
-      return this.value?.length ? this.value[0] : null;
-    }
-    return null;
   }
 
   render() {
@@ -371,7 +391,7 @@ export class Select {
                     ? this.i18nPlaceholderEditable
                     : this.i18nPlaceholder
                 }
-                value={this.getInputValue()}
+                value={this.inputValue}
                 ref={(ref) => (this.inputRef = ref)}
                 onInput={() => this.filterItemsWithTypeahead()}
               />
@@ -387,7 +407,7 @@ export class Select {
               )}
             </div>
           </div>
-          {this.allowClear && (this.value?.length || this.inputText) ? (
+          {this.allowClear && (this.value?.length || this.inputFilterText) ? (
             <ix-icon-button
               class="clear"
               icon="clear"
@@ -424,7 +444,7 @@ export class Select {
           <div class="select-list-header">{this.i18nSelectListHeader}</div>
           <slot></slot>
           <div ref={(ref) => (this.addItemRef = ref)} class="d-contents"></div>
-          {this.itemExists(this.inputText) ? (
+          {this.itemExists(this.inputFilterText) ? (
             ''
           ) : (
             <ix-dropdown-item
@@ -432,13 +452,13 @@ export class Select {
               icon="plus"
               class={{
                 'add-item': true,
-                'd-none': !(this.editable && this.inputText),
+                'd-none': !(this.editable && this.inputFilterText),
               }}
-              label={this.inputText}
+              label={this.inputFilterText}
               onItemClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                this.emitAddItem(this.inputText);
+                this.emitAddItem(this.inputFilterText);
               }}
             ></ix-dropdown-item>
           )}

--- a/packages/core/src/components/select/test/cw-select.spec.tsx
+++ b/packages/core/src/components/select/test/cw-select.spec.tsx
@@ -12,6 +12,13 @@ import { fireEvent, screen } from '@testing-library/dom';
 import { SelectItem } from '../../select-item/select-item';
 import { Select } from '../select';
 
+//@ts-ignore
+global.MutationObserver = class {
+  constructor() {}
+  disconnect() {}
+  observe() {}
+};
+
 describe('ix-select', () => {
   it('renders', async () => {
     const page = await newSpecPage({

--- a/packages/core/src/components/select/test/cw-select.spec.tsx
+++ b/packages/core/src/components/select/test/cw-select.spec.tsx
@@ -149,6 +149,47 @@ describe('ix-select', () => {
   });
 
   describe('single mode selection', () => {
+    it('change label of selected item', async () => {
+      let updateCallback = jest.fn();
+
+      //@ts-ignore
+      global.MutationObserver = class {
+        constructor(callback) {
+          updateCallback = callback;
+        }
+        disconnect() {}
+        observe() {}
+      };
+
+      const page = await newSpecPage({
+        components: [Select, SelectItem],
+        html: `
+        <ix-select data-testid="select">
+          <ix-select-item data-testid="select-1" value="1" label="ABC"></ix-select-item>
+          <ix-select-item data-testid="select-2" value="2" label="ABC 2"></ix-select-item>
+          <ix-select-item data-testid="select-3" value="3" label="XYZ"></ix-select-item>
+        </ix-select>`,
+      });
+      await page.waitForChanges();
+
+      const selectElement = page.doc.querySelector('ix-select');
+      selectElement.selectedIndices = ['2'];
+      await page.waitForChanges();
+
+      const inputElement = screen.getByTestId('input') as HTMLInputElement;
+      expect(inputElement.value).toBe('ABC 2');
+
+      const selectItemElement = screen.getByTestId(
+        'select-2'
+      ) as HTMLIxSelectItemElement;
+      selectItemElement.label = 'CHANGED!';
+      updateCallback();
+
+      await page.waitForChanges();
+
+      expect(inputElement.value).toBe('CHANGED!');
+    });
+
     it('select item', async () => {
       const page = await newSpecPage({
         components: [Select, SelectItem],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/siemens/ix) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test` and `yarn visual-regression` (docker needed)).
  5. Format your code with [prettier](https://github.com/prettier/prettier).
  6. Make sure your code lints.

-->

## Summary

If a label of `ix-select-item` is changed the input element was not updated.
Iam added a MutationObserver to observe child changes regarding label

## How did you test this change?

- [x] Unit test