### PR TITLE
feat(vue): add v-model support to ix-select and ix-toggle

### DIFF
--- a/.changeset/yellow-rabbits-behave.md
+++ b/.changeset/yellow-rabbits-behave.md
@@ -1,0 +1,6 @@
+---
+"@siemens/ix": minor
+"@siemens/ix-vue": minor
+---
+
+feat(vue): add v-model support to ix-select and ix-toggle

--- a/packages/core/stencil.config.ts
+++ b/packages/core/stencil.config.ts
@@ -76,6 +76,18 @@ export const config: Config = {
       includePolyfills: false,
       includeDefineCustomElements: false,
       excludeComponents: ['ix-playground-internal', 'ix-icon'],
+      componentModels: [
+        {
+          elements: ['ix-select'],
+          event: 'valueChange',
+          targetAttr: 'value',
+        },
+        {
+          elements: ['ix-toggle'],
+          event: 'checkedChange',
+          targetAttr: 'checked',
+        },
+      ]
     }),
     angularOutputTarget({
       componentCorePackage: '@siemens/ix',

--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -784,7 +784,7 @@ export const IxPushCard = /*@__PURE__*/ defineContainer<JSX.IxPushCard>('ix-push
 export const IxRow = /*@__PURE__*/ defineContainer<JSX.IxRow>('ix-row', defineIxRow);
 
 
-export const IxSelect = /*@__PURE__*/ defineContainer<JSX.IxSelect>('ix-select', defineIxSelect, [
+export const IxSelect = /*@__PURE__*/ defineContainer<JSX.IxSelect, JSX.IxSelect["value"]>('ix-select', defineIxSelect, [
   'selectedIndices',
   'value',
   'allowClear',
@@ -801,7 +801,8 @@ export const IxSelect = /*@__PURE__*/ defineContainer<JSX.IxSelect>('ix-select',
   'itemSelectionChange',
   'inputChange',
   'addItem'
-]);
+],
+'value', 'valueChange');
 
 
 export const IxSelectItem = /*@__PURE__*/ defineContainer<JSX.IxSelectItem>('ix-select-item', defineIxSelectItem, [
@@ -919,7 +920,7 @@ export const IxToastContainer = /*@__PURE__*/ defineContainer<JSX.IxToastContain
 ]);
 
 
-export const IxToggle = /*@__PURE__*/ defineContainer<JSX.IxToggle>('ix-toggle', defineIxToggle, [
+export const IxToggle = /*@__PURE__*/ defineContainer<JSX.IxToggle, JSX.IxToggle["checked"]>('ix-toggle', defineIxToggle, [
   'checked',
   'disabled',
   'indeterminate',
@@ -928,7 +929,8 @@ export const IxToggle = /*@__PURE__*/ defineContainer<JSX.IxToggle>('ix-toggle',
   'textIndeterminate',
   'hideText',
   'checkedChange'
-]);
+],
+'checked', 'checkedChange');
 
 
 export const IxToggleButton = /*@__PURE__*/ defineContainer<JSX.IxToggleButton>('ix-toggle-button', defineIxToggleButton, [


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

IxSelect and IxToggle don't support v-model directive out of the box. Being components that often are used in form control v-model support should exist.

## 🆕 What is the new behavior?

- Updated vueOutputTarget options to enable support for v-model binding in ix-select and ix-toggle.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
