### PR TITLE
fix(angular): icon size property missing in wrapper generation

### DIFF
--- a/packages/angular/src/ix-icon.ts
+++ b/packages/angular/src/ix-icon.ts
@@ -21,13 +21,13 @@ export declare interface IxIcon extends Components.IxIcon {}
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['color', 'name'],
+  inputs: ['color', 'name', 'size'],
 })
 @Component({
   selector: 'ix-icon',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['color', 'name'],
+  inputs: ['color', 'name', 'size'],
 })
 export class IxIcon {
   protected el: HTMLElement;


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: Closes #1057

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Add size property to angular proxy component

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated (`yarn docs`)
- [x] 🧪 Unit tests were added/updated and pass (`yarn test`)
- [x] 📸 Visual regression tests were added/updated and pass (`yarn visual-regression`)
- [x] 🧐 Static code analysis passes (`yarn lint`)
- [x] 🏗️ Successful compilation (`yarn build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->