### PR TITLE
fix(core/modal): fires 2 events on closing

### DIFF
--- a/.changeset/breezy-hotels-tap.md
+++ b/.changeset/breezy-hotels-tap.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix': patch
+---
+
+fix(core/modal): duplicate event firing

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -182,6 +182,10 @@ export class Modal {
    */
   @Method()
   async dismissModal<T = any>(reason?: T) {
+    if (!this.modalVisible) {
+      return;
+    }
+
     let allowDismiss = true;
 
     if (this.beforeDismiss !== undefined) {
@@ -213,7 +217,12 @@ export class Modal {
    */
   @Method()
   async closeModal<T = any>(reason: T) {
+    if (!this.modalVisible) {
+      return;
+    }
+
     this.slideOutModal(() => {
+      this.modalVisible = false;
       this.dialog.close(
         JSON.stringify(
           {
@@ -255,7 +264,12 @@ export class Modal {
               modal: true,
               [`modal-size-${this.size}`]: true,
             }}
+            onClose={() => this.dismissModal()}
             onClick={(event) => this.onModalClick(event)}
+            onCancel={(e) => {
+              e.preventDefault();
+              this.dismissModal();
+            }}
           >
             <slot></slot>
           </dialog>

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -255,12 +255,7 @@ export class Modal {
               modal: true,
               [`modal-size-${this.size}`]: true,
             }}
-            onClose={() => this.dismissModal()}
             onClick={(event) => this.onModalClick(event)}
-            onCancel={(e) => {
-              e.preventDefault();
-              this.dismissModal();
-            }}
           >
             <slot></slot>
           </dialog>

--- a/packages/core/src/components/modal/test/modal.ct.ts
+++ b/packages/core/src/components/modal/test/modal.ct.ts
@@ -150,7 +150,7 @@ test.describe('closeOnBackdropClick = true', () => {
   });
 });
 
-test('emits one event on dismiss', async ({ mount, page }) => {
+test('emits one event on close', async ({ mount, page }) => {
   await mount(``);
 
   await page.evaluate(() => {


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?
- modal closing fires 2 events
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: Closes #1149, [IX-985]

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- removed onClose / onDismiss on dialog as this triggers the closing methods again

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
