### PR TITLE
fix(core/burger-menu): a11y expand state

### DIFF
--- a/packages/core/src/components/menu/burger-menu.scss
+++ b/packages/core/src/components/menu/burger-menu.scss
@@ -74,8 +74,4 @@ $focus-bdr-width: 0.0625rem;
     transform: rotate(45deg);
     y: 11px;
   }
-
-  ix-icon-button {
-    transform: rotate(180deg);
-  }
 }

--- a/packages/core/src/components/menu/burger-menu.tsx
+++ b/packages/core/src/components/menu/burger-menu.tsx
@@ -52,7 +52,10 @@ export class BurgerMenu {
         }}
       >
         {this.pinned ? (
-          <ix-icon-button icon={'double-chevron-right'} ghost></ix-icon-button>
+          <ix-icon-button
+            icon={`double-chevron-${this.expanded ? 'left' : 'right'}`}
+            ghost
+          ></ix-icon-button>
         ) : (
           <button
             class={{

--- a/packages/core/src/components/menu/test/menu.ct.ts
+++ b/packages/core/src/components/menu/test/menu.ct.ts
@@ -206,6 +206,28 @@ test('should close menu by bottom icon click', async ({ mount, page }) => {
   await expect(element).toBeVisible();
 });
 
+test('should have correct aria label', async ({ mount, page }) => {
+  await mount(`
+    <ix-menu pinned>
+    </ix-menu>
+    `);
+
+  await page.locator('ix-menu');
+  const chevronButton = page.locator('ix-icon-button button');
+
+  await expect(chevronButton).toHaveAttribute(
+    'aria-label',
+    'Double Chevron Right'
+  );
+
+  chevronButton.click();
+
+  await expect(chevronButton).toHaveAttribute(
+    'aria-label',
+    'Double Chevron Left'
+  );
+});
+
 async function clickAboutButton(element: Locator, page: Page) {
   const aboutButton = element.locator('ix-menu-item#aboutAndLegal');
   await aboutButton.click();


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/siemens/ix) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test` and `yarn visual-regression` (docker needed)).
  5. Format your code with [prettier](https://github.com/prettier/prettier).
  6. Make sure your code lints.

-->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [x] Unit tests (`yarn test`) were run locally and passed
- [x] Visual Regression Tests (`yarn visual-regression`) were run locally and passed
- [x] Linting (`npm lint`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug fix
- [ ] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Before the chevron button was flipped via rotation which caused the aria-label to be wrong while expanded
- Now the icon will get swapped instead and the aria label will get computed anew everytime the menu toggles
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
