### PR TITLE
fix(core/message-bar): hide entire `ix-message-bar` and turn off user-interactions

### DIFF
--- a/.changeset/silly-pandas-peel.md
+++ b/.changeset/silly-pandas-peel.md
@@ -1,5 +1,0 @@
----
-'@siemens/ix': major
----
-
-Hide the entiner `ix-messsage-bar` and disable all user interactions with it

--- a/.changeset/silly-pandas-peel.md
+++ b/.changeset/silly-pandas-peel.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix': major
+---
+
+Hide the entiner `ix-messsage-bar` and disable all user interactions with it

--- a/packages/core/src/components/message-bar/message-bar.scss
+++ b/packages/core/src/components/message-bar/message-bar.scss
@@ -59,7 +59,7 @@
     margin-top: $tiny-space;
   }
 
-  .d-none {
+  .message-bar-hidden {
     display: none;
   }
 }

--- a/packages/core/src/components/message-bar/message-bar.scss
+++ b/packages/core/src/components/message-bar/message-bar.scss
@@ -58,4 +58,8 @@
   ix-icon {
     margin-top: $tiny-space;
   }
+
+  .d-none {
+    display: none;
+  }
 }

--- a/packages/core/src/components/message-bar/message-bar.tsx
+++ b/packages/core/src/components/message-bar/message-bar.tsx
@@ -80,7 +80,7 @@ export class MessageBar {
         opacity: [1, 0],
         easing: 'easeOutSine',
         complete: () => {
-          el.classList.add('d-none');
+          el.classList.add('message-bar-hidden');
           this.closeAnimationCompleted.emit();
         },
       });

--- a/packages/core/src/components/message-bar/test/message-bar.ct.ts
+++ b/packages/core/src/components/message-bar/test/message-bar.ct.ts
@@ -32,7 +32,7 @@ test.describe('ix-message-bar', () => {
     await expect(messageBar).not.toBeVisible();
   });
 
-  test('adds d-none class after dismissing', async ({ page }) => {
+  test('adds message-bar-hidden class after dismissing', async ({ page }) => {
     const messageBar = page.locator('ix-message-bar');
     const closeButton = messageBar.locator('[data-testid="close-btn"]');
 
@@ -40,6 +40,6 @@ test.describe('ix-message-bar', () => {
     await page.waitForTimeout(300);
 
     const messageContainer = messageBar.locator('.message-container');
-    await expect(messageContainer).toHaveClass(/d-none/);
+    await expect(messageContainer).toHaveClass(/message-bar-hidden/);
   });
 });

--- a/packages/core/src/components/message-bar/test/message-bar.ct.ts
+++ b/packages/core/src/components/message-bar/test/message-bar.ct.ts
@@ -1,3 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import { expect } from '@playwright/test';
 import { test } from '@utils/test';
 
@@ -12,18 +21,15 @@ test.describe('ix-message-bar', () => {
     const messageBar = page.locator('ix-message-bar');
     const closeButton = messageBar.locator('[data-testid="close-btn"]');
 
-    const [event] = await Promise.all([
-      messageBar.evaluate((element: HTMLElement) => {
-        return new Promise((resolve) => {
-          element.addEventListener('closeAnimationCompleted', (e) =>
-            resolve(e)
-          );
-        });
-      }),
-      closeButton.click(),
-    ]);
+    const onCloseAnimationCompleted = messageBar.evaluate((element) => {
+      return new Promise<void>((resolve) => {
+        element.addEventListener('closeAnimationCompleted', () => resolve());
+      });
+    });
+    await closeButton.click();
+    await onCloseAnimationCompleted;
 
-    expect(event).toBeTruthy();
+    await expect(messageBar).not.toBeVisible();
   });
 
   test('adds d-none class after dismissing', async ({ page }) => {

--- a/packages/core/src/components/message-bar/test/message-bar.ct.ts
+++ b/packages/core/src/components/message-bar/test/message-bar.ct.ts
@@ -1,0 +1,39 @@
+import { expect } from '@playwright/test';
+import { test } from '@utils/test';
+
+test.describe('ix-message-bar', () => {
+  test.beforeEach(async ({ mount }) => {
+    await mount(
+      `<ix-message-bar type="danger" dismissible>Content</ix-message-bar>`
+    );
+  });
+
+  test('emits closeAnimationCompleted event', async ({ page }) => {
+    const messageBar = page.locator('ix-message-bar');
+    const closeButton = messageBar.locator('[data-testid="close-btn"]');
+
+    const [event] = await Promise.all([
+      messageBar.evaluate((element: HTMLElement) => {
+        return new Promise((resolve) => {
+          element.addEventListener('closeAnimationCompleted', (e) =>
+            resolve(e)
+          );
+        });
+      }),
+      closeButton.click(),
+    ]);
+
+    expect(event).toBeTruthy();
+  });
+
+  test('adds d-none class after dismissing', async ({ page }) => {
+    const messageBar = page.locator('ix-message-bar');
+    const closeButton = messageBar.locator('[data-testid="close-btn"]');
+
+    await closeButton.click();
+    await page.waitForTimeout(300);
+
+    const messageContainer = messageBar.locator('.message-container');
+    await expect(messageContainer).toHaveClass(/d-none/);
+  });
+});

--- a/packages/core/src/components/message-bar/test/message-bar.ct.ts
+++ b/packages/core/src/components/message-bar/test/message-bar.ct.ts
@@ -31,15 +31,4 @@ test.describe('ix-message-bar', () => {
 
     await expect(messageBar).not.toBeVisible();
   });
-
-  test('adds message-bar-hidden class after dismissing', async ({ page }) => {
-    const messageBar = page.locator('ix-message-bar');
-    const closeButton = messageBar.locator('[data-testid="close-btn"]');
-
-    await closeButton.click();
-    await page.waitForTimeout(300);
-
-    const messageContainer = messageBar.locator('.message-container');
-    await expect(messageContainer).toHaveClass(/message-bar-hidden/);
-  });
 });


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?
- Examples of DOM removal already done in the last PR
- Button interactions still possible
- d-none applied but not implemented

GitHub Issue Number: Closes #1608, [IX-2201]

## 🆕 What is the new behavior?
- implemented d-none
- Buttons not reachable through mouse or keyboard interactions
- also NVDA screen reader was tried -> buttons are not interactable

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
