### PR TITLE
docs(ux-writing): copyright information of Siemens without `AG`

### DIFF
--- a/packages/documentation/docs/language/main-menu-functions.md
+++ b/packages/documentation/docs/language/main-menu-functions.md
@@ -136,7 +136,7 @@ import {Guideline} from '@site/src/components/Guideline';
 
 - Digital ID
 
-- © Siemens AG 20XX
+- © Siemens 20XX
 
 <span class="m-2">
 <Guideline do={false} label='V1'></Guideline>


### PR DESCRIPTION
## 💡 What is the current behavior?

Writing guide shows copyright of Siemens with `AG`

## 🆕 What is the new behavior?

The copyright info should be without AG.

