### PR TITLE
Update fullscreen modal size to not result in scroll bars

### DIFF
--- a/packages/core/src/components/modal/modal.scss
+++ b/packages/core/src/components/modal/modal.scss
@@ -71,13 +71,13 @@
     top: 0 !important;
     transform: none !important;
 
-    width: calc(100% - 28px);
-    min-width: calc(100% - 28px);
-    max-width: calc(100% - 28px);
+    width: calc(100% - 2rem);
+    min-width: calc(100% - 2rem);
+    max-width: calc(100% - 2rem);
 
-    height: calc(100% - 28px);
-    min-height: calc(100% - 28px);
-    max-height: calc(100% - 28px);
+    height: calc(100% - 2rem);
+    min-height: calc(100% - 2rem);
+    max-height: calc(100% - 2rem);
   }
 
   .dialog-backdrop {


### PR DESCRIPTION

## 💡 What is the current behavior?

When using the full screen modal (in angular) i get scroll bars because the width and height are too big. This was due to the padding of 1rem that is set on the dialog. And the calc(100% - 28px) was not enough to counteract that. So setting it to 100% - 2rem for width and height fixed the issue for me.

GitHub Issue Number: -

## 🆕 What is the new behavior?

When opening a full screen modal in angular it now results in not having the scroll bars of the browser shown
-
-

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [x] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

I honestly didnt run pnpm docs, test etc. because it was just 4 lines of css that looked faulty