### PR TITLE
fix(core/tooltip): cutoff near viewport edges

### DIFF
--- a/packages/core/src/components/tooltip/tooltip.scss
+++ b/packages/core/src/components/tooltip/tooltip.scss
@@ -1,8 +1,8 @@
 :host {
   display: inline-block;
   position: fixed;
-  left: 0px;
-  top: 0px;
+  left: 0;
+  top: 0;
   z-index: var(--theme-z-index-tooltip);
 
   max-width: 18.25rem;
@@ -32,7 +32,7 @@
     padding: 0.375rem 0.75rem 0.375rem 0.875rem;
 
     box-shadow: var(--theme-shadow-4);
-
+    border-radius: inherit;
   }
 }
 

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -139,7 +139,6 @@ export class Tooltip implements IxOverlayComponent {
     if (placement.startsWith('top')) {
       return {
         left: numberToPixel(x),
-        top: numberToPixel(y),
       };
     }
 
@@ -177,6 +176,7 @@ export class Tooltip implements IxOverlayComponent {
         }),
         flip({
           fallbackStrategy: 'initialPlacement',
+          fallbackAxisSideDirection: 'start',
           padding: 10,
         }),
         hide(),


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?
- If a tooltip gets to near  to the view port  edge the tooltip will get cutoff
- It seems  that the PR from [IX-901] leads to an issue, where the border-radius will not get  adapted
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: Closes #740,  [IX-849]

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-  Tooltip will automatically gets placed (if there isn't enough space) in following order:  ['right', 'left', 'top', 'bottom']
- Border radius gets inherited

## Note
- computePosition also return  a  top property, when 'fallbackAxisSideDirection' is set, this result in missplacement of the arrow
- Potential source: 
<img width="96" alt="image" src="https://github.com/user-attachments/assets/e2017b12-c220-4f29-bd6d-476801b2c6f8">
As the postion is set during computing and the middlewareData is deepmerged, this can result in the unwanted  top  property -> As postion = 'top' doesn't need  the  property, it has been removed


## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
