### PR TITLE
fix(core/menu): use label property to render internal menu items

### DIFF
--- a/.changeset/tame-shrimps-press.md
+++ b/.changeset/tame-shrimps-press.md
@@ -1,0 +1,5 @@
+---
+"@siemens/ix": patch
+---
+
+fix(core/menu): use label property to render internal menu items

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -681,9 +681,8 @@ export class Menu {
               }}
               icon={'cogwheel'}
               onClick={async () => this.toggleSettings(!this.showSettings)}
-            >
-              {this.i18nSettings}
-            </ix-menu-item>
+              label={this.i18nSettings}
+            ></ix-menu-item>
           ) : null}
           <div onClick={(e) => this.onMenuItemsClick(e)}>
             <slot name="bottom"></slot>
@@ -701,9 +700,8 @@ export class Menu {
               }}
               icon={'info'}
               onClick={async () => this.toggleAbout(!this.showAbout)}
-            >
-              {this.i18nLegal}
-            </ix-menu-item>
+              label={this.i18nLegal}
+            ></ix-menu-item>
           ) : null}
           {this.enableToggleTheme ? (
             <ix-menu-item
@@ -712,9 +710,8 @@ export class Menu {
               onClick={() => themeSwitcher.toggleMode()}
               class="internal-tab bottom-tab"
               icon={'light-dark'}
-            >
-              {this.i18nToggleTheme}
-            </ix-menu-item>
+              label={this.i18nToggleTheme}
+            ></ix-menu-item>
           ) : null}
           {this.enableMapExpand || this.applicationLayoutContext?.sidebar ? (
             <ix-menu-item
@@ -723,9 +720,8 @@ export class Menu {
               onClick={() => this.sidebarToggle()}
               class="internal-tab bottom-tab"
               icon={`${this.getCollapseIcon()}`}
-            >
-              {this.getCollapseText()}
-            </ix-menu-item>
+              label={this.getCollapseText()}
+            ></ix-menu-item>
           ) : null}
         </aside>
         <div


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 🆕 What is the new behavior?

Using slot for content results sometimes to empty tooltip within the menu, to avoid this use the label property.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [x] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
