### PR TITLE
refactor(core/select): change itemSelectionChange event signature

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -2,6 +2,14 @@
 
 ## v2.0.0
 
+### Change `itemSelectionChange` event from `ix-select`
+
+Change type of CustomEvent to:
+
+```typescript
+@Event() itemSelectionChange: EventEmitter<string[]>
+```
+
 ### Remove `ix-animated-tab` and `ix-animated-tabs`
 
 Replaced by `ix-tabs` implementation.

--- a/packages/angular/src/components.ts
+++ b/packages/angular/src/components.ts
@@ -1706,7 +1706,7 @@ export declare interface IxSelect extends Components.IxSelect {
   /**
    * Item selection changed
    */
-  itemSelectionChange: EventEmitter<CustomEvent<string | string[]>>;
+  itemSelectionChange: EventEmitter<CustomEvent<string[]>>;
   /**
    * Event dispatched whenever the text input changes. @since 2.0.0
    */

--- a/packages/core/component-doc.json
+++ b/packages/core/component-doc.json
@@ -8522,7 +8522,7 @@
         },
         {
           "event": "itemSelectionChange",
-          "detail": "string | string[]",
+          "detail": "string[]",
           "bubbles": true,
           "cancelable": true,
           "composed": true,

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -4441,7 +4441,7 @@ declare namespace LocalJSX {
         /**
           * Item selection changed
          */
-        "onItemSelectionChange"?: (event: IxSelectCustomEvent<string | string[]>) => void;
+        "onItemSelectionChange"?: (event: IxSelectCustomEvent<string[]>) => void;
         /**
           * If true the select will be in readonly mode
          */

--- a/packages/core/src/components/select/select.tsx
+++ b/packages/core/src/components/select/select.tsx
@@ -93,7 +93,7 @@ export class Select {
   /**
    * Item selection changed
    */
-  @Event() itemSelectionChange: EventEmitter<string | string[]>;
+  @Event() itemSelectionChange: EventEmitter<string[]>;
 
   /**
    * Event dispatched whenever the text input changes.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/siemens/ix) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test` and `yarn visual-regression` (docker needed)).
  5. Format your code with [prettier](https://github.com/prettier/prettier).
  6. Make sure your code lints.

-->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`yarn build`) was run locally and any changes were pushed
- [ ] Unit tests (`yarn test`) were run locally and passed
- [ ] Visual Regression Tests (`yarn visual-regression`) were run locally and passed
- [ ] Linting (`npm lint`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug fix
- [ ] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: 

Closes #280

## Does this introduce a breaking change?

- [x] Yes, see BREAKING_CHANGES.md
- [ ] No
