### PR TITLE
fix(core/windows-doc-generation): fix for component-doc generation

### DIFF
--- a/packages/core/stencil.config.ts
+++ b/packages/core/stencil.config.ts
@@ -146,7 +146,7 @@ export const config: Config = {
 
         fs.writeFileSync(
           'component-doc.json',
-          JSON.stringify(patchedJson, null, 2).replace(/(?:\\[r])+/g, '')
+          JSON.stringify(patchedJson, null, 2)
         );
       },
     },

--- a/packages/core/stencil.config.ts
+++ b/packages/core/stencil.config.ts
@@ -163,7 +163,8 @@ function normalizeProperties(obj: JsonDocs, deleteProps: string[]) {
     if (obj[key] && typeof obj[key] === 'object') {
       normalizeProperties(obj[key], deleteProps);
     } else if (deleteProps.includes(key)) {
-      obj[key] = path.relative(__dirname, obj[key]);
+      const posixPath = path.join(...path.relative(__dirname, obj[key]).split(path.sep)).toString();
+      obj[key] = posixPath.replace(/\\/g, '/');
     }
   }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/siemens/ix) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test` and `yarn visual-regression` (docker needed)).
  5. Format your code with [prettier](https://github.com/prettier/prettier).
  6. Make sure your code lints.

-->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`yarn build`) was run locally and any changes were pushed
- [ ] Unit tests (`yarn test`) were run locally and passed
- [ ] Visual Regression Tests (`yarn visual-regression`) were run locally and passed
- [ ] Linting (`npm lint`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bug fix
- [ ] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
When building on Windows, the relative paths are formatted in Windows style and getting escaped (e.g., \\src\\components\\action-card.tsx), potentially causing issues in the pipeline due to inconsistent path formats. To ensure seamless behavior, a small adaptation has been made to transform paths to Unix-style, even when building on Windows.
Tested on Windows 10 and Fedora 38.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A

## What is the new behavior?
All paths are getting formated in a unix style way
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
