### PR TITLE
fix(core): avoid initial validation of required boolean input types

### DIFF
--- a/.changeset/curly-berries-count.md
+++ b/.changeset/curly-berries-count.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix': patch
+---
+
+Prevent **ix-number-input** to get invalid if required with zero as value

--- a/.changeset/curly-berries-count.md
+++ b/.changeset/curly-berries-count.md
@@ -2,4 +2,4 @@
 '@siemens/ix': patch
 ---
 
-Prevent **ix-number-input** to get invalid if required with zero as value
+Prevent required **ix-number-input** from becoming invalid if value is zero

--- a/.changeset/old-wasps-vanish.md
+++ b/.changeset/old-wasps-vanish.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix': minor
+---
+
+Introduce `required` property for **ix-radio**. To make the **ix-radio-group** required at least one **ix-radio** must be `required`

--- a/.changeset/olive-ducks-applaud.md
+++ b/.changeset/olive-ducks-applaud.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix': patch
+---
+
+min-length of **ix-input** is now working as expected

--- a/.changeset/pretty-fans-reply.md
+++ b/.changeset/pretty-fans-reply.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix': patch
+---
+
+show `required` validation error only after first interaction (pointer/focus) with **ix-checkbox**, **ix-radio** and **ix-toggle**

--- a/.changeset/pretty-fans-reply.md
+++ b/.changeset/pretty-fans-reply.md
@@ -2,4 +2,4 @@
 '@siemens/ix': patch
 ---
 
-show `required` validation error only after first interaction (pointer/focus) with **ix-checkbox**, **ix-radio** and **ix-toggle**
+Show `required` validation error only after first interaction (pointer/focus) with **ix-checkbox**, **ix-radio** and **ix-toggle**

--- a/packages/angular/src/components.ts
+++ b/packages/angular/src/components.ts
@@ -1255,7 +1255,7 @@ export declare interface IxIconToggleButton extends Components.IxIconToggleButto
 
 @ProxyCmp({
   inputs: ['allowedCharactersPattern', 'disabled', 'helperText', 'infoText', 'invalidText', 'label', 'maxLength', 'minLength', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'showTextAsTooltip', 'type', 'validText', 'value', 'warningText'],
-  methods: ['getNativeInputElement', 'focusInput']
+  methods: ['getNativeInputElement', 'getValidityState', 'focusInput']
 })
 @Component({
   selector: 'ix-input',

--- a/packages/angular/src/components.ts
+++ b/packages/angular/src/components.ts
@@ -2154,7 +2154,7 @@ export declare interface IxRadio extends Components.IxRadio {
    */
   valueChange: EventEmitter<CustomEvent<string>>;
   /**
-   * Event emitted when the radio is focused
+   * Event emitted when the radio is blurred
    */
   ixBlur: EventEmitter<CustomEvent<void>>;
 }

--- a/packages/angular/src/components.ts
+++ b/packages/angular/src/components.ts
@@ -411,7 +411,7 @@ export class IxCheckbox {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['checkedChange', 'valueChange']);
+    proxyOutputs(this, this.el, ['checkedChange', 'valueChange', 'ixBlur']);
   }
 }
 
@@ -425,6 +425,10 @@ export declare interface IxCheckbox extends Components.IxCheckbox {
    * Event emitted when the value of the checkbox changes
    */
   valueChange: EventEmitter<CustomEvent<string>>;
+  /**
+   * Event emitted when the checkbox is blurred
+   */
+  ixBlur: EventEmitter<CustomEvent<void>>;
 }
 
 
@@ -1946,7 +1950,7 @@ Can be prevented, in which case only the event is triggered, and the modal remai
 
 
 @ProxyCmp({
-  inputs: ['allowedCharactersPattern', 'disabled', 'helperText', 'infoText', 'invalidText', 'label', 'max', 'min', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'showStepperButtons', 'showTextAsTooltip', 'validText', 'value', 'warningText'],
+  inputs: ['allowedCharactersPattern', 'disabled', 'helperText', 'infoText', 'invalidText', 'label', 'max', 'min', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'showStepperButtons', 'showTextAsTooltip', 'step', 'validText', 'value', 'warningText'],
   methods: ['getNativeInputElement', 'focusInput']
 })
 @Component({
@@ -1954,7 +1958,7 @@ Can be prevented, in which case only the event is triggered, and the modal remai
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['allowedCharactersPattern', 'disabled', 'helperText', 'infoText', 'invalidText', 'label', 'max', 'min', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'showStepperButtons', 'showTextAsTooltip', 'validText', 'value', 'warningText'],
+  inputs: ['allowedCharactersPattern', 'disabled', 'helperText', 'infoText', 'invalidText', 'label', 'max', 'min', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'showStepperButtons', 'showTextAsTooltip', 'step', 'validText', 'value', 'warningText'],
 })
 export class IxNumberInput {
   protected el: HTMLIxNumberInputElement;
@@ -2121,21 +2125,21 @@ export declare interface IxPushCard extends Components.IxPushCard {}
 
 
 @ProxyCmp({
-  inputs: ['checked', 'disabled', 'label', 'name', 'value']
+  inputs: ['checked', 'disabled', 'label', 'name', 'required', 'value']
 })
 @Component({
   selector: 'ix-radio',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['checked', 'disabled', 'label', 'name', 'value'],
+  inputs: ['checked', 'disabled', 'label', 'name', 'required', 'value'],
 })
 export class IxRadio {
   protected el: HTMLIxRadioElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['checkedChange', 'valueChange']);
+    proxyOutputs(this, this.el, ['checkedChange', 'valueChange', 'ixBlur']);
   }
 }
 
@@ -2149,6 +2153,10 @@ export declare interface IxRadio extends Components.IxRadio {
    * Event emitted when the value of the radio changes
    */
   valueChange: EventEmitter<CustomEvent<string>>;
+  /**
+   * Event emitted when the radio is focused
+   */
+  ixBlur: EventEmitter<CustomEvent<void>>;
 }
 
 
@@ -2562,7 +2570,7 @@ export class IxToggle {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['checkedChange']);
+    proxyOutputs(this, this.el, ['checkedChange', 'ixBlur']);
   }
 }
 
@@ -2572,6 +2580,10 @@ export declare interface IxToggle extends Components.IxToggle {
    * An event will be dispatched each time the slide-toggle changes its value.
    */
   checkedChange: EventEmitter<CustomEvent<boolean>>;
+  /**
+   * An event will be dispatched each time the toggle is blurred.
+   */
+  ixBlur: EventEmitter<CustomEvent<void>>;
 }
 
 

--- a/packages/angular/standalone/src/components.ts
+++ b/packages/angular/standalone/src/components.ts
@@ -2413,7 +2413,7 @@ export declare interface IxRadio extends Components.IxRadio {
    */
   valueChange: EventEmitter<CustomEvent<string>>;
   /**
-   * Event emitted when the radio is focused
+   * Event emitted when the radio is blurred
    */
   ixBlur: EventEmitter<CustomEvent<void>>;
 }

--- a/packages/angular/standalone/src/components.ts
+++ b/packages/angular/standalone/src/components.ts
@@ -544,7 +544,7 @@ export class IxCheckbox {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['checkedChange', 'valueChange']);
+    proxyOutputs(this, this.el, ['checkedChange', 'valueChange', 'ixBlur']);
   }
 }
 
@@ -558,6 +558,10 @@ export declare interface IxCheckbox extends Components.IxCheckbox {
    * Event emitted when the value of the checkbox changes
    */
   valueChange: EventEmitter<CustomEvent<string>>;
+  /**
+   * Event emitted when the checkbox is blurred
+   */
+  ixBlur: EventEmitter<CustomEvent<void>>;
 }
 
 
