### PR TITLE
fix(core/toast): delay animation into next frame

### DIFF
--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -116,9 +116,11 @@ export class Toast {
     }
 
     const updateProgress = () => {
-      if (progressBarElement) {
-        progressBarElement.style.transform = `scaleX(${this.progress})`;
-      }
+      requestAnimationFrame(() => {
+        if (progressBarElement) {
+          progressBarElement.style.transform = `scaleX(${this.progress})`;
+        }
+      });
     };
 
     return (
@@ -163,7 +165,9 @@ export class Toast {
             class={progressBarClass.join(' ')}
             style={progressBarStyle}
             ref={(r) => (progressBarElement = r)}
-            onAnimationEnd={() => this.close()}
+            onAnimationEnd={() => {
+              this.close();
+            }}
             onTransitionEnd={() => {
               if (this.progress === 0) {
                 this.close();


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/siemens/ix) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test` and `yarn visual-regression` (docker needed)).
  5. Format your code with [prettier](https://github.com/prettier/prettier).
  6. Make sure your code lints.

-->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [x] Unit tests (`yarn test`) were run locally and passed
- [x] Visual Regression Tests (`yarn visual-regression`) were run locally and passed
- [x] Linting (`npm lint`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug fix
- [ ] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Put scaling into `requestAnimationFrame` to be sure that `onTransitionEnd` event is triggered properly.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
