### PR TITLE
feat(core): added hydrate output target

### DIFF
--- a/.changeset/olive-seas-type.md
+++ b/.changeset/olive-seas-type.md
@@ -1,0 +1,5 @@
+---
+"@siemens/ix": minor
+---
+
+feat(core): add hydrate output target

--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,7 @@ yarn-error.log*
 # Build output
 ##
 packages/core/components/
+packages/core/hydrate/
 packages/*/dist/
 packages/*/www/
 packages/*/loader/

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,8 @@
     "components/",
     "dist/",
     "loader/",
-    "scss/"
+    "scss/",
+    "hydrate/"
   ],
   "scripts": {
     "build": "stencil build --prod && npm run build:scss",

--- a/packages/core/stencil.config.ts
+++ b/packages/core/stencil.config.ts
@@ -155,6 +155,9 @@ export const config: Config = {
       serviceWorker: null,
       copy: copyAssets,
     },
+    {
+      type: 'dist-hydrate-script',
+    },
   ],
 };
 


### PR DESCRIPTION
## 💡 What is the current behavior?

Cannot use IX via SSR

## 🆕 What is the new behavior?

A new Hydration output is generated so that it can be used to hydrate the IX components on the server

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

- Please help with the changeset
- Should we add an extra doc information to the installation page regarding SSR?