### PR TITLE
fix(core/tooltip): cancel tooltip positioning when reference is not visible

### DIFF
--- a/.changeset/ninety-ligers-invite.md
+++ b/.changeset/ninety-ligers-invite.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix': patch
+---
+
+fix(core/tooltip): fix performance issue

--- a/.changeset/ninety-ligers-invite.md
+++ b/.changeset/ninety-ligers-invite.md
@@ -2,4 +2,4 @@
 '@siemens/ix': patch
 ---
 
-fix(core/tooltip): fix performance issue
+fix(core/tooltip): cancel tooltip positioning when reference is not visible

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -273,7 +273,6 @@ export class Tooltip implements IxOverlayComponent {
       };
 
       const onMouseLeave = () => {
-        console.log(this.titleContent, 'Mouseleave!!!');
         this.hideTooltip();
       };
 

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -12,6 +12,7 @@ import {
   computePosition,
   ComputePositionReturn,
   flip,
+  hide,
   offset,
   shift,
 } from '@floating-ui/dom';
@@ -179,6 +180,7 @@ export class Tooltip implements IxOverlayComponent {
           fallbackStrategy: 'initialPlacement',
           padding: 10,
         }),
+        hide(),
       ],
     });
   }
@@ -201,6 +203,14 @@ export class Tooltip implements IxOverlayComponent {
         async () => {
           setTimeout(async () => {
             const computeResponse = await this.computeTooltipPosition(target);
+
+            const isHidden =
+              computeResponse.middlewareData.hide?.referenceHidden;
+
+            if (isHidden) {
+              setTimeout(() => this.hideTooltip());
+              resolve(computeResponse);
+            }
 
             if (computeResponse.middlewareData.arrow) {
               this.applyTooltipArrowPosition(computeResponse);
@@ -263,6 +273,7 @@ export class Tooltip implements IxOverlayComponent {
       };
 
       const onMouseLeave = () => {
+        console.log(this.titleContent, 'Mouseleave!!!');
         this.hideTooltip();
       };
 


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?
 - When the reference element is scrolled out of view, the change detection is nevertheless triggered, which leads to performance issues
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #N/A, [IX-1603]

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- on referenceHidden the tooltip gets hidden and the cleanup function is called

Findings:
- When window not in focus -> hover / mouse leave does not work (check scope of ticket? -> was this meant?)
- Strange behavior in combination with angular devtools -> influence performance?

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
