### PR TITLE
fix: update selector in value-accessor for ix-number-input

### DIFF
--- a/.changeset/giant-melons-worry.md
+++ b/.changeset/giant-melons-worry.md
@@ -1,0 +1,5 @@
+---
+"@siemens/ix-angular": patch
+---
+
+update selector in value-accessor for ix-number-input

--- a/packages/angular/src/control-value-accessors/text-value-accessor.ts
+++ b/packages/angular/src/control-value-accessors/text-value-accessor.ts
@@ -11,7 +11,7 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ValueAccessor } from './value-accessor';
 
 @Directive({
-  selector: 'ix-input,ix-number-field,ix-textarea-field',
+  selector: 'ix-input,ix-number-input,ix-textarea-field',
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,


### PR DESCRIPTION

<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

the wrong selector was used. it was not possible to access any values via "formControlName" in case of ix-number-input. Reason: ix-number-field does not exist

## 🆕 What is the new behavior?

- Values from ix-number-input are accessiable via formControlName


## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
