### PR TITLE
fix(core/tooltip): prevent focusin event call showTooltip

### DIFF
--- a/.changeset/short-bulldogs-repeat.md
+++ b/.changeset/short-bulldogs-repeat.md
@@ -1,0 +1,5 @@
+---
+"@siemens/ix": patch
+---
+
+fix(core/tooltip): prevent focusin event call showTooltip

--- a/packages/core/src/components/tooltip/test/tooltip.ct.ts
+++ b/packages/core/src/components/tooltip/test/tooltip.ct.ts
@@ -67,3 +67,42 @@ test('hide tooltip after delay', async ({ mount, page }) => {
   await page.waitForTimeout(1000);
   await expect(tooltip).not.toBeVisible();
 });
+
+test('avoid double visibility request by focusin event', async ({
+  mount,
+  page,
+}) => {
+  await mount(`
+    <ix-menu>
+      <ix-menu-item>Item 1</ix-menu-item>
+      <ix-menu-item>Item 2</ix-menu-item>
+    </ix-menu>
+  `);
+
+  const menuItem1 = page.locator('ix-menu-item:nth-child(1)');
+  const menuItem2 = page.locator('ix-menu-item:nth-child(2)');
+
+  await menuItem1.hover();
+  await page.waitForTimeout(5);
+  await menuItem1.click();
+  await page.waitForTimeout(200);
+  await expect(menuItem1.locator('ix-tooltip')).toBeVisible();
+
+  await menuItem2.hover();
+  await page.waitForTimeout(5);
+  await menuItem2.click();
+  await page.waitForTimeout(200);
+  await expect(menuItem2.locator('ix-tooltip')).toBeVisible();
+
+  await menuItem1.hover();
+  await page.waitForTimeout(5);
+  await menuItem1.click();
+  await page.waitForTimeout(200);
+  await expect(menuItem1.locator('ix-tooltip')).toBeVisible();
+
+  await page.mouse.move(0, 0);
+  await page.waitForTimeout(200);
+
+  await expect(menuItem1.locator('ix-tooltip')).not.toBeVisible();
+  await expect(menuItem2.locator('ix-tooltip')).not.toBeVisible();
+});

--- a/packages/core/src/components/tooltip/tooltip-controller.ts
+++ b/packages/core/src/components/tooltip/tooltip-controller.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { OverlayController } from '../utils/overlay';
+
+class TooltipController extends OverlayController {}
+
+export const tooltipController = new TooltipController();

--- a/packages/core/src/components/utils/overlay.ts
+++ b/packages/core/src/components/utils/overlay.ts
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { IxComponent } from '../utils/internal';
+
+export interface IxOverlayComponent extends IxComponent {
+  isPresent(): boolean;
+
+  willPresent?(): boolean;
+  willDismiss?(): boolean;
+
+  present(): void;
+  dismiss(): void;
+}
+
+export class OverlayController {
+  overlays: Set<IxOverlayComponent> = new Set();
+
+  connected(instance: IxOverlayComponent): void {
+    this.overlays.add(instance);
+  }
+
+  disconnected(instance: IxOverlayComponent): void {
+    this.overlays.delete(instance);
+  }
+
+  present(instance: IxOverlayComponent): void {
+    if (instance.willPresent && !instance.willPresent()) {
+      return;
+    }
+    this.dismissOthers(instance);
+    instance.present();
+  }
+
+  dismiss(instance: IxOverlayComponent): void {
+    if (instance.willDismiss && !instance.willDismiss()) {
+      return;
+    }
+    instance.dismiss();
+  }
+
+  private dismissOthers(instance: IxOverlayComponent): void {
+    this.overlays.forEach((overlay) => {
+      if (overlay !== instance) {
+        this.dismiss(overlay);
+      }
+    });
+  }
+}


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

IX-896

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Prevent tooltip focusin event to call showTooltip, if a setTimeout call is already running.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
