### PR TITLE
fix(react|vue): define internal components

### DIFF
--- a/packages/react/src/internal-components.ts
+++ b/packages/react/src/internal-components.ts
@@ -6,6 +6,14 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import { defineCustomElement as defineIxApplicationSidebar } from '@siemens/ix/components/ix-application-sidebar.js';
 import { defineCustomElement as defineIxApplicationSwitchModal } from '@siemens/ix/components/ix-application-switch-modal.js';
+import { defineCustomElement as defineIxBurgerMenu } from '@siemens/ix/components/ix-burger-menu.js';
+import { defineCustomElement as defineIxDateTimeCard } from '@siemens/ix/components/ix-date-time-card.js';
+import { defineCustomElement as defineIxModalLoading } from '@siemens/ix/components/ix-modal-loading.js';
 
 defineIxApplicationSwitchModal();
+defineIxApplicationSidebar();
+defineIxDateTimeCard();
+defineIxBurgerMenu();
+defineIxModalLoading();

--- a/packages/vue/src/internal-components.ts
+++ b/packages/vue/src/internal-components.ts
@@ -6,6 +6,14 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import { defineCustomElement as defineIxApplicationSidebar } from '@siemens/ix/components/ix-application-sidebar.js';
 import { defineCustomElement as defineIxApplicationSwitchModal } from '@siemens/ix/components/ix-application-switch-modal.js';
+import { defineCustomElement as defineIxBurgerMenu } from '@siemens/ix/components/ix-burger-menu.js';
+import { defineCustomElement as defineIxDateTimeCard } from '@siemens/ix/components/ix-date-time-card.js';
+import { defineCustomElement as defineIxModalLoading } from '@siemens/ix/components/ix-modal-loading.js';
 
 defineIxApplicationSwitchModal();
+defineIxApplicationSidebar();
+defineIxDateTimeCard();
+defineIxBurgerMenu();
+defineIxModalLoading();


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 🆕 What is the new behavior?

React and Vue have to define the internal components they are not part of the generation.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated (`yarn docs`)
- [x] 🧪 Unit tests were added/updated and pass (`yarn test`)
- [x] 📸 Visual regression tests were added/updated and pass (`yarn visual-regression`)
- [x] 🧐 Static code analysis passes (`yarn lint`)
- [x] 🏗️ Successful compilation (`yarn build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->