### PR TITLE
fix(core/pagination): disable buttons if count is unset

### DIFF
--- a/.changeset/soft-pens-reply.md
+++ b/.changeset/soft-pens-reply.md
@@ -1,0 +1,5 @@
+---
+"@siemens/ix": patch
+---
+
+fix(core/pagination): disable buttons if count is unset

--- a/packages/core/component-doc.json
+++ b/packages/core/component-doc.json
@@ -11752,6 +11752,7 @@
           "reflectToAttr": false,
           "docs": "Advanced mode",
           "docsTags": [],
+          "default": "false",
           "values": [
             {
               "type": "boolean"

--- a/packages/core/src/components/pagination/pagination.tsx
+++ b/packages/core/src/components/pagination/pagination.tsx
@@ -51,7 +51,7 @@ export class Pagination {
   /**
    * Advanced mode
    */
-  @Prop() advanced: boolean;
+  @Prop() advanced = false;
 
   /**
    * Number of items shown at once.
@@ -93,12 +93,12 @@ export class Pagination {
   /**
    * Page selection event
    */
-  @Event() pageSelected: EventEmitter<number>;
+  @Event() pageSelected!: EventEmitter<number>;
 
   /**
    * Item count change event
    */
-  @Event() itemCountChanged: EventEmitter<number>;
+  @Event() itemCountChanged!: EventEmitter<number>;
 
   private selectPage(index: number) {
     if (index < 0) {
@@ -211,7 +211,7 @@ export class Pagination {
     return (
       <Host>
         <ix-icon-button
-          disabled={this.selectedPage === 0}
+          disabled={!this.count || this.selectedPage === 0}
           ghost
           icon={'chevron-left-small'}
           onClick={() => this.decrease()}
@@ -242,7 +242,7 @@ export class Pagination {
         )}
 
         <ix-icon-button
-          disabled={this.selectedPage === this.count - 1}
+          disabled={!this.count || this.selectedPage === this.count - 1}
           ghost
           icon={'chevron-right-small'}
           onClick={() => this.increase()}


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #<ISSUE NUMBER>

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Arrow buttons get disabled if count is either 0 or undefined
-

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [x] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
