### PR TITLE
fix(core/select): fix editable mode with shadow DOM

### DIFF
--- a/packages/core/src/components/select/select.tsx
+++ b/packages/core/src/components/select/select.tsx
@@ -139,7 +139,12 @@ export class Select {
   private labelMutationObserver: MutationObserver;
 
   get items() {
-    return Array.from(this.hostElement.querySelectorAll('ix-select-item'));
+    return [
+      ...Array.from(this.hostElement.querySelectorAll('ix-select-item')),
+      ...Array.from(
+        this.hostElement.shadowRoot.querySelectorAll('ix-select-item')
+      ),
+    ];
   }
 
   get selectedItems() {
@@ -147,7 +152,7 @@ export class Select {
   }
 
   get addItemButton() {
-    return this.hostElement.querySelector('.add-item');
+    return this.hostElement.shadowRoot.querySelector('.add-item');
   }
 
   get isSingleMode() {

--- a/packages/core/src/components/select/test/select.ct.ts
+++ b/packages/core/src/components/select/test/select.ct.ts
@@ -51,6 +51,9 @@ test('editable mode', async ({ mount, page }) => {
   await expect(add).toBeVisible();
 
   await add.click();
+
+  await expect(page.getByTestId('input')).toHaveValue(/Not existing/);
+
   await page.locator('.chevron-down-container').click();
 
   await expect(page.getByRole('button', { name: 'Item 1' })).toBeVisible();


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/siemens/ix) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test` and `yarn visual-regression` (docker needed)).
  5. Format your code with [prettier](https://github.com/prettier/prettier).
  6. Make sure your code lints.

-->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`yarn build`) was run locally and any changes were pushed
- [X] Unit tests (`yarn test`) were run locally and passed
- [X] Visual Regression Tests (`yarn visual-regression`) were run locally and passed
- [X] Linting (`npm lint`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bug fix
- [ ] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Selection of added options in `<ix-select editable/>` does not work.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Selecting a created option with `editable` works now with Shadow DOM.
- Modified the items getter to also retrieve `ix-select-item` inside the shadow DOM.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