@@ -2192,7 +2196,7 @@ Can be prevented, in which case only the event is triggered, and the modal remai
 
 @ProxyCmp({
   defineCustomElementFn: defineIxNumberInput,
-  inputs: ['allowedCharactersPattern', 'disabled', 'helperText', 'infoText', 'invalidText', 'label', 'max', 'min', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'showStepperButtons', 'showTextAsTooltip', 'validText', 'value', 'warningText'],
+  inputs: ['allowedCharactersPattern', 'disabled', 'helperText', 'infoText', 'invalidText', 'label', 'max', 'min', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'showStepperButtons', 'showTextAsTooltip', 'step', 'validText', 'value', 'warningText'],
   methods: ['getNativeInputElement', 'focusInput']
 })
 @Component({
@@ -2200,7 +2204,7 @@ Can be prevented, in which case only the event is triggered, and the modal remai
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['allowedCharactersPattern', 'disabled', 'helperText', 'infoText', 'invalidText', 'label', 'max', 'min', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'showStepperButtons', 'showTextAsTooltip', 'validText', 'value', 'warningText'],
+  inputs: ['allowedCharactersPattern', 'disabled', 'helperText', 'infoText', 'invalidText', 'label', 'max', 'min', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'showStepperButtons', 'showTextAsTooltip', 'step', 'validText', 'value', 'warningText'],
   standalone: true
 })
 export class IxNumberInput {
@@ -2379,14 +2383,14 @@ export declare interface IxPushCard extends Components.IxPushCard {}
 
 @ProxyCmp({
   defineCustomElementFn: defineIxRadio,
-  inputs: ['checked', 'disabled', 'label', 'name', 'value']
+  inputs: ['checked', 'disabled', 'label', 'name', 'required', 'value']
 })
 @Component({
   selector: 'ix-radio',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['checked', 'disabled', 'label', 'name', 'value'],
+  inputs: ['checked', 'disabled', 'label', 'name', 'required', 'value'],
   standalone: true
 })
 export class IxRadio {
@@ -2394,7 +2398,7 @@ export class IxRadio {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['checkedChange', 'valueChange']);
+    proxyOutputs(this, this.el, ['checkedChange', 'valueChange', 'ixBlur']);
   }
 }
 
@@ -2408,6 +2412,10 @@ export declare interface IxRadio extends Components.IxRadio {
    * Event emitted when the value of the radio changes
    */
   valueChange: EventEmitter<CustomEvent<string>>;
+  /**
+   * Event emitted when the radio is focused
+   */
+  ixBlur: EventEmitter<CustomEvent<void>>;
 }
 
 
@@ -2851,7 +2859,7 @@ export class IxToggle {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['checkedChange']);
+    proxyOutputs(this, this.el, ['checkedChange', 'ixBlur']);
   }
 }
 
@@ -2861,6 +2869,10 @@ export declare interface IxToggle extends Components.IxToggle {
    * An event will be dispatched each time the slide-toggle changes its value.
    */
   checkedChange: EventEmitter<CustomEvent<boolean>>;
+  /**
+   * An event will be dispatched each time the toggle is blurred.
+   */
+  ixBlur: EventEmitter<CustomEvent<void>>;
 }
 
 

