### PR TITLE
docs: character limit for forms without displaying a counter

### DIFF
--- a/packages/documentation/docs/controls/forms/_forms-field_code.mdx
+++ b/packages/documentation/docs/controls/forms/_forms-field_code.mdx
@@ -30,7 +30,7 @@ To display a helper or feedback text below your component please refer to [valid
 
 ### Counter
 
-To display a counter on inputs or textareas, use the attribute `maxLength`.
+To display a counter on inputs or textareas, use the attribute `maxLength`. If you prefer not to display a counter, instead apply validation rules to set a character limit for the input.
 
 ```html
 <ix-input max-length="128"></ix-input>


### PR DESCRIPTION
## 💡 What is the current behavior?

Docu refers to using "maxLength" property to show a counter on input fields but does not say anything about setting a character limit without displaying a counter.

## 🆕 What is the new behavior?

Docu now refers to validation rules to set a character limit without displaying a counter.

