### PR TITLE
fix(core/workflow-step): load icon names before component is initialized

### DIFF
--- a/.changeset/kind-maps-approve.md
+++ b/.changeset/kind-maps-approve.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix': patch
+---
+
+fix(core/workflow-step): load icon names before component is initialized

--- a/packages/core/component-doc.json
+++ b/packages/core/component-doc.json
@@ -13865,6 +13865,51 @@
       },
       "props": [
         {
+          "name": "closeBehavior",
+          "type": "\"both\" | \"inside\" | \"outside\" | boolean",
+          "complexType": {
+            "original": "CloseBehavior",
+            "resolved": "\"both\" | \"inside\" | \"outside\" | boolean",
+            "references": {
+              "CloseBehavior": {
+                "location": "import",
+                "path": "../dropdown/dropdown-controller",
+                "id": "src/components/dropdown/dropdown-controller.ts::CloseBehavior"
+              }
+            }
+          },
+          "mutable": false,
+          "attr": "close-behavior",
+          "reflectToAttr": false,
+          "docs": "Controls if the dropdown will be closed in response to a click event depending on the position of the event relative to the dropdown.",
+          "docsTags": [
+            {
+              "name": "since",
+              "text": "2.3.0"
+            }
+          ],
+          "default": "'both'",
+          "values": [
+            {
+              "value": "both",
+              "type": "string"
+            },
+            {
+              "value": "inside",
+              "type": "string"
+            },
+            {
+              "value": "outside",
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "optional": false,
+          "required": false
+        },
+        {
           "name": "disabled",
           "type": "boolean",
           "complexType": {
@@ -17678,6 +17723,11 @@
       "docstring": "",
       "path": "src/components/split-button/split-button.tsx"
     },
+    "src/components/dropdown/dropdown-controller.ts::CloseBehavior": {
+      "declaration": "export type CloseBehavior = 'inside' | 'outside' | 'both' | boolean;",
+      "docstring": "",
+      "path": "src/components/dropdown/dropdown-controller.ts"
+    },
     "src/components/tab-item/tab-item.tsx::TabClickDetail": {
       "declaration": "{\n  nativeEvent: MouseEvent;\n}",
       "docstring": "",
@@ -17727,11 +17777,6 @@
       "declaration": "any",
       "docstring": "",
       "path": "src/components/category-filter/input-state.ts"
-    },
-    "src/components/dropdown/dropdown-controller.ts::CloseBehavior": {
-      "declaration": "export type CloseBehavior = 'inside' | 'outside' | 'both' | boolean;",
-      "docstring": "",
-      "path": "src/components/dropdown/dropdown-controller.ts"
     },
     "src/components/flip-tile/flip-tile-state.ts::FlipTileState": {
       "declaration": "export enum FlipTileState {\n  None = 'none',\n  Info = 'info',\n  Warning = 'warning',\n  Alarm = 'alarm',\n  Primary = 'primary',\n}",

--- a/packages/core/src/components/workflow-step/workflow-step.tsx
+++ b/packages/core/src/components/workflow-step/workflow-step.tsx
@@ -121,7 +121,7 @@ export class WorkflowStep {
     }
   }
 
-  componentDidLoad() {
+  componentWillLoad() {
     this.watchPropHandler();
     this.selectedHandler();
 


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: closes #999, IX-882

## 🆕 What is the new behavior?

Set icon name before component is loaded first time. 

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [x] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