--- a/packages/angular/standalone/src/components.ts
+++ b/packages/angular/standalone/src/components.ts
@@ -1451,7 +1451,7 @@ export declare interface IxIconToggleButton extends Components.IxIconToggleButto
 @ProxyCmp({
   defineCustomElementFn: defineIxInput,
   inputs: ['allowedCharactersPattern', 'disabled', 'helperText', 'infoText', 'invalidText', 'label', 'maxLength', 'minLength', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'showTextAsTooltip', 'type', 'validText', 'value', 'warningText'],
-  methods: ['getNativeInputElement', 'focusInput']
+  methods: ['getNativeInputElement', 'getValidityState', 'focusInput']
 })
 @Component({
   selector: 'ix-input',

--- a/packages/core/component-doc.json
+++ b/packages/core/component-doc.json
@@ -16686,7 +16686,7 @@
           },
           "cancelable": true,
           "composed": true,
-          "docs": "Event emitted when the radio is focused",
+          "docs": "Event emitted when the radio is blurred",
           "docsTags": []
         },
         {

--- a/packages/core/component-doc.json
+++ b/packages/core/component-doc.json
@@ -2859,6 +2859,20 @@
           "docsTags": []
         },
         {
+          "event": "ixBlur",
+          "detail": "void",
+          "bubbles": true,
+          "complexType": {
+            "original": "void",
+            "resolved": "void",
+            "references": {}
+          },
+          "cancelable": true,
+          "composed": true,
+          "docs": "Event emitted when the checkbox is blurred",
+          "docsTags": []
+        },
+        {
           "event": "valueChange",
           "detail": "string",
           "bubbles": true,
@@ -15032,6 +15046,37 @@
           "setter": false
         },
         {
+          "name": "step",
+          "type": "number | string",
+          "complexType": {
+            "original": "string | number",
+            "resolved": "number | string",
+            "references": {}
+          },
+          "mutable": false,
+          "attr": "step",
+          "reflectToAttr": false,
+          "docs": "Step value to increment or decrement the input value",
+          "docsTags": [
+            {
+              "name": "since",
+              "text": "3.0.0"
+            }
+          ],
+          "values": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "optional": true,
+          "required": false,
+          "getter": false,
+          "setter": false
+        },
+        {
           "name": "validText",
           "type": "string",
           "complexType": {
@@ -16562,6 +16607,35 @@
           "setter": false
         },
         {
+          "name": "required",
+          "type": "boolean",
+          "complexType": {
+            "original": "boolean",
+            "resolved": "boolean",
+            "references": {}
+          },
+          "mutable": false,
+          "attr": "required",
+          "reflectToAttr": true,
+          "docs": "Requires the radio component and its group to be checked for the form to be submittable",
+          "docsTags": [
+            {
+              "name": "since",
+              "text": "3.0.0"
+            }
+          ],
+          "default": "false",
+          "values": [
+            {
+              "type": "boolean"
+            }
+          ],
+          "optional": false,
+          "required": false,
+          "getter": false,
+          "setter": false
+        },
+        {
           "name": "value",
           "type": "string",
           "complexType": {
@@ -16599,6 +16673,20 @@
           "cancelable": true,
           "composed": true,
           "docs": "Event emitted when the checked state of the radio changes",
+          "docsTags": []
+        },
+        {
+          "event": "ixBlur",
+          "detail": "void",
+          "bubbles": true,
+          "complexType": {
+            "original": "void",
+            "resolved": "void",
+            "references": {}
+          },
+          "cancelable": true,
+          "composed": true,
+          "docs": "Event emitted when the radio is focused",
           "docsTags": []
         },
         {
@@ -20845,6 +20933,20 @@
           "cancelable": true,
           "composed": true,
           "docs": "An event will be dispatched each time the slide-toggle changes its value.",
+          "docsTags": []
+        },
+        {
+          "event": "ixBlur",
+          "detail": "void",
+          "bubbles": true,
+          "complexType": {
+            "original": "void",
+            "resolved": "void",
+            "references": {}
+          },
+          "cancelable": true,
+          "composed": true,
+          "docs": "An event will be dispatched each time the toggle is blurred.",
           "docsTags": []
         }
       ],

--- a/packages/core/component-doc.json
+++ b/packages/core/component-doc.json
@@ -10775,6 +10775,32 @@
           "parameters": [],
           "docs": "Returns the native input element used in the text field.",
           "docsTags": []
+        },
+        {
+          "name": "getValidityState",
+          "returns": {
+            "type": "Promise<ValidityState>",
+            "docs": ""
+          },
+          "complexType": {
+            "signature": "() => Promise<ValidityState>",
+            "parameters": [],
+            "references": {
+              "Promise": {
+                "location": "global",
+                "id": "global::Promise"
+              },
+              "ValidityState": {
+                "location": "global",
+                "id": "global::ValidityState"
+              }
+            },
+            "return": "Promise<ValidityState>"
+          },
+          "signature": "getValidityState() => Promise<ValidityState>",
+          "parameters": [],
+          "docs": "Returns the validity state of the input field.",
+          "docsTags": []
         }
       ],
       "events": [

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -1561,6 +1561,10 @@ export namespace Components {
           * Returns the native input element used in the text field.
          */
         "getNativeInputElement": () => Promise<HTMLInputElement>;
+        /**
+          * Returns the validity state of the input field.
+         */
+        "getValidityState": () => Promise<ValidityState>;
         "hasValidValue": () => Promise<boolean>;
         /**
           * The helper text for the text field.

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -455,6 +455,7 @@ export namespace Components {
           * Indeterminate state of the checkbox component
          */
         "indeterminate": boolean;
+        "isTouched": () => Promise<boolean>;
         /**
           * Label for the checkbox component
          */
@@ -2179,6 +2180,11 @@ export namespace Components {
          */
         "showTextAsTooltip"?: boolean;
         /**
+          * Step value to increment or decrement the input value
+          * @since 3.0.0
+         */
+        "step"?: string | number;
+        /**
           * The valid text for the input field
          */
         "validText"?: string;
@@ -2382,6 +2388,11 @@ export namespace Components {
          */
         "name"?: string;
         /**
+          * Requires the radio component and its group to be checked for the form to be submittable
+          * @since 3.0.0
+         */
+        "required": boolean;
+        /**
           * Value of the radio component
          */
         "value"?: string;
@@ -2395,6 +2406,7 @@ export namespace Components {
           * Alignment of the radio buttons in the group
          */
         "direction": 'column' | 'row';
+        "hasValidValue": () => Promise<boolean>;
         /**
           * Show text below the field component
          */
@@ -2407,10 +2419,15 @@ export namespace Components {
           * Error text for the field component
          */
         "invalidText"?: string;
+        "isTouched": () => Promise<boolean>;
         /**
           * Label for the field component
          */
         "label"?: string;
+        /**
+          * Required state of the checkbox component
+         */
+        "required"?: boolean;
         /**
           * Show helper, info, warning, error and valid text as tooltip
          */
@@ -2936,6 +2953,7 @@ export namespace Components {
           * If true the control is in indeterminate state
          */
         "indeterminate": boolean;
+        "isTouched": () => Promise<boolean>;
         /**
           * Name of the checkbox component
          */
@@ -3654,6 +3672,7 @@ declare global {
     interface HTMLIxCheckboxElementEventMap {
         "checkedChange": boolean;
         "valueChange": string;
+        "ixBlur": void;
     }
     /**
      * @since 2.6.0
@@ -4587,6 +4606,7 @@ declare global {
     interface HTMLIxRadioElementEventMap {
         "checkedChange": boolean;
         "valueChange": string;
+        "ixBlur": void;
     }
     /**
      * @since 2.6.0
@@ -4826,6 +4846,7 @@ declare global {
     interface HTMLIxToggleElementEventMap {
         "checkedChange": boolean;
         "valueChange": string;
+        "ixBlur": void;
     }
     /**
      * @form-ready 2.6.0
@@ -5515,6 +5536,10 @@ declare namespace LocalJSX {
           * Event emitted when the checked state of the checkbox changes
          */
         "onCheckedChange"?: (event: IxCheckboxCustomEvent<boolean>) => void;
+        /**
+          * Event emitted when the checkbox is blurred
+         */
+        "onIxBlur"?: (event: IxCheckboxCustomEvent<void>) => void;
         /**
           * Event emitted when the value of the checkbox changes
          */
@@ -7344,6 +7369,11 @@ declare namespace LocalJSX {
          */
         "showTextAsTooltip"?: boolean;
         /**
+          * Step value to increment or decrement the input value
+          * @since 3.0.0
+         */
+        "step"?: string | number;
+        /**
           * The valid text for the input field
          */
         "validText"?: string;
@@ -7571,9 +7601,18 @@ declare namespace LocalJSX {
          */
         "onCheckedChange"?: (event: IxRadioCustomEvent<boolean>) => void;
         /**
+          * Event emitted when the radio is focused
+         */
+        "onIxBlur"?: (event: IxRadioCustomEvent<void>) => void;
+        /**
           * Event emitted when the value of the radio changes
          */
         "onValueChange"?: (event: IxRadioCustomEvent<string>) => void;
+        /**
+          * Requires the radio component and its group to be checked for the form to be submittable
+          * @since 3.0.0
+         */
+        "required"?: boolean;
         /**
           * Value of the radio component
          */
@@ -7608,6 +7647,10 @@ declare namespace LocalJSX {
           * Event emitted when the value of the radiobutton group changes
          */
         "onValueChange"?: (event: IxRadioGroupCustomEvent<string>) => void;
+        /**
+          * Required state of the checkbox component
+         */
+        "required"?: boolean;
         /**
           * Show helper, info, warning, error and valid text as tooltip
          */
@@ -8158,6 +8201,10 @@ declare namespace LocalJSX {
           * An event will be dispatched each time the slide-toggle changes its value.
          */
         "onCheckedChange"?: (event: IxToggleCustomEvent<boolean>) => void;
+        /**
+          * An event will be dispatched each time the toggle is blurred.
+         */
+        "onIxBlur"?: (event: IxToggleCustomEvent<void>) => void;
         "onValueChange"?: (event: IxToggleCustomEvent<string>) => void;
         /**
           * Required state of the checkbox component.  If true, checkbox needs to be checked to be valid

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -482,6 +482,7 @@ export namespace Components {
           * Alignment of the checkboxes in the group
          */
         "direction": 'row' | 'column';
+        "hasValidValue": () => Promise<boolean>;
         /**
           * Optional helper text displayed below the checkbox group
          */
@@ -494,10 +495,12 @@ export namespace Components {
           * Error text for the checkbox group
          */
         "invalidText"?: string;
+        "isTouched": () => Promise<boolean>;
         /**
           * Label for the checkbox group
          */
         "label"?: string;
+        "required": boolean;
         /**
           * Show helper, info, warning, error and valid text as tooltip
          */
@@ -5578,6 +5581,7 @@ declare namespace LocalJSX {
           * Label for the checkbox group
          */
         "label"?: string;
+        "required"?: boolean;
         /**
           * Show helper, info, warning, error and valid text as tooltip
          */

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -7605,7 +7605,7 @@ declare namespace LocalJSX {
          */
         "onCheckedChange"?: (event: IxRadioCustomEvent<boolean>) => void;
         /**
-          * Event emitted when the radio is focused
+          * Event emitted when the radio is blurred
          */
         "onIxBlur"?: (event: IxRadioCustomEvent<void>) => void;
         /**

--- a/packages/core/src/components/checkbox-group/test/checkbox-group.ct.ts
+++ b/packages/core/src/components/checkbox-group/test/checkbox-group.ct.ts
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { expect } from '@playwright/test';
+import { regressionTest } from '@utils/test';
+
+regressionTest('renders', async ({ mount, page }) => {
+  await mount(
+    `
+      <ix-checkbox-group>
+        <ix-checkbox label="Option 1" value="option1"></ix-checkbox>
+        <ix-checkbox label="Option 2" value="option2"></ix-checkbox>
+        <ix-checkbox label="Option 3" value="option3"></ix-checkbox>
+      </ix-checkbox-group>
+    `
+  );
+  const radioGroupElement = page.locator('ix-checkbox-group');
+  const radioOption1 = page.locator('ix-checkbox').nth(0);
+  const radioOption2 = page.locator('ix-checkbox').nth(1);
+  const radioOption3 = page.locator('ix-checkbox').nth(2);
+  await expect(radioGroupElement).toHaveClass(/hydrated/);
+  await expect(radioOption1).toHaveClass(/hydrated/);
+  await expect(radioOption2).toHaveClass(/hydrated/);
+  await expect(radioOption3).toHaveClass(/hydrated/);
+});
+
+regressionTest('required', async ({ mount, page }) => {
+  await mount(
+    `
+      <ix-checkbox-group label="example">
+        <ix-checkbox label="Option 1" value="option1"></ix-checkbox>
+        <ix-checkbox label="Option 2" value="option2" required></ix-checkbox>
+        <ix-checkbox label="Option 3" value="option3"></ix-checkbox>
+      </ix-checkbox-group>
+    `
+  );
+  const radioGroupElement = page.locator('ix-checkbox-group');
+  await expect(radioGroupElement).toHaveClass(/hydrated/);
+  await expect(radioGroupElement).toHaveText(/example\*/);
+
+  const radioOption2 = page.locator('ix-checkbox').nth(1);
+  const radioOption3 = page.locator('ix-checkbox').nth(2);
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Tab');
+
+  await expect(radioGroupElement).toHaveClass(/ix-invalid--required/);
+  await expect(radioOption2).toHaveClass(/ix-invalid--required/);
+  await expect(radioOption3).not.toHaveClass(/ix-invalid/);
+});

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -10,19 +10,19 @@
 import {
   AttachInternals,
   Component,
+  Element,
   Event,
   EventEmitter,
+  Fragment,
+  h,
   Host,
+  Method,
   Prop,
   Watch,
-  h,
-  Element,
-  Method,
-  Fragment,
 } from '@stencil/core';
+import { a11yBoolean } from '../utils/a11y';
 import { HookValidationLifecycle, IxFormComponent } from '../utils/input';
 import { makeRef } from '../utils/make-ref';
-import { a11yBoolean } from '../utils/a11y';
 
 /**
  * @since 2.6.0

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -86,6 +86,13 @@ export class Checkbox implements IxFormComponent<string> {
    */
   @Event() valueChange!: EventEmitter<string>;
 
+  /**
+   * Event emitted when the checkbox is blurred
+   */
+  @Event() ixBlur!: EventEmitter<void>;
+
+  private touched = false;
+
   private readonly inputRef = makeRef<HTMLInputElement>((checkboxRef) => {
     checkboxRef.checked = this.checked;
   });
@@ -97,6 +104,7 @@ export class Checkbox implements IxFormComponent<string> {
 
   @Watch('checked')
   onCheckedChange() {
+    this.touched = true;
     this.updateFormInternalValue();
   }
 
@@ -127,6 +135,12 @@ export class Checkbox implements IxFormComponent<string> {
   @Method()
   getAssociatedFormElement(): Promise<HTMLFormElement | null> {
     return Promise.resolve(this.formInternals.form);
+  }
+
+  /** @internal */
+  @Method()
+  isTouched(): Promise<boolean> {
+    return Promise.resolve(this.touched);
   }
 
   @HookValidationLifecycle()
@@ -178,10 +192,13 @@ export class Checkbox implements IxFormComponent<string> {
           checked: this.checked,
           indeterminate: this.indeterminate,
         }}
+        onFocus={() => (this.touched = true)}
+        onBlur={() => this.ixBlur.emit()}
       >
         <label>
           <input
             aria-checked={a11yBoolean(this.checked)}
+            required={this.required}
             disabled={this.disabled}
             checked={this.checked}
             ref={this.inputRef}

--- a/packages/core/src/components/input/input.fc.tsx
+++ b/packages/core/src/components/input/input.fc.tsx
@@ -10,26 +10,28 @@ import { h, FunctionalComponent } from '@stencil/core';
 import { MakeRef } from '../utils/make-ref';
 import { A11yAttributes } from '../utils/a11y';
 
-export function TextareaElement(props: {
-  resizeBehavior: 'both' | 'horizontal' | 'vertical' | 'none';
-  textareaHeight?: string;
-  textareaWidth?: string;
-  textareaRows?: number;
-  textareaCols?: number;
-  disabled: boolean;
-  readonly: boolean;
-  maxLength?: number;
-  minLength?: number;
-  isInvalid: boolean;
-  required: boolean;
-  value: string;
-  placeholder?: string;
-  textAreaRef: (el: HTMLTextAreaElement | undefined) => void;
-  valueChange: (value: string) => void;
-  updateFormInternalValue: (value: string) => void;
-  onBlur: () => void;
-  ariaAttributes?: A11yAttributes;
-}) {
+export function TextareaElement(
+  props: Readonly<{
+    resizeBehavior: 'both' | 'horizontal' | 'vertical' | 'none';
+    textareaHeight?: string;
+    textareaWidth?: string;
+    textareaRows?: number;
+    textareaCols?: number;
+    disabled: boolean;
+    readonly: boolean;
+    maxLength?: number;
+    minLength?: number;
+    isInvalid: boolean;
+    required: boolean;
+    value: string;
+    placeholder?: string;
+    textAreaRef: (el: HTMLTextAreaElement | undefined) => void;
+    valueChange: (value: string) => void;
+    updateFormInternalValue: (value: string) => void;
+    onBlur: () => void;
+    ariaAttributes?: A11yAttributes;
+  }>
+) {
   return (
     <textarea
       readOnly={props.readonly}
@@ -61,27 +63,29 @@ export function TextareaElement(props: {
   );
 }
 
-export function InputElement(props: {
-  id: string;
-  disabled: boolean;
-  readonly: boolean;
-  maxLength?: string | number;
-  minLength?: string | number;
-  max?: string | number;
-  min?: string | number;
-  pattern?: string;
-  type: string;
-  isInvalid: boolean;
-  required: boolean;
-  value: string | number;
-  placeholder?: string;
-  inputRef: (el: HTMLInputElement | undefined) => void;
-  onKeyPress: (event: KeyboardEvent) => void;
-  valueChange: (value: string) => void;
-  updateFormInternalValue: (value: string) => void;
-  onBlur: () => void;
-  ariaAttributes?: A11yAttributes;
-}) {
+export function InputElement(
+  props: Readonly<{
+    id: string;
+    disabled: boolean;
+    readonly: boolean;
+    maxLength?: string | number;
+    minLength?: string | number;
+    max?: string | number;
+    min?: string | number;
+    pattern?: string;
+    type: string;
+    isInvalid: boolean;
+    required: boolean;
+    value: string | number;
+    placeholder?: string;
+    inputRef: (el: HTMLInputElement | undefined) => void;
+    onKeyPress: (event: KeyboardEvent) => void;
+    valueChange: (value: string) => void;
+    updateFormInternalValue: (value: string) => void;
+    onBlur: () => void;
+    ariaAttributes?: A11yAttributes;
+  }>
+) {
   return (
     <input
       id={props.id}
@@ -91,7 +95,7 @@ export function InputElement(props: {
       min={props.min}
       max={props.max}
       maxLength={props.maxLength ? Number(props.maxLength) : undefined}
-      minLength={props.maxLength ? Number(props.minLength) : undefined}
+      minLength={props.minLength ? Number(props.minLength) : undefined}
       ref={props.inputRef}
       pattern={props.pattern}
       type={props.type}

--- a/packages/core/src/components/input/input.fc.tsx
+++ b/packages/core/src/components/input/input.fc.tsx
@@ -72,6 +72,7 @@ export function InputElement(
     minLength?: string | number;
     max?: string | number;
     min?: string | number;
+    step?: string | number;
     pattern?: string;
     type: string;
     isInvalid: boolean;
@@ -92,6 +93,7 @@ export function InputElement(
       autoComplete="off"
       readOnly={props.readonly}
       disabled={props.disabled}
+      step={props.step}
       min={props.min}
       max={props.max}
       maxLength={props.maxLength ? Number(props.maxLength) : undefined}

--- a/packages/core/src/components/input/input.tsx
+++ b/packages/core/src/components/input/input.tsx
@@ -239,6 +239,14 @@ export class Input implements IxInputFieldComponent<string> {
   }
 
   /**
+   * Returns the validity state of the input field.
+   */
+  @Method()
+  getValidityState(): Promise<ValidityState> {
+    return Promise.resolve(this.inputRef.current.validity);
+  }
+
+  /**
    * Focuses the input field
    */
   @Method()

--- a/packages/core/src/components/input/number-input.tsx
+++ b/packages/core/src/components/input/number-input.tsx
@@ -146,6 +146,13 @@ export class NumberInput implements IxInputFieldComponent<number> {
   @Prop() showStepperButtons?: boolean;
 
   /**
+   * Step value to increment or decrement the input value
+   *
+   * @since 3.0.0
+   */
+  @Prop() step?: string | number;
+
+  /**
    * Event emitted when the value of the input field changes
    */
   @Event() valueChange!: EventEmitter<number>;
@@ -294,6 +301,7 @@ export class NumberInput implements IxInputFieldComponent<number> {
               id={this.numberInputId}
               readonly={this.readonly}
               disabled={this.disabled}
+              step={this.step}
               min={this.min}
               max={this.max}
               pattern={this.pattern}
@@ -328,6 +336,7 @@ export class NumberInput implements IxInputFieldComponent<number> {
                   icon={iconMinus}
                   size="16"
                   class="number-stepper-button step-minus"
+                  aria-label="decrement number"
                   onClick={() => {
                     if (!this.inputRef.current) {
                       return;
@@ -345,6 +354,7 @@ export class NumberInput implements IxInputFieldComponent<number> {
                   icon={iconPlus}
                   size="16"
                   class="number-stepper-button step-plus"
+                  aria-label="increment number"
                   onClick={() => {
                     if (!this.inputRef.current) {
                       return;

--- a/packages/core/src/components/input/number-input.tsx
+++ b/packages/core/src/components/input/number-input.tsx
@@ -216,8 +216,15 @@ export class NumberInput implements IxInputFieldComponent<number> {
 
   /** @internal */
   @Method()
-  hasValidValue(): Promise<boolean> {
-    return Promise.resolve(!!this.value);
+  async hasValidValue(): Promise<boolean> {
+    const nativeInput = await this.getNativeInputElement();
+    if (nativeInput.value === '') {
+      return Promise.resolve(false);
+    }
+
+    return Promise.resolve(
+      this.value !== null && this.value !== undefined && !isNaN(this.value)
+    );
   }
 
   /**

--- a/packages/core/src/components/input/tests/validation.ct.ts
+++ b/packages/core/src/components/input/tests/validation.ct.ts
@@ -46,10 +46,11 @@ test.describe('validation', () => {
       mount,
       page,
     }) => {
-      await mount('<ix-number-input required value="0"></ix-number-input>');
+      await mount('<ix-number-input required></ix-number-input>');
 
       const ixInput = page.locator('ix-number-input');
       const shadowDomInput = ixInput.locator('input');
+
       await shadowDomInput.fill('0');
       await shadowDomInput.blur();
 
@@ -69,6 +70,24 @@ test.describe('validation', () => {
       await shadowDomInput.blur();
       await expect(ixInput).toHaveClass(/ix-invalid--required/);
     });
+
+    // Current component test not working inside playwright environment.
+    // Tested step feature manual or via storybook
+    test.fixme('increment by step', async ({ mount, page }) => {
+      await mount(
+        '<ix-number-input show-stepper-buttons step="3" value="5"></ix-number-input>'
+      );
+
+      const ixInput = page.locator('ix-number-input');
+      const shadowDomInput = ixInput.locator('input');
+      await expect(shadowDomInput).toHaveAttribute('step', '3');
+      await expect(ixInput).toHaveAttribute('value', '5');
+
+      const buttonPlus = ixInput.getByLabel('increment number');
+      await buttonPlus.click();
+
+      await expect(ixInput).toHaveAttribute('value', '8');
+    });
   });
 });
 
@@ -84,7 +103,7 @@ test.describe('prevent initial require validation', async () => {
     'ix-textarea',
   ].forEach((selector) => {
     test(selector, async ({ mount, page }) => {
-      await mount(`<${selector} required></${selector}>`);
+      await mount(`<${selector} required value=""></${selector}>`);
 
       const inputComponent = page.locator(selector);
       const input = inputComponent.locator(

--- a/packages/core/src/components/input/tests/validation.ct.ts
+++ b/packages/core/src/components/input/tests/validation.ct.ts
@@ -10,18 +10,65 @@ import { test } from '@utils/test';
 import { expect } from '@playwright/test';
 
 test.describe('validation', () => {
-  test('validation class should persist if provided by user', async ({
-    mount,
-    page,
-  }) => {
-    await mount('<ix-input class="ix-invalid"></ix-input>');
-    const input = page.locator('ix-input');
-    const shadowDomInput = input.locator('input');
+  test.describe('ix-input', () => {
+    test('validation class should persist if provided by user', async ({
+      mount,
+      page,
+    }) => {
+      await mount('<ix-input class="ix-invalid"></ix-input>');
+      const input = page.locator('ix-input');
+      const shadowDomInput = input.locator('input');
 
-    await shadowDomInput.fill('my example');
-    await shadowDomInput.blur();
+      await shadowDomInput.fill('my example');
+      await shadowDomInput.blur();
 
-    await expect(input).toHaveClass(/ix-invalid/);
+      await expect(input).toHaveClass(/ix-invalid/);
+    });
+
+    test('min-length validation should be triggered', async ({
+      mount,
+      page,
+    }) => {
+      await mount('<ix-input min-length="3" value="123"></ix-input>');
+
+      const input = page.locator('ix-input');
+      const shadowDomInput = input.locator('input');
+
+      await shadowDomInput.fill('12');
+      await shadowDomInput.blur();
+
+      await expect(input).toHaveClass(/ix-invalid/);
+    });
+  });
+
+  test.describe('ix-number-input', () => {
+    test('number input should be invalid if value is zero', async ({
+      mount,
+      page,
+    }) => {
+      await mount('<ix-number-input required value="0"></ix-number-input>');
+
+      const ixInput = page.locator('ix-number-input');
+      const shadowDomInput = ixInput.locator('input');
+      await shadowDomInput.fill('0');
+      await shadowDomInput.blur();
+
+      await expect(ixInput).not.toHaveClass(/ix-invalid--required/);
+    });
+
+    test('number input should be invalid if value is empty', async ({
+      mount,
+      page,
+    }) => {
+      await mount('<ix-number-input required></ix-number-input>');
+
+      const ixInput = page.locator('ix-number-input');
+      const shadowDomInput = ixInput.locator('input');
+
+      await shadowDomInput.fill('');
+      await shadowDomInput.blur();
+      await expect(ixInput).toHaveClass(/ix-invalid--required/);
+    });
   });
 });
 

--- a/packages/core/src/components/radio-group/radio-group.tsx
+++ b/packages/core/src/components/radio-group/radio-group.tsx
@@ -107,7 +107,7 @@ export class RadiobuttonGroup
 
   private readonly observer = new MutationObserver(() => {
     this.ensureOnlyLastRadioChecked();
-    this.checkRequiredOfRadioComponent();
+    this.hasNestedRequiredRadio();
   });
 
   private get radiobuttonElements() {
@@ -126,7 +126,7 @@ export class RadiobuttonGroup
   componentWillLoad(): void | Promise<void> {
     this.selectInitialValue();
     this.ensureOnlyLastRadioChecked();
-    this.checkRequiredOfRadioComponent();
+    this.hasNestedRequiredRadio();
   }
 
   disconnectedCallback(): void {
@@ -156,7 +156,7 @@ export class RadiobuttonGroup
     });
   }
 
-  private checkRequiredOfRadioComponent() {
+  private hasNestedRequiredRadio() {
     this.required = this.radiobuttonElements.some(
       (radiobutton) => radiobutton.required
     );

--- a/packages/core/src/components/radio-group/radio-group.tsx
+++ b/packages/core/src/components/radio-group/radio-group.tsx
@@ -103,7 +103,7 @@ export class RadiobuttonGroup
   @State() isWarning = false;
 
   private touched = false;
-  private readonly fakeRef = makeRef<HTMLIxRadioGroupElement>();
+  private readonly groupRef = makeRef<HTMLIxRadioGroupElement>();
 
   private readonly observer = new MutationObserver(() => {
     this.ensureOnlyLastRadioChecked();
@@ -216,7 +216,7 @@ export class RadiobuttonGroup
 
   render() {
     return (
-      <Host onIxBlur={() => (this.touched = true)} ref={this.fakeRef}>
+      <Host onIxBlur={() => (this.touched = true)} ref={this.groupRef}>
         <ix-field-wrapper
           label={this.label}
           helperText={this.helperText}
@@ -229,7 +229,7 @@ export class RadiobuttonGroup
           isInfo={this.isInfo}
           isWarning={this.isWarning}
           isInvalid={this.isInvalid}
-          controlRef={this.fakeRef}
+          controlRef={this.groupRef}
         >
           <div
             class={{

--- a/packages/core/src/components/radio-group/test/radio-group.ct.ts
+++ b/packages/core/src/components/radio-group/test/radio-group.ct.ts
@@ -29,6 +29,28 @@ regressionTest('renders', async ({ mount, page }) => {
   await expect(radioOption3).toHaveClass(/hydrated/);
 });
 
+regressionTest('required', async ({ mount, page }) => {
+  await mount(
+    `
+      <ix-radio-group label="example">
+        <ix-radio label="Option 1" value="option1"></ix-radio>
+        <ix-radio label="Option 2" value="option2" required></ix-radio>
+        <ix-radio label="Option 3" value="option3"></ix-radio>
+      </ix-radio-group>
+    `
+  );
+  const radioGroupElement = page.locator('ix-radio-group');
+  await expect(radioGroupElement).toHaveClass(/hydrated/);
+  await expect(radioGroupElement).toHaveText(/example\*/);
+
+  const radioOption1 = page.locator('ix-radio').nth(0);
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Tab');
+
+  await expect(radioGroupElement).toHaveClass(/ix-invalid--required/);
+  await expect(radioOption1).toHaveClass(/ix-invalid--required/);
+});
+
 regressionTest('initial checked', async ({ mount, page }) => {
   await mount(
     `

--- a/packages/core/src/components/radio/radio.tsx
+++ b/packages/core/src/components/radio/radio.tsx
@@ -84,7 +84,7 @@ export class Radio implements IxFormComponent<string> {
   @Event() valueChange!: EventEmitter<string>;
 
   /**
-   * Event emitted when the radio is focused
+   * Event emitted when the radio is blurred
    */
   @Event() ixBlur: EventEmitter<void>;
 

--- a/packages/core/src/components/radio/radio.tsx
+++ b/packages/core/src/components/radio/radio.tsx
@@ -120,8 +120,8 @@ export class Radio implements IxFormComponent<string> {
   }
 
   connectedCallback(): void {
-    const parent = this.hostElement.parentElement;
-    if (parent && parent.tagName.toLowerCase() === 'ix-radio-group') {
+    const parent = this.hostElement.closest('ix-radio-group');
+    if (parent) {
       this.classMutationObserver = createClassMutationObserver(parent, () => {
         this.hostElement.classList.toggle(
           'ix-invalid--required',

--- a/packages/core/src/components/radio/radio.tsx
+++ b/packages/core/src/components/radio/radio.tsx
@@ -20,7 +20,11 @@ import {
   Element,
 } from '@stencil/core';
 import { makeRef } from '../utils/make-ref';
-import { IxFormComponent } from '../utils/input';
+import {
+  ClassMutationObserver,
+  createClassMutationObserver,
+  IxFormComponent,
+} from '../utils/input';
 import { a11yBoolean } from '../utils/a11y';
 
 /**
@@ -63,6 +67,13 @@ export class Radio implements IxFormComponent<string> {
   @Prop({ reflect: true, mutable: true }) checked: boolean = false;
 
   /**
+   * Requires the radio component and its group to be checked for the form to be submittable
+   *
+   * @since 3.0.0
+   */
+  @Prop({ reflect: true }) required: boolean = false;
+
+  /**
    * Event emitted when the checked state of the radio changes
    */
   @Event() checkedChange!: EventEmitter<boolean>;
@@ -73,9 +84,11 @@ export class Radio implements IxFormComponent<string> {
   @Event() valueChange!: EventEmitter<string>;
 
   /**
-   * Single radio cannot be required
-   * */
-  required = false;
+   * Event emitted when the radio is focused
+   */
+  @Event() ixBlur: EventEmitter<void>;
+
+  private classMutationObserver?: ClassMutationObserver;
 
   private readonly inputRef = makeRef<HTMLInputElement>((radiobuttonRef) => {
     radiobuttonRef.checked = this.checked;
@@ -104,6 +117,24 @@ export class Radio implements IxFormComponent<string> {
   @Watch('value')
   onValueChange() {
     this.valueChange.emit(this.value);
+  }
+
+  connectedCallback(): void {
+    const parent = this.hostElement.parentElement;
+    if (parent && parent.tagName.toLowerCase() === 'ix-radio-group') {
+      this.classMutationObserver = createClassMutationObserver(parent, () => {
+        this.hostElement.classList.toggle(
+          'ix-invalid--required',
+          parent.classList.contains('ix-invalid--required')
+        );
+      });
+    }
+  }
+
+  disconnectedCallback(): void {
+    if (this.classMutationObserver) {
+      this.classMutationObserver.destroy();
+    }
   }
 
   componentWillLoad() {
@@ -140,12 +171,15 @@ export class Radio implements IxFormComponent<string> {
           disabled: this.disabled,
           checked: this.checked,
         }}
+        onBlur={() => this.ixBlur.emit()}
       >
         <label>
           <input
             aria-checked={a11yBoolean(this.checked)}
+            required={this.required}
             disabled={this.disabled}
             checked={this.checked}
+            name={this.name}
             ref={this.inputRef}
             type="radio"
             onChange={() => {

--- a/packages/core/src/components/toggle/toggle.tsx
+++ b/packages/core/src/components/toggle/toggle.tsx
@@ -20,7 +20,7 @@ import {
   Watch,
 } from '@stencil/core';
 import { a11yBoolean } from '../utils/a11y';
-import { IxFormComponent } from '../utils/input';
+import { IxFormComponent, HookValidationLifecycle } from '../utils/input';
 
 /**
  * @form-ready 2.6.0
@@ -96,6 +96,13 @@ export class Toggle implements IxFormComponent<string> {
   /** @internal */
   @Event() valueChange!: EventEmitter<string>;
 
+  /**
+   * An event will be dispatched each time the toggle is blurred.
+   */
+  @Event() ixBlur!: EventEmitter<void>;
+
+  private touched = false;
+
   onCheckedChange(newChecked: boolean) {
     if (this.disabled) {
       return;
@@ -132,6 +139,7 @@ export class Toggle implements IxFormComponent<string> {
 
   @Watch('checked')
   watchCheckedChange() {
+    this.touched = true;
     this.updateFormInternalValue();
   }
 
@@ -145,6 +153,17 @@ export class Toggle implements IxFormComponent<string> {
   @Method()
   getAssociatedFormElement(): Promise<HTMLFormElement | null> {
     return Promise.resolve(this.formInternals.form);
+  }
+
+  /** @internal */
+  @Method()
+  isTouched(): Promise<boolean> {
+    return Promise.resolve(this.touched);
+  }
+
+  @HookValidationLifecycle()
+  updateClassMappings() {
+    /** This function is intentionally empty */
   }
 
   render() {
@@ -162,6 +181,8 @@ export class Toggle implements IxFormComponent<string> {
         class={{
           disabled: this.disabled,
         }}
+        onBlur={() => this.ixBlur.emit()}
+        onFocus={() => (this.touched = true)}
       >
         <label class="wrapper">
           <button

--- a/packages/core/src/components/utils/input/index.ts
+++ b/packages/core/src/components/utils/input/index.ts
@@ -71,6 +71,8 @@ export interface IxFormComponent<T = string> extends IxComponent {
   disabled: boolean;
 
   valueChange: EventEmitter<T>;
+  ixBlur: EventEmitter<void>;
+
   updateFormInternalValue(value: T): void | Promise<void>;
   hasValidValue(): Promise<boolean>;
   getValidityState?(): Promise<ValidityState>;
@@ -86,8 +88,6 @@ export interface IxInputFieldComponent<T = string>
   placeholder?: string;
   // Annotate as @Prop()
   readonly: boolean;
-
-  ixBlur: EventEmitter<void>;
 
   // Annotate as @Method()
   getNativeInputElement(): Promise<HTMLInputElement | HTMLTextAreaElement>;

--- a/packages/core/src/components/utils/input/validation.ts
+++ b/packages/core/src/components/utils/input/validation.ts
@@ -120,6 +120,7 @@ export function HookValidationLifecycle(options?: {
         if (host.hasValidValue && typeof host.hasValidValue === 'function') {
           const hasValue = await host.hasValidValue();
           const touched = await isTouched(host);
+
           if (host.required) {
             host.classList.toggle('ix-invalid--required', !hasValue && touched);
           } else {
@@ -140,6 +141,7 @@ export function HookValidationLifecycle(options?: {
         }
       };
 
+      host.addEventListener('checkedChange', checkIfRequiredFunction);
       host.addEventListener('valueChange', checkIfRequiredFunction);
       host.addEventListener('ixBlur', checkIfRequiredFunction);
       setTimeout(checkIfRequiredFunction);
@@ -172,6 +174,7 @@ export function HookValidationLifecycle(options?: {
       }
 
       if (host && checkIfRequiredFunction) {
+        host.removeEventListener('checkedChange', checkIfRequiredFunction);
         host.removeEventListener('valueChange', checkIfRequiredFunction);
         host.removeEventListener('ixBlur', checkIfRequiredFunction);
         checkIfRequiredFunction = null;

--- a/packages/react/src/components.server.ts
+++ b/packages/react/src/components.server.ts
@@ -383,7 +383,8 @@ export const IxCheckboxGroup: StencilReactComponent<IxCheckboxGroupElement, IxCh
         infoText: 'info-text',
         validText: 'valid-text',
         warningText: 'warning-text',
-        showTextAsTooltip: 'show-text-as-tooltip'
+        showTextAsTooltip: 'show-text-as-tooltip',
+        required: 'required'
     },
     hydrateModule: import('@siemens/ix/hydrate'),
     serializeShadowRoot

--- a/packages/react/src/components.server.ts
+++ b/packages/react/src/components.server.ts
@@ -352,7 +352,8 @@ export const IxCategoryFilter: StencilReactComponent<IxCategoryFilterElement, Ix
 
 export type IxCheckboxEvents = {
     onCheckedChange: EventName<CustomEvent<boolean>>,
-    onValueChange: EventName<CustomEvent<string>>
+    onValueChange: EventName<CustomEvent<string>>,
+    onIxBlur: EventName<CustomEvent<void>>
 };
 
 export const IxCheckbox: StencilReactComponent<IxCheckboxElement, IxCheckboxEvents> = /*@__PURE__*/ createComponent<IxCheckboxElement, IxCheckboxEvents>({
@@ -1292,7 +1293,8 @@ export const IxNumberInput: StencilReactComponent<IxNumberInputElement, IxNumber
         min: 'min',
         max: 'max',
         allowedCharactersPattern: 'allowed-characters-pattern',
-        showStepperButtons: 'show-stepper-buttons'
+        showStepperButtons: 'show-stepper-buttons',
+        step: 'step'
     },
     hydrateModule: import('@siemens/ix/hydrate'),
     serializeShadowRoot
@@ -1391,7 +1393,8 @@ export const IxPushCard: StencilReactComponent<IxPushCardElement, IxPushCardEven
 
 export type IxRadioEvents = {
     onCheckedChange: EventName<CustomEvent<boolean>>,
-    onValueChange: EventName<CustomEvent<string>>
+    onValueChange: EventName<CustomEvent<string>>,
+    onIxBlur: EventName<CustomEvent<void>>
 };
 
 export const IxRadio: StencilReactComponent<IxRadioElement, IxRadioEvents> = /*@__PURE__*/ createComponent<IxRadioElement, IxRadioEvents>({
@@ -1401,7 +1404,8 @@ export const IxRadio: StencilReactComponent<IxRadioElement, IxRadioEvents> = /*@
         value: 'value',
         label: 'label',
         disabled: 'disabled',
-        checked: 'checked'
+        checked: 'checked',
+        required: 'required'
     },
     hydrateModule: import('@siemens/ix/hydrate'),
     serializeShadowRoot
@@ -1420,7 +1424,8 @@ export const IxRadioGroup: StencilReactComponent<IxRadioGroupElement, IxRadioGro
         warningText: 'warning-text',
         validText: 'valid-text',
         showTextAsTooltip: 'show-text-as-tooltip',
-        direction: 'direction'
+        direction: 'direction',
+        required: 'required'
     },
     hydrateModule: import('@siemens/ix/hydrate'),
     serializeShadowRoot
@@ -1665,7 +1670,10 @@ export const IxToastContainer: StencilReactComponent<IxToastContainerElement, Ix
     serializeShadowRoot
 });
 
-export type IxToggleEvents = { onCheckedChange: EventName<CustomEvent<boolean>> };
+export type IxToggleEvents = {
+    onCheckedChange: EventName<CustomEvent<boolean>>,
+    onIxBlur: EventName<CustomEvent<void>>
+};
 
 export const IxToggle: StencilReactComponent<IxToggleElement, IxToggleEvents> = /*@__PURE__*/ createComponent<IxToggleElement, IxToggleEvents>({
     tagName: 'ix-toggle',

--- a/packages/react/src/components.ts
+++ b/packages/react/src/components.ts
@@ -314,7 +314,8 @@ export const IxCategoryFilter: StencilReactComponent<IxCategoryFilterElement, Ix
 
 export type IxCheckboxEvents = {
     onCheckedChange: EventName<CustomEvent<boolean>>,
-    onValueChange: EventName<CustomEvent<string>>
+    onValueChange: EventName<CustomEvent<string>>,
+    onIxBlur: EventName<CustomEvent<void>>
 };
 
 export const IxCheckbox: StencilReactComponent<IxCheckboxElement, IxCheckboxEvents> = /*@__PURE__*/ createComponent<IxCheckboxElement, IxCheckboxEvents>({
@@ -324,7 +325,8 @@ export const IxCheckbox: StencilReactComponent<IxCheckboxElement, IxCheckboxEven
     react: React,
     events: {
         onCheckedChange: 'checkedChange',
-        onValueChange: 'valueChange'
+        onValueChange: 'valueChange',
+        onIxBlur: 'ixBlur'
     } as IxCheckboxEvents,
     defineCustomElement: defineIxCheckbox
 });
@@ -1127,7 +1129,8 @@ export const IxPushCard: StencilReactComponent<IxPushCardElement, IxPushCardEven
 
 export type IxRadioEvents = {
     onCheckedChange: EventName<CustomEvent<boolean>>,
-    onValueChange: EventName<CustomEvent<string>>
+    onValueChange: EventName<CustomEvent<string>>,
+    onIxBlur: EventName<CustomEvent<void>>
 };
 
 export const IxRadio: StencilReactComponent<IxRadioElement, IxRadioEvents> = /*@__PURE__*/ createComponent<IxRadioElement, IxRadioEvents>({
@@ -1137,7 +1140,8 @@ export const IxRadio: StencilReactComponent<IxRadioElement, IxRadioEvents> = /*@
     react: React,
     events: {
         onCheckedChange: 'checkedChange',
-        onValueChange: 'valueChange'
+        onValueChange: 'valueChange',
+        onIxBlur: 'ixBlur'
     } as IxRadioEvents,
     defineCustomElement: defineIxRadio
 });
@@ -1320,14 +1324,20 @@ export const IxToastContainer: StencilReactComponent<IxToastContainerElement, Ix
     defineCustomElement: defineIxToastContainer
 });
 
-export type IxToggleEvents = { onCheckedChange: EventName<CustomEvent<boolean>> };
+export type IxToggleEvents = {
+    onCheckedChange: EventName<CustomEvent<boolean>>,
+    onIxBlur: EventName<CustomEvent<void>>
+};
 
 export const IxToggle: StencilReactComponent<IxToggleElement, IxToggleEvents> = /*@__PURE__*/ createComponent<IxToggleElement, IxToggleEvents>({
     tagName: 'ix-toggle',
     elementClass: IxToggleElement,
     // @ts-ignore - React type of Stencil Output Target may differ from the React version used in the Nuxt.js project, this can be ignored.
     react: React,
-    events: { onCheckedChange: 'checkedChange' } as IxToggleEvents,
+    events: {
+        onCheckedChange: 'checkedChange',
+        onIxBlur: 'ixBlur'
+    } as IxToggleEvents,
     defineCustomElement: defineIxToggle
 });
 

--- a/packages/storybook-docs/src/stories/checkbox-group.stories.ts
+++ b/packages/storybook-docs/src/stories/checkbox-group.stories.ts
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+
+type Element = {
+  label: string;
+};
+
+const meta = {
+  title: 'Example/Checkbox/Group',
+  tags: [],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/r2nqdNNXXZtPmWuVjIlM1Q/iX-Components?node-id=42365-150769&p=f&t=eGUQESg89t8bPyiB-0',
+    },
+  },
+} satisfies Meta<Element>;
+
+export default meta;
+type Story = StoryObj<Element>;
+
+export const Required: Story = {
+  args: {
+    label: 'Required',
+  },
+  render: ({ label }) => html`<ix-checkbox-group label="${label}">
+    <ix-checkbox label="Option 1" value="option1"></ix-checkbox>
+    <ix-checkbox label="Option 2" value="option2" required></ix-checkbox>
+    <ix-checkbox label="Option 3" value="option3"></ix-checkbox>
+  </ix-checkbox-group>`,
+};

--- a/packages/storybook-docs/src/stories/checkbox.stories.ts
+++ b/packages/storybook-docs/src/stories/checkbox.stories.ts
@@ -98,3 +98,10 @@ export const Group: GroupStory = {
     label: 'Checkbox Group',
   },
 };
+
+export const Required: Story = {
+  args: {
+    label: 'Required',
+    required: true,
+  },
+};

--- a/packages/storybook-docs/src/stories/input-number.stories.ts
+++ b/packages/storybook-docs/src/stories/input-number.stories.ts
@@ -73,3 +73,11 @@ export const Required: Story = {
   },
 };
 
+export const Step: Story = {
+  args: {
+    label: 'Stepper',
+    showStepperButtons: true,
+    step: 3,
+    max: 10,
+  },
+};

--- a/packages/storybook-docs/src/stories/input-number.stories.ts
+++ b/packages/storybook-docs/src/stories/input-number.stories.ts
@@ -72,3 +72,4 @@ export const Required: Story = {
     label: 'Required',
   },
 };
+

--- a/packages/storybook-docs/src/stories/input.stories.ts
+++ b/packages/storybook-docs/src/stories/input.stories.ts
@@ -35,3 +35,12 @@ export const Required: Story = {
     required: true,
   },
 };
+
+export const MinLength: Story = {
+  args: {
+    label: 'MinLength',
+    minLength: 3,
+    maxLength: 5,
+    value: '1234567',
+  },
+};

--- a/packages/storybook-docs/src/stories/radio-group.stories.ts
+++ b/packages/storybook-docs/src/stories/radio-group.stories.ts
@@ -6,10 +6,10 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type { ArgTypes, Meta, StoryObj } from '@storybook/web-components';
 import type { Components } from '@siemens/ix/components';
-import { genericRender, makeArgTypes } from './utils/generic-render';
 import { action } from '@storybook/addon-actions';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { genericRender } from './utils/generic-render';
 
 type Element = Components.IxRadio & {
   defaultSlot: string;
@@ -32,10 +32,7 @@ const radioRender = (args: Element) => {
 };
 
 const radioGroupRender = (args: GroupElement) => {
-  const container = genericRender('ix-radio-group', args);
-  const radioGroup = container.querySelector(
-    'ix-radio-group'
-  ) as HTMLIxRadioGroupElement;
+  const radioGroup = document.createElement('ix-radio-group');
   radioGroup.setAttribute('label', args.label || 'Group');
 
   const radio1 = document.createElement('ix-radio');
@@ -51,20 +48,14 @@ const radioGroupRender = (args: GroupElement) => {
 
   radioGroup.appendChild(radio1);
   radioGroup.appendChild(radio2);
-  container.appendChild(radioGroup);
 
-  return container;
+  return radioGroup;
 };
 
 const meta = {
-  title: 'Example/Radio',
+  title: 'Example/Radio/Group',
   tags: [],
   render: (args) => radioRender(args),
-  argTypes: makeArgTypes<Partial<ArgTypes<Element>>>('ix-radio', {
-    validation: {
-      control: { type: 'select' },
-    },
-  }),
   parameters: {
     design: {
       type: 'figma',
@@ -74,20 +65,21 @@ const meta = {
 } satisfies Meta<Element>;
 
 export default meta;
-type Story = StoryObj<Element>;
+type Story = StoryObj<GroupElement>;
 
-// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
 export const Default: Story = {
+  render: (args) => radioGroupRender(args),
   args: {
-    disabled: false,
-    label: 'Radio',
-    required: true,
+    label: 'Radio Group',
   },
+  argTypes: {},
 };
 
-export const Disabled: Story = {
+export const Required: Story = {
+  render: (args) => radioGroupRender(args),
   args: {
-    disabled: true,
-    label: 'Radio',
+    label: 'Radio Group',
+    required: true,
   },
+  argTypes: {},
 };

--- a/packages/storybook-docs/src/stories/toggle.stories.ts
+++ b/packages/storybook-docs/src/stories/toggle.stories.ts
@@ -102,3 +102,9 @@ export const Overflow: Story = {
     return container;
   },
 };
+
+export const Required: Story = {
+  args: {
+    required: true,
+  },
+};

--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -275,7 +275,8 @@ export const IxCheckboxGroup = /*@__PURE__*/ defineContainer<JSX.IxCheckboxGroup
   'infoText',
   'validText',
   'warningText',
-  'showTextAsTooltip'
+  'showTextAsTooltip',
+  'required'
 ]);
 
 

--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -261,7 +261,8 @@ export const IxCheckbox = /*@__PURE__*/ defineContainer<JSX.IxCheckbox, JSX.IxCh
   'indeterminate',
   'required',
   'checkedChange',
-  'valueChange'
+  'valueChange',
+  'ixBlur'
 ],
 'checked', 'checkedChange');
 
@@ -867,6 +868,7 @@ export const IxNumberInput = /*@__PURE__*/ defineContainer<JSX.IxNumberInput, JS
   'max',
   'allowedCharactersPattern',
   'showStepperButtons',
+  'step',
   'valueChange',
   'validityStateChange',
   'ixBlur'
@@ -941,8 +943,10 @@ export const IxRadio = /*@__PURE__*/ defineContainer<JSX.IxRadio>('ix-radio', de
   'label',
   'disabled',
   'checked',
+  'required',
   'checkedChange',
-  'valueChange'
+  'valueChange',
+  'ixBlur'
 ]);
 
 
@@ -956,6 +960,7 @@ export const IxRadioGroup = /*@__PURE__*/ defineContainer<JSX.IxRadioGroup>('ix-
   'validText',
   'showTextAsTooltip',
   'direction',
+  'required',
   'valueChange'
 ]);
 
@@ -1140,7 +1145,8 @@ export const IxToggle = /*@__PURE__*/ defineContainer<JSX.IxToggle>('ix-toggle',
   'hideText',
   'required',
   'checkedChange',
-  'valueChange'
+  'valueChange',
+  'ixBlur'
 ]);
 
 


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: Fixes #1801 

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Avoid initial validation of required boolean components (ix-radio, ix-checkbox, ix-toggle)
- Handle group validation of radio and checkbox
- Show required indicator (*) for ix-radio-group and ix-checkbox-group

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
