### PR TITLE
docs: add dropdown items to angular blind-header-actions example

### DIFF
--- a/packages/angular-test-app/src/preview-examples/blind-header-actions.ts
+++ b/packages/angular-test-app/src/preview-examples/blind-header-actions.ts
@@ -20,7 +20,6 @@ import { Component } from '@angular/core';
         icon="context-menu"
         icon-color="color-primary"
       ></ix-icon-button>
-      <ix-dropdown trigger="context-menu">test</ix-dropdown>
       Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
       eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
       voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet

--- a/packages/angular-test-app/src/preview-examples/blind-header-actions.ts
+++ b/packages/angular-test-app/src/preview-examples/blind-header-actions.ts
@@ -31,6 +31,10 @@ import { Component } from '@angular/core';
       Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor
       sit amet.
     </ix-blind>
+    <ix-dropdown trigger="context-menu">
+      <ix-dropdown-item icon="rename">Rename...</ix-dropdown-item>
+      <ix-dropdown-item icon="trashcan">Delete...</ix-dropdown-item>
+    </ix-dropdown>
   `,
   styleUrls: ['./blind-header-actions.css'],
 })


### PR DESCRIPTION
## 💡 What is the current behavior?

When viewing the [blind example](https://ix.siemens.io/docs/controls/blind), the dropdown options in the angular documentation are missing.



## 🆕 What is the new behavior?

Now the angular-test-app and therefore also the documentation is updated with dropdown options

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)
