### PR TITLE
fix(core/menu): fix firefox overflow behavior and input styling

### DIFF
--- a/.changeset/twenty-hornets-sort.md
+++ b/.changeset/twenty-hornets-sort.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix': patch
+---
+
+fix(core/menu): fix firefox overflow behavior and input styling

--- a/packages/core/scss/components/form/_input.scss
+++ b/packages/core/scss/components/form/_input.scss
@@ -17,6 +17,7 @@
     padding: 0.25rem 0.5rem;
     background-color: var(--theme-input--background);
     color: var(--theme-input--color);
+    -moz-appearance: textfield;
     text-overflow: ellipsis;
     border: var(--theme-input--border-thickness, 1px) solid
       var(--theme-input--border-color);

--- a/packages/core/src/components/menu-item/menu-item.scss
+++ b/packages/core/src/components/menu-item/menu-item.scss
@@ -48,9 +48,7 @@ $menuItemPadding: 0.875rem;
     outline-offset: -1px;
   }
 
-  .tab:not(:last-child) {
-    margin-bottom: $small-space;
-  }
+
 
   .notification {
     display: inline-flex;

--- a/packages/core/src/components/menu-item/menu-item.scss
+++ b/packages/core/src/components/menu-item/menu-item.scss
@@ -48,8 +48,6 @@ $menuItemPadding: 0.875rem;
     outline-offset: -1px;
   }
 
-
-
   .notification {
     display: inline-flex;
     position: absolute;

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -103,6 +103,7 @@ export class Menu {
    * Menu stays pinned to the left
    */
   @Prop() pinned = false;
+
   @Watch('pinned')
   pinnedChange(newPinned: boolean) {
     if (this.applicationLayoutContext?.host === 'map-navigation') {
@@ -522,6 +523,7 @@ export class Menu {
   @Listen('resize', { target: 'window' })
   private handleOverflowIndicator() {
     const { clientHeight, scrollTop, scrollHeight } = this.menuItemsContainer;
+
     this.itemsScrollShadowTop = scrollTop > 0;
     this.itemsScrollShadowBottom =
       Math.round(scrollTop + clientHeight) < scrollHeight;

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -523,7 +523,6 @@ export class Menu {
   @Listen('resize', { target: 'window' })
   private handleOverflowIndicator() {
     const { clientHeight, scrollTop, scrollHeight } = this.menuItemsContainer;
-
     this.itemsScrollShadowTop = scrollTop > 0;
     this.itemsScrollShadowBottom =
       Math.round(scrollTop + clientHeight) < scrollHeight;


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?
- The menu is always scrollable in FF
- The calculation to determine if scrolling is necessary, does not function correctly
- Default +/- buttons are visible at the input type=number
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #<ISSUE NUMBER>

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Menu is only scrollable on overflow
- Default +/- buttons are hidden

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
