### PR TITLE
ci(renovate): run all tests for renovate prs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -83,7 +83,7 @@ jobs:
         run: pnpm build --cache-dir=.turbo --filter documentation
 
   visual-testing-core:
-    if: ${{ needs.changes.outputs.core_any_changed == 'true' }}
+    if: ${{ needs.changes.outputs.core_any_changed == 'true' || contains(github.event.label.name, 'renovate') }}
     needs: [build, changes]
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -136,7 +136,7 @@ jobs:
           retention-days: 14
 
   visual-testing-aggrid:
-    if: ${{ needs.changes.outputs.core_any_changed == 'true' || needs.changes.outputs.aggrid_any_changed == 'true' }}
+    if: ${{ needs.changes.outputs.core_any_changed == 'true' || needs.changes.outputs.aggrid_any_changed == 'true' || contains(github.event.label.name, 'renovate') }}
     needs: [build, changes]
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -159,7 +159,7 @@ jobs:
           retention-days: 1
 
   visual-testing-echarts:
-    if: ${{ needs.changes.outputs.core_any_changed == 'true' || needs.changes.outputs.echarts_any_changed == 'true' }}
+    if: ${{ needs.changes.outputs.core_any_changed == 'true' || needs.changes.outputs.echarts_any_changed == 'true' || contains(github.event.label.name, 'renovate') }}
     needs: [build, changes]
     timeout-minutes: 10
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 🆕 What is the new behavior?

This pr ensures that the complete test suite is executed whenever Renovate creates new pull requests. This change is necessary because the default workflow configuration is optimized to run tests only for the modified packages.
