### PR TITLE
ci(workflow/build): avoid duplicated pipeline on merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,13 @@
 name: build
 
-on: [push, pull_request, workflow_dispatch, workflow_call]
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release/*'
+  pull_request:
+    branches:
+      - '**'
 
 concurrency:
   group: ci-${{ github.event_name }}-${{ github.ref }}-${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches:
       - '**'
+  workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: ci-${{ github.event_name }}-${{ github.ref }}-${{ github.sha }}


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bug fix
- [ ] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): github build action duplicated

## What is the current behavior?

Currently when you create a pull request 2 build actions are triggered

## What is the new behavior?

When creating a merge request there should only be 1 build action

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
