### PR TITLE
fix(angular/modal): avoid overflow of modal content

### DIFF
--- a/.changeset/dry-roses-brake.md
+++ b/.changeset/dry-roses-brake.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix-angular': patch
+---
+
+fix modal overflow issue in angular

--- a/packages/angular-test-app/src/preview-examples/modal-by-template.ts
+++ b/packages/angular-test-app/src/preview-examples/modal-by-template.ts
@@ -16,7 +16,7 @@ import { ModalService } from '@siemens/ix-angular';
     <ix-button (click)="openModal()">Show modal</ix-button>
 
     <ng-template #customModal let-modal>
-      <div>
+      <ix-modal>
         <ix-modal-header> Message headline </ix-modal-header>
         <ix-modal-content
           >Message text lorem ipsum: {{ modal.data }}</ix-modal-content
@@ -33,7 +33,7 @@ import { ModalService } from '@siemens/ix-angular';
             OK
           </ix-button>
         </ix-modal-footer>
-      </div>
+      </ix-modal>
     </ng-template>
   `,
 })

--- a/packages/angular/src/modal/modal.service.spec.ts
+++ b/packages/angular/src/modal/modal.service.spec.ts
@@ -68,7 +68,7 @@ test('should create modal by component typ', async () => {
       },
       injector: {
         get: jest.fn(() => ({
-          nativeElement: {}
+          nativeElement: { style: {} }
         })),
       },
     })),

--- a/packages/angular/src/modal/modal.service.ts
+++ b/packages/angular/src/modal/modal.service.ts
@@ -85,6 +85,7 @@ export class ModalService {
     this.appRef.attachView(instance.hostView);
 
     const element = instance.injector.get(ElementRef);
+    element.nativeElement.style.display = 'contents';
 
     const modalInstance = await this.createModalInstance<TData, TReason>(
       context,

--- a/packages/angular/src/modal/modal.service.ts
+++ b/packages/angular/src/modal/modal.service.ts
@@ -85,7 +85,9 @@ export class ModalService {
     this.appRef.attachView(instance.hostView);
 
     const element = instance.injector.get(ElementRef);
-    element.nativeElement.style.display = 'contents';
+    if (element.nativeElement.style) {
+      element.nativeElement.style.display = 'contents';
+    }
 
     const modalInstance = await this.createModalInstance<TData, TReason>(
       context,

--- a/packages/angular/src/modal/modal.service.ts
+++ b/packages/angular/src/modal/modal.service.ts
@@ -85,9 +85,7 @@ export class ModalService {
     this.appRef.attachView(instance.hostView);
 
     const element = instance.injector.get(ElementRef);
-    if (element.nativeElement.style) {
-      element.nativeElement.style.display = 'contents';
-    }
+    element.nativeElement.style.display = 'contents';
 
     const modalInstance = await this.createModalInstance<TData, TReason>(
       context,


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?
- The modal can overflow (e.g very long text in the the modal content) because of the wrapper applied 
- Behavior has also been tested in react, but is only observerable in Angular
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number:  Closes #1035, Closes #701, IX-861

## 🆕 What is the new behavior?
- CSS Property applied
- Adjusted the wrapper of the template
-  Modal does not overflow anymore (test-case already created,  but does not emerge in stencil )
<!-- Please describe the behavior or changes that are being added by this PR. -->

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
