### PR TITLE
fix(core/input-group): add padding left for error image

### DIFF
--- a/packages/core/scss/components/form/_input.scss
+++ b/packages/core/scss/components/form/_input.scss
@@ -18,7 +18,7 @@
     padding: 0.25rem 0.5rem;
     background-color: var(--theme-input--background);
     color: var(--theme-input--color);
-
+    text-overflow: ellipsis;
     border: var(--theme-input--border-thickness, 1px) solid
       var(--theme-input--border-color);
     border-radius: var(--theme-input--border-radius);

--- a/packages/core/src/components/input-group/input-group.tsx
+++ b/packages/core/src/components/input-group/input-group.tsx
@@ -115,7 +115,8 @@ export class InputGroup {
           this.inputElement.form?.noValidate === false) &&
         !this.inputElement.validity.valid
       ) {
-        this.inputElement.style.backgroundPositionX = `${this.inputPaddingLeft}px`;
+        const left = this.inputPaddingLeft !== 0 ? this.inputPaddingLeft : 8;
+        this.inputElement.style.backgroundPositionX = `${left}px`;
         this.inputPaddingLeft += 32;
       }
     });

--- a/packages/core/src/components/input-group/tests/input-group.ct.ts
+++ b/packages/core/src/components/input-group/tests/input-group.ct.ts
@@ -99,3 +99,64 @@ test('update padding end', async ({ mount, page }) => {
   await expect(input).toHaveCSS('padding-left', '55px');
   await expect(input).toHaveCSS('padding-right', '65px');
 });
+
+test('validation padding', async ({ mount, page }) => {
+  await mount(`
+    <form class="needs-validation" noValidation>
+      <ix-input-group>
+        <input type="text" required />
+      </ix-input-group>
+
+      <ix-button type="submit">Submit</ix-button>
+    </form>
+  `);
+
+  const form = page.locator('form');
+  await form.evaluate((form) =>
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      form.classList.add('was-validated');
+    })
+  );
+
+  const group = page.locator('ix-input-group');
+  await expect(group).toHaveClass(/hydrated/);
+
+  const input = group.locator('input');
+  const button = page.locator('ix-button');
+
+  await button.click();
+
+  await expect(input).toHaveCSS('background-position-x', '8px');
+});
+
+test('validation padding with input-start slot', async ({ mount, page }) => {
+  await mount(`
+    <form class="needs-validation" noValidation>
+      <ix-input-group>
+        <ix-icon name="eye" size="12" slot="input-start"></ix-icon>
+        <input type="text" required />
+      </ix-input-group>
+
+      <ix-button type="submit">Submit</ix-button>
+    </form>
+  `);
+
+  const form = page.locator('form');
+  await form.evaluate((form) =>
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      form.classList.add('was-validated');
+    })
+  );
+
+  const group = page.locator('ix-input-group');
+  await expect(group).toHaveClass(/hydrated/);
+
+  const input = group.locator('input');
+  const button = page.locator('ix-button');
+
+  await button.click();
+
+  await expect(input).toHaveCSS('background-position-x', '27px');
+});


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/siemens/ix) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test` and `yarn visual-regression` (docker needed)).
  5. Format your code with [prettier](https://github.com/prettier/prettier).
  6. Make sure your code lints.

-->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [ ] Unit tests (`yarn test`) were run locally and passed
- [ ] Visual Regression Tests (`yarn visual-regression`) were run locally and passed
- [ ] Linting (`npm lint`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug fix
- [ ] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fix padding if used inside a form validation
- Add ellipsis to handle input overflow

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
