### PR TITLE
fix(core/basic-navigation): fixed behavior on missing breakpoints

### DIFF
--- a/packages/core/src/components/utils/application-layout/service.ts
+++ b/packages/core/src/components/utils/application-layout/service.ts
@@ -53,8 +53,10 @@ class ApplicationLayoutService {
     });
 
     if (matchBreakpoints.every(([_, match]) => match === false)) {
-      this.#breakpointChangeListener.emit(breakpoints[0]);
-      this.#breakpoint = breakpoints[0];
+      this.#breakpointChangeListener.emit(
+        breakpoints[matchBreakpoints.length - 1]
+      );
+      this.#breakpoint = breakpoints[breakpoints[matchBreakpoints.length - 1]];
       return;
     }
 

--- a/packages/core/src/components/utils/application-layout/service.ts
+++ b/packages/core/src/components/utils/application-layout/service.ts
@@ -53,10 +53,14 @@ class ApplicationLayoutService {
     });
 
     if (matchBreakpoints.every(([_, match]) => match === false)) {
-      this.#breakpointChangeListener.emit(
-        breakpoints[matchBreakpoints.length - 1]
-      );
-      this.#breakpoint = breakpoints[breakpoints[matchBreakpoints.length - 1]];
+      let breakPointIndex = 0;
+      if (!this.#supportedBreakpoints.includes('lg')) {
+        breakPointIndex = matchBreakpoints.length - 1;
+      }
+
+      const [breakpoint, _] = matchBreakpoints[breakPointIndex];
+      this.#breakpointChangeListener.emit(breakpoint);
+      this.#breakpoint = breakpoint;
       return;
     }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/siemens/ix) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test` and `yarn visual-regression` (docker needed)).
  5. Format your code with [prettier](https://github.com/prettier/prettier).
  6. Make sure your code lints.

-->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [x] Unit tests (`yarn test`) were run locally and passed
- [x] Visual Regression Tests (`yarn visual-regression`) were run locally and passed
- [x] Linting (`npm lint`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug fix
- [ ] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- when using breakpoints inside the basic navigation, there might occur strange behavior when some breakpoints are not supported
- e.g ['sm', 'md'] -> on lg 'sm' would be used instead of md
- e.g ['md', 'lg'] -> on sm 'sm' would be used

GitHub Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- only supported breakpoints are evaluated
- lg has a different breakpoint logic
- if md is not available, sm will be used instead of md

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
