### PR TITLE
fix(core/scrollbar): fix firefox appearance (scrollbar & input & tabs)

### DIFF
--- a/.changeset/great-files-tie.md
+++ b/.changeset/great-files-tie.md
@@ -1,0 +1,5 @@
+---
+"@siemens/ix": patch
+---
+
+fix(core/scrollbar): fix firefox appearance (scrollbar & input & tabs)

--- a/packages/core/scss/mixins/_scrollbar.scss
+++ b/packages/core/scss/mixins/_scrollbar.scss
@@ -11,6 +11,13 @@
     display: none;
   }
 
+  @-moz-document url-prefix() {
+    * {
+      scrollbar-color: var(--theme-scrollbar-thumb--background) var(--theme-scrollbar-track--background);
+      scrollbar-width: thin;
+    }
+  }
+
   /* width */
   ::-webkit-scrollbar {
     width: 0.5rem;

--- a/packages/core/src/components/menu/menu.scss
+++ b/packages/core/src/components/menu/menu.scss
@@ -35,11 +35,12 @@ $menu-expanded-width: 16rem;
 
     -ms-overflow-style: none;
 
-    scrollbar-width: inherit;
+    scrollbar-width: none;
 
     &::-webkit-scrollbar {
       display: none;
     }
+
   }
 
   .show-scrollbar {

--- a/packages/core/src/components/pagination/pagination.scss
+++ b/packages/core/src/components/pagination/pagination.scss
@@ -34,6 +34,8 @@
     width: 4.125rem;
     text-align: center;
     margin: 0 $small-space;
+    -moz-appearance: textfield;
+    -webkit-appearance: textfield;
   }
 
   .page-buttons {

--- a/packages/core/src/components/tab-item/tab-item.scss
+++ b/packages/core/src/components/tab-item/tab-item.scss
@@ -25,7 +25,7 @@
   background-color: var(--theme-tab--background);
   color: var(--theme-tab--color);
 
-  ::after {
+  &::after {
     content: '';
     position: absolute;
     background-color: var(--theme-tab-indicator--background);
@@ -110,7 +110,6 @@
       border-color: var(--theme-tab-pill--border-color--selected);
 
       &::after {
-        display: none;
       }
     }
 
@@ -119,7 +118,6 @@
     }
 
     &::after {
-      display: none;
     }
   }
 
@@ -133,13 +131,13 @@
 }
 
 :host(.top) {
-  ::after {
+  &::after {
     top: 0;
   }
 }
 
 :host(.bottom) {
-  ::after {
+  &::after {
     bottom: 0;
   }
 }
@@ -155,7 +153,7 @@
   color: var(--theme-tab-color-hover);
   cursor: pointer;
 
-  ::after {
+  &::after {
     background-color: var(--theme-tab-indicator--background--hover);
   }
 }
@@ -164,7 +162,7 @@
   background-color: var(--theme-tab--background--active);
   color: var(--theme-tab-color--active);
 
-  ::after {
+  &::after {
     background-color: var(--theme-tab-indicator--background--active);
   }
 }
@@ -186,7 +184,7 @@
   color: var(--theme-tab--color--disabled);
   background-color: var(--theme-tab--background--disabled);
 
-  ::after {
+  &::after {
     background-color: var(--theme-tab-indicator--background--disabled);
   }
 }
@@ -195,7 +193,7 @@
   background-color: var(--theme-tab--background--selected);
   color: var(--theme-tab--color--selected);
 
-  ::after {
+  &::after {
     background-color: var(--theme-tab-indicator--background--selected);
   }
 }

--- a/packages/core/src/components/tab-item/tab-item.scss
+++ b/packages/core/src/components/tab-item/tab-item.scss
@@ -108,16 +108,10 @@
 
     &.selected {
       border-color: var(--theme-tab-pill--border-color--selected);
-
-      &::after {
-      }
     }
 
     &.disabled {
       border-color: var(--theme-tab-pill--border-color--disabled);
-    }
-
-    &::after {
     }
   }
 


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?
- Input, spefically the pagination has the increment / decrement buttons shown
- Default Scrollbar applied in Firefox

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #N/A, [IX-1126], [IX-1127], [IX-1207]
Note: Viva Engage Firefox issue has also been adapted

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Increment / Decrement buttons are hidden
- Unfortunately Firefox does not offer that big of a support of scrollbar styling, so only available classes have been used (see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_scrollbars_styling)
- Note: There is a difference between the default Firefox Scrollbar in Windows 10 and Windows 11!
- No Tests, since we only test in Chrome

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
