### PR TITLE
chore(core): remove all since annotation for v1 and v2

### DIFF
--- a/packages/angular/src/components.ts
+++ b/packages/angular/src/components.ts
@@ -73,11 +73,11 @@ export class IxApplicationHeader {
 
 export declare interface IxApplicationHeader extends Components.IxApplicationHeader {
   /**
-   * Event emitted when the menu toggle button is clicked @since 2.5.0
+   * Event emitted when the menu toggle button is clicked
    */
   menuToggle: EventEmitter<CustomEvent<boolean>>;
   /**
-   * Event emitted when the app switch button is clicked @since 3.0.0
+   * Event emitted when the app switch button is clicked
    */
   openAppSwitch: EventEmitter<CustomEvent<void>>;
 }
@@ -472,7 +472,7 @@ export class IxChip {
 
 export declare interface IxChip extends Components.IxChip {
   /**
-   * Fire event if close button is clicked @since 1.5.0
+   * Fire event if close button is clicked
    */
   closeChip: EventEmitter<CustomEvent<any>>;
 }
@@ -666,16 +666,16 @@ import type { DateChangeEvent as IIxDatePickerDateChangeEvent } from '@siemens/i
 export declare interface IxDatePicker extends Components.IxDatePicker {
   /**
    * Triggers if the date selection changes.
-Note: Since 2.0.0 `dateChange` does not dispatch detail property as `string` @since 2.1.0
+Note: Since 2.0.0 `dateChange` does not dispatch detail property as `string`
    */
   dateChange: EventEmitter<CustomEvent<IIxDatePickerDateChangeEvent>>;
   /**
    * Triggers if the date selection changes.
-Only triggered if date-picker-rework is in range mode. @since 2.1.0
+Only triggered if date-picker-rework is in range mode.
    */
   dateRangeChange: EventEmitter<CustomEvent<IIxDatePickerDateChangeEvent>>;
   /**
-   * Date selection confirmed via button action @since 1.1.0
+   * Date selection confirmed via button action
    */
   dateSelect: EventEmitter<CustomEvent<IIxDatePickerDateChangeEvent>>;
 }
@@ -706,16 +706,15 @@ import type { DateTimeSelectEvent as IIxDatetimePickerDateTimeSelectEvent } from
 
 export declare interface IxDatetimePicker extends Components.IxDatetimePicker {
   /**
-   * 
-Time change @since 1.1.0
+   * Time change
    */
   timeChange: EventEmitter<CustomEvent<string>>;
   /**
-   * Date change @since 1.1.0
+   * Date change
    */
   dateChange: EventEmitter<CustomEvent<IIxDatetimePickerDateTimeDateChangeEvent>>;
   /**
-   * Datetime selection event is fired after confirm button is pressed @since 1.1.0
+   * Datetime selection event is fired after confirm button is pressed
    */
   dateSelect: EventEmitter<CustomEvent<IIxDatetimePickerDateTimeSelectEvent>>;
 }
@@ -2224,11 +2223,11 @@ export class IxSelect {
 
 export declare interface IxSelect extends Components.IxSelect {
   /**
-   * Value changed @since 2.0.0
+   * Value changed
    */
   valueChange: EventEmitter<CustomEvent<string | string[]>>;
   /**
-   * Event dispatched whenever the text input changes. @since 2.0.0
+   * Event dispatched whenever the text input changes.
    */
   inputChange: EventEmitter<CustomEvent<string>>;
   /**
@@ -2370,7 +2369,7 @@ import type { TabClickDetail as IIxTabItemTabClickDetail } from '@siemens/ix';
 
 export declare interface IxTabItem extends Components.IxTabItem {
   /**
-   * Emitted when the tab is clicked. @since 2.0.0
+   * Emitted when the tab is clicked.
    */
   tabClick: EventEmitter<CustomEvent<IIxTabItemTabClickDetail>>;
 }
@@ -2398,7 +2397,7 @@ export class IxTabs {
 
 export declare interface IxTabs extends Components.IxTabs {
   /**
-   * `selected` property changed @since 2.0.0
+   * `selected` property changed
    */
   selectedChange: EventEmitter<CustomEvent<number>>;
 }

--- a/packages/angular/standalone/src/components.ts
+++ b/packages/angular/standalone/src/components.ts
@@ -180,11 +180,11 @@ export class IxApplicationHeader {
 
 export declare interface IxApplicationHeader extends Components.IxApplicationHeader {
   /**
-   * Event emitted when the menu toggle button is clicked @since 2.5.0
+   * Event emitted when the menu toggle button is clicked
    */
   menuToggle: EventEmitter<CustomEvent<boolean>>;
   /**
-   * Event emitted when the app switch button is clicked @since 3.0.0
+   * Event emitted when the app switch button is clicked
    */
   openAppSwitch: EventEmitter<CustomEvent<void>>;
 }
@@ -609,7 +609,7 @@ export class IxChip {
 
 export declare interface IxChip extends Components.IxChip {
   /**
-   * Fire event if close button is clicked @since 1.5.0
+   * Fire event if close button is clicked
    */
   closeChip: EventEmitter<CustomEvent<any>>;
 }
@@ -817,16 +817,16 @@ import type { DateChangeEvent as IIxDatePickerDateChangeEvent } from '@siemens/i
 export declare interface IxDatePicker extends Components.IxDatePicker {
   /**
    * Triggers if the date selection changes.
-Note: Since 2.0.0 `dateChange` does not dispatch detail property as `string` @since 2.1.0
+Note: Since 2.0.0 `dateChange` does not dispatch detail property as `string`
    */
   dateChange: EventEmitter<CustomEvent<IIxDatePickerDateChangeEvent>>;
   /**
    * Triggers if the date selection changes.
-Only triggered if date-picker-rework is in range mode. @since 2.1.0
+Only triggered if date-picker-rework is in range mode.
    */
   dateRangeChange: EventEmitter<CustomEvent<IIxDatePickerDateChangeEvent>>;
   /**
-   * Date selection confirmed via button action @since 1.1.0
+   * Date selection confirmed via button action
    */
   dateSelect: EventEmitter<CustomEvent<IIxDatePickerDateChangeEvent>>;
 }
@@ -859,16 +859,15 @@ import type { DateTimeSelectEvent as IIxDatetimePickerDateTimeSelectEvent } from
 
 export declare interface IxDatetimePicker extends Components.IxDatetimePicker {
   /**
-   * 
-Time change @since 1.1.0
+   * Time change
    */
   timeChange: EventEmitter<CustomEvent<string>>;
   /**
-   * Date change @since 1.1.0
+   * Date change
    */
   dateChange: EventEmitter<CustomEvent<IIxDatetimePickerDateTimeDateChangeEvent>>;
   /**
-   * Datetime selection event is fired after confirm button is pressed @since 1.1.0
+   * Datetime selection event is fired after confirm button is pressed
    */
   dateSelect: EventEmitter<CustomEvent<IIxDatetimePickerDateTimeSelectEvent>>;
 }
@@ -2489,11 +2488,11 @@ export class IxSelect {
 
 export declare interface IxSelect extends Components.IxSelect {
   /**
-   * Value changed @since 2.0.0
+   * Value changed
    */
   valueChange: EventEmitter<CustomEvent<string | string[]>>;
   /**
-   * Event dispatched whenever the text input changes. @since 2.0.0
+   * Event dispatched whenever the text input changes.
    */
   inputChange: EventEmitter<CustomEvent<string>>;
   /**
@@ -2645,7 +2644,7 @@ import type { TabClickDetail as IIxTabItemTabClickDetail } from '@siemens/ix/com
 
 export declare interface IxTabItem extends Components.IxTabItem {
   /**
-   * Emitted when the tab is clicked. @since 2.0.0
+   * Emitted when the tab is clicked.
    */
   tabClick: EventEmitter<CustomEvent<IIxTabItemTabClickDetail>>;
 }
@@ -2675,7 +2674,7 @@ export class IxTabs {
 
 export declare interface IxTabs extends Components.IxTabs {
   /**
-   * `selected` property changed @since 2.0.0
+   * `selected` property changed
    */
   selectedChange: EventEmitter<CustomEvent<number>>;
 }

--- a/packages/core/component-doc.json
+++ b/packages/core/component-doc.json
@@ -16,12 +16,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "1.6.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [
@@ -212,12 +207,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.1.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [],
@@ -484,12 +474,7 @@
           "attr": "show-menu",
           "reflectToAttr": false,
           "docs": "Controls the visibility of the menu toggle button based on the context of the application header.\n\nWhen the application header is utilized outside the application frame, the menu toggle button is displayed.\nConversely, if the header is within the application frame, this property is ineffective.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.5.0"
-            }
-          ],
+          "docsTags": [],
           "default": "false",
           "values": [
             {
@@ -516,12 +501,7 @@
           "cancelable": true,
           "composed": true,
           "docs": "Event emitted when the menu toggle button is clicked",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.5.0"
-            }
-          ]
+          "docsTags": []
         },
         {
           "event": "openAppSwitch",
@@ -535,12 +515,7 @@
           "cancelable": true,
           "composed": true,
           "docs": "Event emitted when the app switch button is clicked",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "3.0.0"
-            }
-          ]
+          "docsTags": []
         }
       ],
       "styles": [],
@@ -563,12 +538,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.0.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [
         "ix-menu-avatar"
@@ -603,12 +573,7 @@
           "attr": "extra",
           "reflectToAttr": false,
           "docs": "Optional description text that will be displayed underneath the username.\nNote: Only working if avatar is part of the ix-application-header",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.1.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -677,12 +642,7 @@
           "attr": "username",
           "reflectToAttr": false,
           "docs": "If set an info card displaying the username will be placed inside the dropdown.\nNote: Only working if avatar is part of the ix-application-header",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.1.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -929,12 +889,7 @@
           "attr": "icon",
           "reflectToAttr": false,
           "docs": "Optional icon to be displayed next to the header label",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.5.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -980,12 +935,7 @@
           "attr": "sublabel",
           "reflectToAttr": false,
           "docs": "Secondary label inside blind header",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.0.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -1014,12 +964,7 @@
           "attr": "variant",
           "reflectToAttr": false,
           "docs": "Blind variant",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.0.0"
-            }
-          ],
+          "docsTags": [],
           "default": "'filled'",
           "values": [
             {
@@ -1128,12 +1073,7 @@
           "attr": "aria-label-previous-button",
           "reflectToAttr": false,
           "docs": "Accessibility label for the dropdown button (ellipsis icon) used to access the dropdown list\nwith conditionally hidden previous items",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.0.0"
-            }
-          ],
+          "docsTags": [],
           "default": "'previous'",
           "values": [
             {
@@ -1486,12 +1426,7 @@
           "attr": "loading",
           "reflectToAttr": false,
           "docs": "Loading button",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.0.0"
-            }
-          ],
+          "docsTags": [],
           "default": "false",
           "values": [
             {
@@ -1574,12 +1509,7 @@
           "attr": "variant",
           "reflectToAttr": false,
           "docs": "Button variant",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.3.0 - variant danger"
-            }
-          ],
+          "docsTags": [],
           "default": "'primary'",
           "values": [
             {
@@ -1624,12 +1554,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "1.6.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [
         "ix-action-card",
@@ -1660,13 +1585,8 @@
           "mutable": false,
           "attr": "selected",
           "reflectToAttr": false,
-          "docs": "",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.1.0"
-            }
-          ],
+          "docs": "Show card in selected state",
+          "docsTags": [],
           "default": "false",
           "values": [
             {
@@ -1759,12 +1679,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "1.6.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [
         "ix-push-card"
@@ -1788,12 +1703,7 @@
           "attr": "collapse",
           "reflectToAttr": false,
           "docs": "Collapse the card",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.1.0"
-            }
-          ],
+          "docsTags": [],
           "default": "false",
           "values": [
             {
@@ -1823,12 +1733,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "1.6.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [
         "ix-action-card",
@@ -1865,12 +1770,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "1.6.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [
@@ -1932,12 +1832,7 @@
           "attr": "hide-show-all",
           "reflectToAttr": false,
           "docs": "Hide the show all button",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.2.0"
-            }
-          ],
+          "docsTags": [],
           "default": "false",
           "values": [
             {
@@ -2178,10 +2073,6 @@
         {
           "name": "slot",
           "text": "title-actions - Place additional actions inside title"
-        },
-        {
-          "name": "since",
-          "text": "1.6.0"
         }
       ],
       "encapsulation": "shadow",
@@ -2525,12 +2416,7 @@
           "attr": "static-operator",
           "reflectToAttr": false,
           "docs": "If set categories will always be filtered via the respective logical operator.\nToggling of the operator will not be available to the user.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.2.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "LogicalFilterOperator.EQUAL"
@@ -2655,10 +2541,6 @@
       "usage": {},
       "docs": "",
       "docsTags": [
-        {
-          "name": "since",
-          "text": "2.6.0"
-        },
         {
           "name": "form-ready",
           "text": "2.6.0"
@@ -2889,10 +2771,6 @@
       "usage": {},
       "docs": "",
       "docsTags": [
-        {
-          "name": "since",
-          "text": "2.6.0"
-        },
         {
           "name": "form-ready",
           "text": "2.6.0"
@@ -3390,12 +3268,7 @@
           "cancelable": true,
           "composed": true,
           "docs": "Fire event if close button is clicked",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.5.0"
-            }
-          ]
+          "docsTags": []
         }
       ],
       "styles": [],
@@ -3413,12 +3286,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.0.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [
         "ix-date-dropdown",
@@ -3773,10 +3641,6 @@
       "docs": "",
       "docsTags": [
         {
-          "name": "since",
-          "text": "2.1.0"
-        },
-        {
           "name": "slot",
           "text": "header - Display content at the top of the content page"
         }
@@ -3964,12 +3828,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.6.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [
@@ -4195,12 +4054,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.1.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [
@@ -4326,12 +4180,7 @@
           "attr": "disabled",
           "reflectToAttr": false,
           "docs": "Disable the button that opens the dropdown containing the date picker.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.3.0"
-            }
-          ],
+          "docsTags": [],
           "default": "false",
           "values": [
             {
@@ -4528,12 +4377,7 @@
           "attr": "locale",
           "reflectToAttr": false,
           "docs": "Locale identifier (e.g. 'en' or 'de').",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.6.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -4744,12 +4588,7 @@
           "attr": "week-start-index",
           "reflectToAttr": false,
           "docs": "The index of which day to start the week on, based on the Locale#weekdays array.\nE.g. if the locale is en-us, weekStartIndex = 1 results in starting the week on monday.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.6.0"
-            }
-          ],
+          "docsTags": [],
           "default": "0",
           "values": [
             {
@@ -4829,10 +4668,6 @@
       "usage": {},
       "docs": "",
       "docsTags": [
-        {
-          "name": "since",
-          "text": "2.6.0"
-        },
         {
           "name": "form-ready",
           "text": "2.6.0"
@@ -5062,12 +4897,7 @@
           "attr": "locale",
           "reflectToAttr": false,
           "docs": "Locale identifier (e.g. 'en' or 'de').",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.6.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -5520,12 +5350,7 @@
           "attr": "from",
           "reflectToAttr": false,
           "docs": "The selected starting date. If the date-picker-rework is not in range mode this is the selected date.\nFormat has to match the `format` property.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.1.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -5548,12 +5373,7 @@
           "attr": "i18n-done",
           "reflectToAttr": false,
           "docs": "Text of date select button",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.1.0"
-            }
-          ],
+          "docsTags": [],
           "default": "'Done'",
           "values": [
             {
@@ -5577,12 +5397,7 @@
           "attr": "locale",
           "reflectToAttr": false,
           "docs": "Locale identifier (e.g. 'en' or 'de').",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.1.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -5605,12 +5420,7 @@
           "attr": "max-date",
           "reflectToAttr": false,
           "docs": "The latest date that can be selected by the date picker.\nIf not set there will be no restriction.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.1.0"
-            }
-          ],
+          "docsTags": [],
           "default": "''",
           "values": [
             {
@@ -5634,12 +5444,7 @@
           "attr": "min-date",
           "reflectToAttr": false,
           "docs": "The earliest date that can be selected by the date picker.\nIf not set there will be no restriction.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.1.0"
-            }
-          ],
+          "docsTags": [],
           "default": "''",
           "values": [
             {
@@ -5716,12 +5521,7 @@
           "attr": "to",
           "reflectToAttr": false,
           "docs": "The selected end date. If the the date-picker-rework is not in range mode this property has no impact.\nFormat has to match the `format` property.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.1.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -5744,12 +5544,7 @@
           "attr": "week-start-index",
           "reflectToAttr": false,
           "docs": "The index of which day to start the week on, based on the Locale#weekdays array.\nE.g. if the locale is en-us, weekStartIndex = 1 results in starting the week on monday.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.1.0"
-            }
-          ],
+          "docsTags": [],
           "default": "0",
           "values": [
             {
@@ -5805,12 +5600,7 @@
           "cancelable": true,
           "composed": true,
           "docs": "Triggers if the date selection changes.\nNote: Since 2.0.0 `dateChange` does not dispatch detail property as `string`",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.1.0"
-            }
-          ]
+          "docsTags": []
         },
         {
           "event": "dateRangeChange",
@@ -5830,12 +5620,7 @@
           "cancelable": true,
           "composed": true,
           "docs": "Triggers if the date selection changes.\nOnly triggered if date-picker-rework is in range mode.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.1.0"
-            }
-          ]
+          "docsTags": []
         },
         {
           "event": "dateSelect",
@@ -5855,12 +5640,7 @@
           "cancelable": true,
           "composed": true,
           "docs": "Date selection confirmed via button action",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.1.0"
-            }
-          ]
+          "docsTags": []
         }
       ],
       "styles": [],
@@ -5930,12 +5710,7 @@
           "attr": "date-format",
           "reflectToAttr": false,
           "docs": "Date format string.\nSee {@link \"https://moment.github.io/luxon/#/formatting?id=table-of-tokens\"} for all available tokens.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.1.0"
-            }
-          ],
+          "docsTags": [],
           "default": "'yyyy/LL/dd'",
           "values": [
             {
@@ -5959,12 +5734,7 @@
           "attr": "from",
           "reflectToAttr": false,
           "docs": "The selected starting date. If the picker is not in range mode this is the selected date.\nFormat has to match the `format` property.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.1.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -5987,12 +5757,7 @@
           "attr": "i18n-done",
           "reflectToAttr": false,
           "docs": "Text of date select button",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.1.0"
-            }
-          ],
+          "docsTags": [],
           "default": "'Done'",
           "values": [
             {
@@ -6045,12 +5810,7 @@
           "attr": "locale",
           "reflectToAttr": false,
           "docs": "Format of time string\nSee {@link \"https://moment.github.io/luxon/#/formatting?id=table-of-tokens\"} for all available tokens.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.1.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -6073,12 +5833,7 @@
           "attr": "max-date",
           "reflectToAttr": false,
           "docs": "The latest date that can be selected by the date picker.\nIf not set there will be no restriction.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.1.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -6101,12 +5856,7 @@
           "attr": "min-date",
           "reflectToAttr": false,
           "docs": "The earliest date that can be selected by the date picker.\nIf not set there will be no restriction.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.1.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -6229,10 +5979,6 @@
             {
               "name": "see",
               "text": "{ this.timeFormat}"
-            },
-            {
-              "name": "since",
-              "text": "1.1.0"
             }
           ],
           "default": "false",
@@ -6287,12 +6033,7 @@
           "attr": "time",
           "reflectToAttr": false,
           "docs": "Select time with format string",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.1.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -6315,12 +6056,7 @@
           "attr": "time-format",
           "reflectToAttr": false,
           "docs": "Time format string.\nSee {@link \"https://moment.github.io/luxon/#/formatting?id=table-of-tokens\"} for all available tokens.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.1.0"
-            }
-          ],
+          "docsTags": [],
           "default": "'HH:mm:ss'",
           "values": [
             {
@@ -6372,12 +6108,7 @@
           "attr": "to",
           "reflectToAttr": false,
           "docs": "The selected end date. If the the picker is not in range mode this property has no impact.\nFormat has to match the `format` property.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.1.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -6400,12 +6131,7 @@
           "attr": "week-start-index",
           "reflectToAttr": false,
           "docs": "The index of which day to start the week on, based on the Locale#weekdays array.\nE.g. if the locale is en-us, weekStartIndex = 1 results in starting the week on monday.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.1.0"
-            }
-          ],
+          "docsTags": [],
           "default": "0",
           "values": [
             {
@@ -6438,12 +6164,7 @@
           "cancelable": true,
           "composed": true,
           "docs": "Date change",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.1.0"
-            }
-          ]
+          "docsTags": []
         },
         {
           "event": "dateSelect",
@@ -6463,12 +6184,7 @@
           "cancelable": true,
           "composed": true,
           "docs": "Datetime selection event is fired after confirm button is pressed",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.1.0"
-            }
-          ]
+          "docsTags": []
         },
         {
           "event": "timeChange",
@@ -6481,13 +6197,8 @@
           },
           "cancelable": true,
           "composed": true,
-          "docs": "\nTime change",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.1.0"
-            }
-          ]
+          "docs": "Time change",
+          "docsTags": []
         }
       ],
       "styles": [],
@@ -6505,12 +6216,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "1.4.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [
         "ix-avatar",
@@ -7073,12 +6779,7 @@
           "attr": "suppress-automatic-placement",
           "reflectToAttr": false,
           "docs": "Suppress the automatic placement of the dropdown.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.0.0"
-            }
-          ],
+          "docsTags": [],
           "default": "false",
           "values": [
             {
@@ -7188,12 +6889,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "1.3.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [
@@ -7227,12 +6923,7 @@
           "attr": "close-behavior",
           "reflectToAttr": false,
           "docs": "Controls if the dropdown will be closed in response to a click event depending on the position of the event relative to the dropdown.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.1.0"
-            }
-          ],
+          "docsTags": [],
           "default": "'both'",
           "values": [
             {
@@ -7392,12 +7083,7 @@
           "attr": "placement",
           "reflectToAttr": false,
           "docs": "Placement of the dropdown",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.0.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "value": "bottom-end",
@@ -7494,12 +7180,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.0.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [
@@ -7720,12 +7401,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "1.4.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [],
@@ -7748,12 +7424,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "1.6.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [
@@ -8234,12 +7905,7 @@
           "attr": "full-width",
           "reflectToAttr": false,
           "docs": "If true the search field will fill all available horizontal space of it's parent container when expanded.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.6.0"
-            }
-          ],
+          "docsTags": [],
           "default": "false",
           "values": [
             {
@@ -8583,12 +8249,7 @@
           "attr": "readonly",
           "reflectToAttr": false,
           "docs": "If true the filter chip will be in readonly mode",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.0.0"
-            }
-          ],
+          "docsTags": [],
           "default": "false",
           "values": [
             {
@@ -8660,12 +8321,7 @@
           "attr": "height",
           "reflectToAttr": false,
           "docs": "Height interpreted as REM",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.5.0"
-            }
-          ],
+          "docsTags": [],
           "default": "15.125",
           "values": [
             {
@@ -8763,12 +8419,7 @@
           "attr": "width",
           "reflectToAttr": false,
           "docs": "Width interpreted as REM",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.5.0"
-            }
-          ],
+          "docsTags": [],
           "default": "16",
           "values": [
             {
@@ -9667,12 +9318,7 @@
           "attr": "a11y-label",
           "reflectToAttr": false,
           "docs": "Accessibility label for the icon button\nWill be set as aria-label on the nested HTML button element",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.1.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -9789,12 +9435,7 @@
           "attr": "loading",
           "reflectToAttr": false,
           "docs": "Loading button",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.0.0"
-            }
-          ],
+          "docsTags": [],
           "default": "false",
           "values": [
             {
@@ -9934,12 +9575,7 @@
           "attr": "variant",
           "reflectToAttr": false,
           "docs": "Variant of button",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.3.0 - variant danger"
-            }
-          ],
+          "docsTags": [],
           "default": "'secondary'",
           "values": [
             {
@@ -9978,12 +9614,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.0.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [
@@ -10244,10 +9875,6 @@
       "usage": {},
       "docs": "",
       "docsTags": [
-        {
-          "name": "since",
-          "text": "2.6.0"
-        },
         {
           "name": "form-ready",
           "text": "2.6.0"
@@ -10883,10 +10510,6 @@
         {
           "name": "slot",
           "text": "custom-value - Optional custom value at key value instead of text value"
-        },
-        {
-          "name": "since",
-          "text": "1.6.0"
         }
       ],
       "encapsulation": "shadow",
@@ -11021,12 +10644,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "1.6.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [],
@@ -11232,12 +10850,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.6.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [],
@@ -11285,12 +10898,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.0.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [
         "ix-date-dropdown",
@@ -11409,12 +11017,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.0.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [],
@@ -11780,10 +11383,6 @@
             {
               "name": "param",
               "text": "show new visibility state"
-            },
-            {
-              "name": "since",
-              "text": "1.6.0"
             }
           ]
         }
@@ -12360,12 +11959,7 @@
           "attr": "start-expanded",
           "reflectToAttr": false,
           "docs": "If set the menu will be expanded initially. This will only take effect at the breakpoint 'lg'.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.2.0"
-            }
-          ],
+          "docsTags": [],
           "default": "false",
           "values": [
             {
@@ -13118,12 +12712,7 @@
           "attr": "image",
           "reflectToAttr": false,
           "docs": "Display a avatar image",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.4.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -13146,12 +12735,7 @@
           "attr": "initials",
           "reflectToAttr": false,
           "docs": "Display the initials of the user. Will be overwritten by image",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.4.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -13174,12 +12758,7 @@
           "attr": "show-logout-button",
           "reflectToAttr": false,
           "docs": "Control the visibility of the logout button",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.1.0"
-            }
-          ],
+          "docsTags": [],
           "default": "true",
           "values": [
             {
@@ -13348,12 +12927,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.0.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [
@@ -13638,12 +13212,7 @@
           "attr": "label",
           "reflectToAttr": false,
           "docs": "Label of the menu item. Will also be used as tooltip text",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.2.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -14158,12 +13727,7 @@
           "attr": "close-on-backdrop-click",
           "reflectToAttr": false,
           "docs": "Dismiss modal on backdrop click",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.0.0"
-            }
-          ],
+          "docsTags": [],
           "default": "false",
           "values": [
             {
@@ -14217,12 +13781,7 @@
           "attr": "size",
           "reflectToAttr": false,
           "docs": "Modal size",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.0.0"
-            }
-          ],
+          "docsTags": [],
           "default": "'360'",
           "values": [
             {
@@ -14409,12 +13968,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.0.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [
         "ix-application-switch-modal"
@@ -14443,12 +13997,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.0.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [],
@@ -14471,12 +14020,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.0.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [
         "ix-application-switch-modal"
@@ -14607,10 +14151,6 @@
       "usage": {},
       "docs": "",
       "docsTags": [
-        {
-          "name": "since",
-          "text": "2.6.0"
-        },
         {
           "name": "form-ready",
           "text": "2.6.0"
@@ -15199,12 +14739,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "1.5.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [
@@ -15491,12 +15026,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.1.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [
@@ -15831,12 +15361,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.1.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [],
@@ -16193,12 +15718,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "1.6.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [
@@ -16230,12 +15750,7 @@
           "attr": "collapse",
           "reflectToAttr": false,
           "docs": "Collapse the card",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.1.0"
-            }
-          ],
+          "docsTags": [],
           "default": "true",
           "values": [
             {
@@ -16422,10 +15937,6 @@
       "docs": "",
       "docsTags": [
         {
-          "name": "since",
-          "text": "2.6.0"
-        },
-        {
           "name": "form-ready",
           "text": "2.6.0"
         }
@@ -16606,10 +16117,6 @@
       "usage": {},
       "docs": "",
       "docsTags": [
-        {
-          "name": "since",
-          "text": "2.6.0"
-        },
         {
           "name": "form-ready",
           "text": "2.6.0"
@@ -16889,12 +16396,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.0.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [
         "ix-date-dropdown",
@@ -17039,12 +16541,7 @@
           "attr": "dropdown-max-width",
           "reflectToAttr": false,
           "docs": "The maximum width of the dropdown element with value and unit (e.g. \"200px\" or \"12.5rem\").\nBy default the maximum width of the dropdown element is set to 100%.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.7.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -17067,12 +16564,7 @@
           "attr": "dropdown-width",
           "reflectToAttr": false,
           "docs": "The width of the dropdown element with value and unit (e.g. \"200px\" or \"12.5rem\").",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.7.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -17119,12 +16611,7 @@
           "attr": "helper-text",
           "reflectToAttr": false,
           "docs": "Helper text for the select component",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.6.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -17147,12 +16634,7 @@
           "attr": "hide-list-header",
           "reflectToAttr": false,
           "docs": "Hide list header",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.5.0"
-            }
-          ],
+          "docsTags": [],
           "default": "false",
           "values": [
             {
@@ -17176,12 +16658,7 @@
           "attr": "i-1-8n-no-matches",
           "reflectToAttr": false,
           "docs": "Information inside of dropdown if no items where found with current filter text",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.5.0"
-            }
-          ],
+          "docsTags": [],
           "default": "'No matches'",
           "values": [
             {
@@ -17277,12 +16754,7 @@
           "attr": "info-text",
           "reflectToAttr": false,
           "docs": "Info text for the select component",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.6.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -17305,12 +16777,7 @@
           "attr": "invalid-text",
           "reflectToAttr": false,
           "docs": "Error text for the select component",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.6.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -17333,12 +16800,7 @@
           "attr": "label",
           "reflectToAttr": false,
           "docs": "Label for the select component",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.6.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -17390,12 +16852,7 @@
           "attr": "name",
           "reflectToAttr": true,
           "docs": "A string that represents the element's name attribute,\ncontaining a name that identifies the element when submitting the form.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.6.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -17442,12 +16899,7 @@
           "attr": "required",
           "reflectToAttr": true,
           "docs": "A Boolean attribute indicating that an option with a non-empty string value must be selected",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.6.0"
-            }
-          ],
+          "docsTags": [],
           "default": "false",
           "values": [
             {
@@ -17471,12 +16923,7 @@
           "attr": "show-text-as-tooltip",
           "reflectToAttr": false,
           "docs": "Show helper, error, info, warning text as tooltip",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.6.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "boolean"
@@ -17499,12 +16946,7 @@
           "attr": "valid-text",
           "reflectToAttr": false,
           "docs": "Valid text for the select component",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.6.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -17527,12 +16969,7 @@
           "attr": "value",
           "reflectToAttr": false,
           "docs": "Current selected value.\nThis corresponds to the value property of ix-select-items",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.0.0"
-            }
-          ],
+          "docsTags": [],
           "default": "[]",
           "values": [
             {
@@ -17559,12 +16996,7 @@
           "attr": "warning-text",
           "reflectToAttr": false,
           "docs": "Warning text for the select component",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.6.0"
-            }
-          ],
+          "docsTags": [],
           "values": [
             {
               "type": "string"
@@ -17653,12 +17085,7 @@
           "cancelable": true,
           "composed": true,
           "docs": "Event dispatched whenever the text input changes.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.0.0"
-            }
-          ]
+          "docsTags": []
         },
         {
           "event": "ixBlur",
@@ -17686,12 +17113,7 @@
           "cancelable": true,
           "composed": true,
           "docs": "Value changed",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.0.0"
-            }
-          ]
+          "docsTags": []
         }
       ],
       "styles": [],
@@ -17850,10 +17272,6 @@
       "usage": {},
       "docs": "",
       "docsTags": [
-        {
-          "name": "since",
-          "text": "2.0.0"
-        },
         {
           "name": "slot",
           "text": "label-start - Element will be displayed at the start of the slider"
@@ -18333,12 +17751,7 @@
           "attr": "close-behavior",
           "reflectToAttr": false,
           "docs": "Controls if the dropdown will be closed in response to a click event depending on the position of the event relative to the dropdown.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.3.0"
-            }
-          ],
+          "docsTags": [],
           "default": "'both'",
           "values": [
             {
@@ -18877,12 +18290,7 @@
           "cancelable": true,
           "composed": true,
           "docs": "Emitted when the tab is clicked.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.0.0"
-            }
-          ]
+          "docsTags": []
         }
       ],
       "styles": [],
@@ -19061,12 +18469,7 @@
           "cancelable": true,
           "composed": true,
           "docs": "`selected` property changed",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.0.0"
-            }
-          ]
+          "docsTags": []
         }
       ],
       "styles": [],
@@ -19097,10 +18500,6 @@
       "usage": {},
       "docs": "",
       "docsTags": [
-        {
-          "name": "since",
-          "text": "2.6.0"
-        },
         {
           "name": "form-ready",
           "text": "2.6.0"
@@ -19870,12 +19269,7 @@
           "attr": "format",
           "reflectToAttr": false,
           "docs": "Format of time string\nSee {@link \"https://moment.github.io/luxon/#/formatting?id=table-of-tokens\"} for all available tokens.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.1.0"
-            }
-          ],
+          "docsTags": [],
           "default": "'TT'",
           "values": [
             {
@@ -19995,12 +19389,7 @@
           "attr": "text-select-time",
           "reflectToAttr": false,
           "docs": "Text of date select button",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.1.0"
-            }
-          ],
+          "docsTags": [],
           "default": "'Done'",
           "values": [
             {
@@ -20024,12 +19413,7 @@
           "attr": "text-time",
           "reflectToAttr": false,
           "docs": "Text for top label",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.1.0"
-            }
-          ],
+          "docsTags": [],
           "default": "'Time'",
           "values": [
             {
@@ -20053,12 +19437,7 @@
           "attr": "time",
           "reflectToAttr": false,
           "docs": "Select time with format string\nFormat has to match the `format` property.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.1.0"
-            }
-          ],
+          "docsTags": [],
           "default": "DateTime.now().toFormat(this.format)",
           "values": [
             {
@@ -20837,12 +20216,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.0.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [],
       "dependencies": [
@@ -21077,10 +20451,6 @@
         {
           "name": "slot",
           "text": "title-content - Content of tooltip title"
-        },
-        {
-          "name": "since",
-          "text": "1.4.0"
         }
       ],
       "encapsulation": "shadow",
@@ -21189,12 +20559,7 @@
           "attr": "placement",
           "reflectToAttr": false,
           "docs": "Initial placement of the tooltip.\nIf the selected placement doesn't have enough space, the tooltip will be repositioned to another location.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.5.0"
-            }
-          ],
+          "docsTags": [],
           "default": "'top'",
           "values": [
             {
@@ -21473,12 +20838,7 @@
           "cancelable": true,
           "composed": true,
           "docs": "Node clicked event",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.5.0"
-            }
-          ]
+          "docsTags": []
         },
         {
           "event": "nodeRemoved",
@@ -21506,12 +20866,7 @@
           "cancelable": true,
           "composed": true,
           "docs": "Node toggled event",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "1.5.0"
-            }
-          ]
+          "docsTags": []
         }
       ],
       "styles": [],
@@ -21670,12 +21025,7 @@
       "overview": "",
       "usage": {},
       "docs": "",
-      "docsTags": [
-        {
-          "name": "since",
-          "text": "2.0.0"
-        }
-      ],
+      "docsTags": [],
       "encapsulation": "shadow",
       "dependents": [
         "ix-action-card",
@@ -22470,12 +21820,7 @@
           "attr": "suppress-automatic-placement",
           "reflectToAttr": false,
           "docs": "Suppress the automatic placement of the dropdown.",
-          "docsTags": [
-            {
-              "name": "since",
-              "text": "2.0.0"
-            }
-          ],
+          "docsTags": [],
           "default": "false",
           "values": [
             {

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -98,9 +98,6 @@ export { TreeContext, TreeItemContext, TreeModel, UpdateCallback } from "./compo
 export { TextDecoration, TypographyColors, TypographyFormat } from "./components/typography/typography";
 export { UploadFileState } from "./components/upload/upload-file-state";
 export namespace Components {
-    /**
-     * @since 1.6.0
-     */
     interface IxActionCard {
         /**
           * Card heading
@@ -123,9 +120,6 @@ export namespace Components {
          */
         "variant": ActionCardVariant;
     }
-    /**
-     * @since 2.1.0
-     */
     interface IxApplication {
         /**
           * Define application switch configuration
@@ -155,7 +149,6 @@ export namespace Components {
         "name"?: string;
         /**
           * Controls the visibility of the menu toggle button based on the context of the application header.  When the application header is utilized outside the application frame, the menu toggle button is displayed. Conversely, if the header is within the application frame, this property is ineffective.
-          * @since 2.5.0
          */
         "showMenu"?: boolean;
     }
@@ -164,13 +157,9 @@ export namespace Components {
     interface IxApplicationSwitchModal {
         "config"?: AppSwitchConfiguration;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxAvatar {
         /**
           * Optional description text that will be displayed underneath the username. Note: Only working if avatar is part of the ix-application-header
-          * @since 2.1.0
          */
         "extra"?: string;
         /**
@@ -183,7 +172,6 @@ export namespace Components {
         "initials"?: string;
         /**
           * If set an info card displaying the username will be placed inside the dropdown. Note: Only working if avatar is part of the ix-application-header
-          * @since 2.1.0
          */
         "username"?: string;
     }
@@ -213,7 +201,6 @@ export namespace Components {
         "collapsed": boolean;
         /**
           * Optional icon to be displayed next to the header label
-          * @since 1.5.0
          */
         "icon"?: string;
         /**
@@ -222,19 +209,16 @@ export namespace Components {
         "label"?: string;
         /**
           * Secondary label inside blind header
-          * @since 2.0.0
          */
         "sublabel"?: string;
         /**
           * Blind variant
-          * @since 2.0.0
          */
         "variant": BlindVariant;
     }
     interface IxBreadcrumb {
         /**
           * Accessibility label for the dropdown button (ellipsis icon) used to access the dropdown list with conditionally hidden previous items
-          * @since 2.0.0
          */
         "ariaLabelPreviousButton": string;
         /**
@@ -281,7 +265,6 @@ export namespace Components {
         "iconSize": '12' | '16' | '24';
         /**
           * Loading button
-          * @since 2.0.0
          */
         "loading": boolean;
         /**
@@ -294,16 +277,12 @@ export namespace Components {
         "type": 'button' | 'submit';
         /**
           * Button variant
-          * @since 2.3.0 - variant danger
          */
         "variant": ButtonVariant;
     }
-    /**
-     * @since 1.6.0
-     */
     interface IxCard {
         /**
-          * @since 2.1.0
+          * Show card in selected state
          */
         "selected": boolean;
         /**
@@ -311,24 +290,14 @@ export namespace Components {
          */
         "variant": CardVariant;
     }
-    /**
-     * @since 1.6.0
-     */
     interface IxCardAccordion {
         /**
           * Collapse the card
-          * @since 2.1.0
          */
         "collapse": boolean;
     }
-    /**
-     * @since 1.6.0
-     */
     interface IxCardContent {
     }
-    /**
-     * @since 1.6.0
-     */
     interface IxCardList {
         /**
           * Collapse the list
@@ -336,7 +305,6 @@ export namespace Components {
         "collapse": boolean;
         /**
           * Hide the show all button
-          * @since 2.2.0
          */
         "hideShowAll": boolean;
         /**
@@ -368,9 +336,6 @@ export namespace Components {
          */
         "suppressOverflowHandling": boolean;
     }
-    /**
-     * @since 1.6.0
-     */
     interface IxCardTitle {
     }
     interface IxCategoryFilter {
@@ -427,7 +392,6 @@ export namespace Components {
         "repeatCategories": boolean;
         /**
           * If set categories will always be filtered via the respective logical operator. Toggling of the operator will not be available to the user.
-          * @since 2.2.0
          */
         "staticOperator"?: LogicalFilterOperator;
         /**
@@ -437,7 +401,6 @@ export namespace Components {
         "tmpDisableScrollIntoView": boolean;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface IxCheckbox {
@@ -473,7 +436,6 @@ export namespace Components {
         "value": string;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface IxCheckboxGroup {
@@ -552,9 +514,6 @@ export namespace Components {
     | 'success'
     | 'custom';
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxCol {
         /**
           * Size of the column
@@ -573,9 +532,6 @@ export namespace Components {
          */
         "sizeSm"?: ColumnSize;
     }
-    /**
-     * @since 2.1.0
-     */
     interface IxContent {
     }
     interface IxContentHeader {
@@ -608,9 +564,6 @@ export namespace Components {
          */
         "itemName": string;
     }
-    /**
-     * @since 2.6.0
-     */
     interface IxCustomField {
         /**
           * Show text below the field component which show additional information
@@ -645,9 +598,6 @@ export namespace Components {
          */
         "warningText"?: string;
     }
-    /**
-     * @since 2.1.0
-     */
     interface IxDateDropdown {
         /**
           * Controls whether the user is allowed to pick custom date ranges in the component. When set to 'true', the user can select a custom date range using the date picker. When set to 'false', only predefined time date ranges are available for selection.
@@ -663,7 +613,6 @@ export namespace Components {
         "dateRangeOptions": DateDropdownOption[];
         /**
           * Disable the button that opens the dropdown containing the date picker.
-          * @since 2.3.0
          */
         "disabled": boolean;
         /**
@@ -701,7 +650,6 @@ export namespace Components {
         "loading": boolean;
         /**
           * Locale identifier (e.g. 'en' or 'de').
-          * @since 2.6.0
          */
         "locale"?: string;
         /**
@@ -736,12 +684,10 @@ export namespace Components {
         "variant": ButtonVariant1;
         /**
           * The index of which day to start the week on, based on the Locale#weekdays array. E.g. if the locale is en-us, weekStartIndex = 1 results in starting the week on monday.
-          * @since 2.6.0
          */
         "weekStartIndex": number;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface IxDateInput {
@@ -790,7 +736,6 @@ export namespace Components {
         "label"?: string;
         /**
           * Locale identifier (e.g. 'en' or 'de').
-          * @since 2.6.0
          */
         "locale"?: string;
         /**
@@ -842,7 +787,6 @@ export namespace Components {
         "format": string;
         /**
           * The selected starting date. If the date-picker-rework is not in range mode this is the selected date. Format has to match the `format` property.
-          * @since 1.1.0
          */
         "from": string | undefined;
         /**
@@ -851,22 +795,18 @@ export namespace Components {
         "getCurrentDate": () => Promise<{ from: string; to: string; }>;
         /**
           * Text of date select button
-          * @since 2.1.0
          */
         "i18nDone": string;
         /**
           * Locale identifier (e.g. 'en' or 'de').
-          * @since 2.1.0
          */
         "locale"?: string;
         /**
           * The latest date that can be selected by the date picker. If not set there will be no restriction.
-          * @since 1.1.0
          */
         "maxDate": string;
         /**
           * The earliest date that can be selected by the date picker. If not set there will be no restriction.
-          * @since 1.1.0
          */
         "minDate": string;
         /**
@@ -881,13 +821,11 @@ export namespace Components {
         "standaloneAppearance": boolean;
         /**
           * The selected end date. If the the date-picker-rework is not in range mode this property has no impact. Format has to match the `format` property.
-          * @since 1.1.0
          */
         "to": string | undefined;
         "today": string;
         /**
           * The index of which day to start the week on, based on the Locale#weekdays array. E.g. if the locale is en-us, weekStartIndex = 1 results in starting the week on monday.
-          * @since 2.1.0
          */
         "weekStartIndex": number;
     }
@@ -905,17 +843,14 @@ export namespace Components {
     interface IxDatetimePicker {
         /**
           * Date format string. See {@link "https://moment.github.io/luxon/#/formatting?id=table-of-tokens"} for all available tokens.
-          * @since 1.1.0
          */
         "dateFormat": string;
         /**
           * The selected starting date. If the picker is not in range mode this is the selected date. Format has to match the `format` property.
-          * @since 1.1.0
          */
         "from"?: string;
         /**
           * Text of date select button
-          * @since 2.1.0
          */
         "i18nDone": string;
         /**
@@ -925,17 +860,14 @@ export namespace Components {
         "i18nTime": string;
         /**
           * Format of time string See {@link "https://moment.github.io/luxon/#/formatting?id=table-of-tokens"} for all available tokens.
-          * @since 2.1.0
          */
         "locale"?: string;
         /**
           * The latest date that can be selected by the date picker. If not set there will be no restriction.
-          * @since 1.1.0
          */
         "maxDate"?: string;
         /**
           * The earliest date that can be selected by the date picker. If not set there will be no restriction.
-          * @since 1.1.0
          */
         "minDate"?: string;
         /**
@@ -957,7 +889,6 @@ export namespace Components {
         /**
           * Show time reference input Time reference is default aligned with
           * @see { this.timeFormat}
-          * @since 1.1.0
          */
         "showTimeReference": boolean;
         /**
@@ -967,12 +898,10 @@ export namespace Components {
         "showWeekNumbers": boolean;
         /**
           * Select time with format string
-          * @since 1.1.0
          */
         "time"?: string;
         /**
           * Time format string. See {@link "https://moment.github.io/luxon/#/formatting?id=table-of-tokens"} for all available tokens.
-          * @since 1.1.0
          */
         "timeFormat": string;
         /**
@@ -981,18 +910,13 @@ export namespace Components {
         "timeReference"?: 'AM' | 'PM';
         /**
           * The selected end date. If the the picker is not in range mode this property has no impact. Format has to match the `format` property.
-          * @since 1.1.0
          */
         "to"?: string;
         /**
           * The index of which day to start the week on, based on the Locale#weekdays array. E.g. if the locale is en-us, weekStartIndex = 1 results in starting the week on monday.
-          * @since 2.1.0
          */
         "weekStartIndex": number;
     }
-    /**
-     * @since 1.4.0
-     */
     interface IxDivider {
     }
     interface IxDrawer {
@@ -1068,7 +992,6 @@ export namespace Components {
         "show": boolean;
         /**
           * Suppress the automatic placement of the dropdown.
-          * @since 2.0.0
          */
         "suppressAutomaticPlacement": boolean;
         "suppressOverflowBehavior": boolean;
@@ -1081,13 +1004,9 @@ export namespace Components {
          */
         "updatePosition": () => Promise<void>;
     }
-    /**
-     * @since 1.3.0
-     */
     interface IxDropdownButton {
         /**
           * Controls if the dropdown will be closed in response to a click event depending on the position of the event relative to the dropdown.
-          * @since 2.1.0
          */
         "closeBehavior": 'inside' | 'outside' | 'both' | boolean;
         /**
@@ -1112,7 +1031,6 @@ export namespace Components {
         "outline": boolean;
         /**
           * Placement of the dropdown
-          * @since 2.0.0
          */
         "placement"?: AlignedPlacement;
         /**
@@ -1120,9 +1038,6 @@ export namespace Components {
          */
         "variant": DropdownButtonVariant;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxDropdownHeader {
         /**
           * Display name of the header
@@ -1155,14 +1070,8 @@ export namespace Components {
         "label"?: string;
         "suppressChecked": boolean;
     }
-    /**
-     * @since 1.4.0
-     */
     interface IxDropdownQuickActions {
     }
-    /**
-     * @since 1.6.0
-     */
     interface IxEmptyState {
         /**
           * Optional empty state action
@@ -1225,7 +1134,6 @@ export namespace Components {
     interface IxExpandingSearch {
         /**
           * If true the search field will fill all available horizontal space of it's parent container when expanded.
-          * @since 1.6.0
          */
         "fullWidth": boolean;
         /**
@@ -1334,14 +1242,12 @@ export namespace Components {
         "disabled": boolean;
         /**
           * If true the filter chip will be in readonly mode
-          * @since 2.0.0
          */
         "readonly": boolean;
     }
     interface IxFlipTile {
         /**
           * Height interpreted as REM
-          * @since 1.5.0
          */
         "height": number | 'auto';
         /**
@@ -1355,7 +1261,6 @@ export namespace Components {
         "state"?: FlipTileState;
         /**
           * Width interpreted as REM
-          * @since 1.5.0
          */
         "width": number | 'auto';
     }
@@ -1456,7 +1361,6 @@ export namespace Components {
     interface IxIconButton {
         /**
           * Accessibility label for the icon button Will be set as aria-label on the nested HTML button element
-          * @since 2.1.0
          */
         "a11yLabel"?: string;
         /**
@@ -1477,7 +1381,6 @@ export namespace Components {
         "iconColor"?: string;
         /**
           * Loading button
-          * @since 2.0.0
          */
         "loading": boolean;
         /**
@@ -1498,13 +1401,9 @@ export namespace Components {
         "type": 'button' | 'submit';
         /**
           * Variant of button
-          * @since 2.3.0 - variant danger
          */
         "variant": IconButtonVariant;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxIconToggleButton {
         /**
           * Disable the button
@@ -1540,7 +1439,6 @@ export namespace Components {
         "variant": ButtonVariant1;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface IxInput {
@@ -1637,9 +1535,6 @@ export namespace Components {
      */
     interface IxInputGroup {
     }
-    /**
-     * @since 1.6.0
-     */
     interface IxKeyValue {
         /**
           * Optional key value icon
@@ -1658,9 +1553,6 @@ export namespace Components {
          */
         "value"?: string;
     }
-    /**
-     * @since 1.6.0
-     */
     interface IxKeyValueList {
         /**
           * Optional striped key value list style
@@ -1674,9 +1566,6 @@ export namespace Components {
         "unit"?: string;
         "value"?: string | number;
     }
-    /**
-     * @since 2.6.0
-     */
     interface IxLayoutAuto {
         /**
           * Defines the layout of the form.
@@ -1686,9 +1575,6 @@ export namespace Components {
     columns: number;
   }[];
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxLayoutGrid {
         /**
           * Overwrite the default number of columns. Choose between 2 and 12 columns.
@@ -1703,9 +1589,6 @@ export namespace Components {
          */
         "noMargin": boolean;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxLinkButton {
         /**
           * Disable the link button
@@ -1750,7 +1633,6 @@ export namespace Components {
         /**
           * Change the visibility of the sidebar
           * @param show new visibility state
-          * @since 1.6.0
          */
         "toggleSidebar": (show?: boolean) => Promise<void>;
     }
@@ -1818,7 +1700,6 @@ export namespace Components {
         "showSettings": boolean;
         /**
           * If set the menu will be expanded initially. This will only take effect at the breakpoint 'lg'.
-          * @since 2.2.0
          */
         "startExpanded": boolean;
         /**
@@ -1890,17 +1771,14 @@ export namespace Components {
         "i18nLogout": string;
         /**
           * Display a avatar image
-          * @since 1.4.0
          */
         "image"?: string;
         /**
           * Display the initials of the user. Will be overwritten by image
-          * @since 1.4.0
          */
         "initials"?: string;
         /**
           * Control the visibility of the logout button
-          * @since 2.1.0
          */
         "showLogoutButton": boolean;
         /**
@@ -1919,9 +1797,6 @@ export namespace Components {
          */
         "label"?: string;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxMenuCategory {
         /**
           * Icon of the category
@@ -1979,7 +1854,6 @@ export namespace Components {
         "isCategory": boolean;
         /**
           * Label of the menu item. Will also be used as tooltip text
-          * @since 2.2.0
          */
         "label"?: string;
         /**
@@ -2045,7 +1919,6 @@ export namespace Components {
         "closeModal": <T = any>(reason: T) => Promise<void>;
         /**
           * Dismiss modal on backdrop click
-          * @since 2.0.0
          */
         "closeOnBackdropClick": boolean;
         /**
@@ -2062,23 +1935,13 @@ export namespace Components {
         "showModal": () => Promise<void>;
         /**
           * Modal size
-          * @since 2.0.0
          */
         "size": IxModalSize;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxModalContent {
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxModalFooter {
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxModalHeader {
         /**
           * Hide the close button
@@ -2096,7 +1959,6 @@ export namespace Components {
     interface IxModalLoading {
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface IxNumberInput {
@@ -2187,9 +2049,6 @@ export namespace Components {
          */
         "warningText"?: string;
     }
-    /**
-     * @since 1.5.0
-     */
     interface IxPagination {
         /**
           * Advanced mode
@@ -2224,9 +2083,6 @@ export namespace Components {
          */
         "showItemCount": boolean;
     }
-    /**
-     * @since 2.1.0
-     */
     interface IxPane {
         /**
           * Toggle the border of the pane. Defaults to the borderless attribute of the pane layout. If used standalone it defaults to false.
@@ -2269,9 +2125,6 @@ export namespace Components {
          */
         "variant": 'floating' | 'inline';
     }
-    /**
-     * @since 2.1.0
-     */
     interface IxPaneLayout {
         /**
           * Set the default border state for all panes in the layout
@@ -2324,13 +2177,9 @@ export namespace Components {
     | 'success'
     | 'custom';
     }
-    /**
-     * @since 1.6.0
-     */
     interface IxPushCard {
         /**
           * Collapse the card
-          * @since 2.1.0
          */
         "collapse": boolean;
         /**
@@ -2355,7 +2204,6 @@ export namespace Components {
         "variant": PushCardVariant;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface IxRadio {
@@ -2383,7 +2231,6 @@ export namespace Components {
         "value"?: string;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface IxRadioGroup {
@@ -2424,9 +2271,6 @@ export namespace Components {
          */
         "warningText"?: string;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxRow {
     }
     /**
@@ -2443,12 +2287,10 @@ export namespace Components {
         "disabled": boolean;
         /**
           * The maximum width of the dropdown element with value and unit (e.g. "200px" or "12.5rem"). By default the maximum width of the dropdown element is set to 100%.
-          * @since 2.7.0
          */
         "dropdownMaxWidth"?: string;
         /**
           * The width of the dropdown element with value and unit (e.g. "200px" or "12.5rem").
-          * @since 2.7.0
          */
         "dropdownWidth"?: string;
         /**
@@ -2467,17 +2309,14 @@ export namespace Components {
         "hasValidValue": () => Promise<boolean>;
         /**
           * Helper text for the select component
-          * @since 2.6.0
          */
         "helperText"?: string;
         /**
           * Hide list header
-          * @since 1.5.0
          */
         "hideListHeader": boolean;
         /**
           * Information inside of dropdown if no items where found with current filter text
-          * @since 1.5.0
          */
         "i18nNoMatches": string;
         /**
@@ -2494,12 +2333,10 @@ export namespace Components {
         "i18nSelectListHeader": string;
         /**
           * Info text for the select component
-          * @since 2.6.0
          */
         "infoText"?: string;
         /**
           * Error text for the select component
-          * @since 2.6.0
          */
         "invalidText"?: string;
         /**
@@ -2508,7 +2345,6 @@ export namespace Components {
         "isTouched": () => Promise<boolean>;
         /**
           * Label for the select component
-          * @since 2.6.0
          */
         "label"?: string;
         /**
@@ -2517,7 +2353,6 @@ export namespace Components {
         "mode": 'single' | 'multiple';
         /**
           * A string that represents the element's name attribute, containing a name that identifies the element when submitting the form.
-          * @since 2.6.0
          */
         "name"?: string;
         /**
@@ -2526,27 +2361,22 @@ export namespace Components {
         "readonly": boolean;
         /**
           * A Boolean attribute indicating that an option with a non-empty string value must be selected
-          * @since 2.6.0
          */
         "required": boolean;
         /**
           * Show helper, error, info, warning text as tooltip
-          * @since 2.6.0
          */
         "showTextAsTooltip"?: boolean;
         /**
           * Valid text for the select component
-          * @since 2.6.0
          */
         "validText"?: string;
         /**
           * Current selected value. This corresponds to the value property of ix-select-items
-          * @since 2.0.0
          */
         "value": string | string[];
         /**
           * Warning text for the select component
-          * @since 2.6.0
          */
         "warningText"?: string;
     }
@@ -2570,9 +2400,6 @@ export namespace Components {
          */
         "value": string;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxSlider {
         /**
           * Show control as disabled
@@ -2626,7 +2453,6 @@ export namespace Components {
     interface IxSplitButton {
         /**
           * Controls if the dropdown will be closed in response to a click event depending on the position of the event relative to the dropdown.
-          * @since 2.3.0
          */
         "closeBehavior": CloseBehavior;
         /**
@@ -2719,7 +2545,6 @@ export namespace Components {
         "small": boolean;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface IxTextarea {
@@ -2831,7 +2656,6 @@ export namespace Components {
         "corners": TimePickerCorners;
         /**
           * Format of time string See {@link "https://moment.github.io/luxon/#/formatting?id=table-of-tokens"} for all available tokens.
-          * @since 1.1.0
          */
         "format": string;
         /**
@@ -2856,17 +2680,14 @@ export namespace Components {
         "standaloneAppearance": boolean;
         /**
           * Text of date select button
-          * @since 1.1.0
          */
         "textSelectTime": string;
         /**
           * Text for top label
-          * @since 2.1.0
          */
         "textTime": string;
         /**
           * Select time with format string Format has to match the `format` property.
-          * @since 1.1.0
          */
         "time": string;
         /**
@@ -2957,9 +2778,6 @@ export namespace Components {
          */
         "value": string;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxToggleButton {
         /**
           * Disable the button
@@ -2990,9 +2808,6 @@ export namespace Components {
          */
         "variant": ButtonVariant1;
     }
-    /**
-     * @since 1.4.0
-     */
     interface IxTooltip {
         "animationFrame": boolean;
         /**
@@ -3007,7 +2822,6 @@ export namespace Components {
         "interactive": boolean;
         /**
           * Initial placement of the tooltip. If the selected placement doesn't have enough space, the tooltip will be repositioned to another location.
-          * @since 1.5.0
          */
         "placement": 'top' | 'right' | 'bottom' | 'left';
         "showDelay": number;
@@ -3060,9 +2874,6 @@ export namespace Components {
          */
         "text"?: string;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxTypography {
         /**
           * Display text bold
@@ -3146,7 +2957,6 @@ export namespace Components {
         "placement": Side;
         /**
           * Suppress the automatic placement of the dropdown.
-          * @since 2.0.0
          */
         "suppressAutomaticPlacement": boolean;
     }
@@ -3436,18 +3246,12 @@ export interface IxWorkflowStepsCustomEvent<T> extends CustomEvent<T> {
     target: HTMLIxWorkflowStepsElement;
 }
 declare global {
-    /**
-     * @since 1.6.0
-     */
     interface HTMLIxActionCardElement extends Components.IxActionCard, HTMLStencilElement {
     }
     var HTMLIxActionCardElement: {
         prototype: HTMLIxActionCardElement;
         new (): HTMLIxActionCardElement;
     };
-    /**
-     * @since 2.1.0
-     */
     interface HTMLIxApplicationElement extends Components.IxApplication, HTMLStencilElement {
     }
     var HTMLIxApplicationElement: {
@@ -3484,9 +3288,6 @@ declare global {
         prototype: HTMLIxApplicationSwitchModalElement;
         new (): HTMLIxApplicationSwitchModalElement;
     };
-    /**
-     * @since 2.0.0
-     */
     interface HTMLIxAvatarElement extends Components.IxAvatar, HTMLStencilElement {
     }
     var HTMLIxAvatarElement: {
@@ -3557,9 +3358,6 @@ declare global {
         prototype: HTMLIxButtonElement;
         new (): HTMLIxButtonElement;
     };
-    /**
-     * @since 1.6.0
-     */
     interface HTMLIxCardElement extends Components.IxCard, HTMLStencilElement {
     }
     var HTMLIxCardElement: {
@@ -3569,9 +3367,6 @@ declare global {
     interface HTMLIxCardAccordionElementEventMap {
         "accordionExpand": CardAccordionExpandChangeEvent;
     }
-    /**
-     * @since 1.6.0
-     */
     interface HTMLIxCardAccordionElement extends Components.IxCardAccordion, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxCardAccordionElementEventMap>(type: K, listener: (this: HTMLIxCardAccordionElement, ev: IxCardAccordionCustomEvent<HTMLIxCardAccordionElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -3586,9 +3381,6 @@ declare global {
         prototype: HTMLIxCardAccordionElement;
         new (): HTMLIxCardAccordionElement;
     };
-    /**
-     * @since 1.6.0
-     */
     interface HTMLIxCardContentElement extends Components.IxCardContent, HTMLStencilElement {
     }
     var HTMLIxCardContentElement: {
@@ -3604,9 +3396,6 @@ declare global {
     nativeEvent: MouseEvent;
   };
     }
-    /**
-     * @since 1.6.0
-     */
     interface HTMLIxCardListElement extends Components.IxCardList, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxCardListElementEventMap>(type: K, listener: (this: HTMLIxCardListElement, ev: IxCardListCustomEvent<HTMLIxCardListElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -3621,9 +3410,6 @@ declare global {
         prototype: HTMLIxCardListElement;
         new (): HTMLIxCardListElement;
     };
-    /**
-     * @since 1.6.0
-     */
     interface HTMLIxCardTitleElement extends Components.IxCardTitle, HTMLStencilElement {
     }
     var HTMLIxCardTitleElement: {
@@ -3655,7 +3441,6 @@ declare global {
         "valueChange": string;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface HTMLIxCheckboxElement extends Components.IxCheckbox, HTMLStencilElement {
@@ -3673,7 +3458,6 @@ declare global {
         new (): HTMLIxCheckboxElement;
     };
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface HTMLIxCheckboxGroupElement extends Components.IxCheckboxGroup, HTMLStencilElement {
@@ -3699,18 +3483,12 @@ declare global {
         prototype: HTMLIxChipElement;
         new (): HTMLIxChipElement;
     };
-    /**
-     * @since 2.0.0
-     */
     interface HTMLIxColElement extends Components.IxCol, HTMLStencilElement {
     }
     var HTMLIxColElement: {
         prototype: HTMLIxColElement;
         new (): HTMLIxColElement;
     };
-    /**
-     * @since 2.1.0
-     */
     interface HTMLIxContentElement extends Components.IxContent, HTMLStencilElement {
     }
     var HTMLIxContentElement: {
@@ -3746,9 +3524,6 @@ declare global {
         prototype: HTMLIxCssGridItemElement;
         new (): HTMLIxCssGridItemElement;
     };
-    /**
-     * @since 2.6.0
-     */
     interface HTMLIxCustomFieldElement extends Components.IxCustomField, HTMLStencilElement {
     }
     var HTMLIxCustomFieldElement: {
@@ -3758,9 +3533,6 @@ declare global {
     interface HTMLIxDateDropdownElementEventMap {
         "dateRangeChange": DateRangeChangeEvent;
     }
-    /**
-     * @since 2.1.0
-     */
     interface HTMLIxDateDropdownElement extends Components.IxDateDropdown, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxDateDropdownElementEventMap>(type: K, listener: (this: HTMLIxDateDropdownElement, ev: IxDateDropdownCustomEvent<HTMLIxDateDropdownElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -3782,7 +3554,6 @@ declare global {
         "ixBlur": void;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface HTMLIxDateInputElement extends Components.IxDateInput, HTMLStencilElement {
@@ -3843,9 +3614,6 @@ declare global {
         prototype: HTMLIxDatetimePickerElement;
         new (): HTMLIxDatetimePickerElement;
     };
-    /**
-     * @since 1.4.0
-     */
     interface HTMLIxDividerElement extends Components.IxDivider, HTMLStencilElement {
     }
     var HTMLIxDividerElement: {
@@ -3887,18 +3655,12 @@ declare global {
         prototype: HTMLIxDropdownElement;
         new (): HTMLIxDropdownElement;
     };
-    /**
-     * @since 1.3.0
-     */
     interface HTMLIxDropdownButtonElement extends Components.IxDropdownButton, HTMLStencilElement {
     }
     var HTMLIxDropdownButtonElement: {
         prototype: HTMLIxDropdownButtonElement;
         new (): HTMLIxDropdownButtonElement;
     };
-    /**
-     * @since 2.0.0
-     */
     interface HTMLIxDropdownHeaderElement extends Components.IxDropdownHeader, HTMLStencilElement {
     }
     var HTMLIxDropdownHeaderElement: {
@@ -3922,9 +3684,6 @@ declare global {
         prototype: HTMLIxDropdownItemElement;
         new (): HTMLIxDropdownItemElement;
     };
-    /**
-     * @since 1.4.0
-     */
     interface HTMLIxDropdownQuickActionsElement extends Components.IxDropdownQuickActions, HTMLStencilElement {
     }
     var HTMLIxDropdownQuickActionsElement: {
@@ -3934,9 +3693,6 @@ declare global {
     interface HTMLIxEmptyStateElementEventMap {
         "actionClick": void;
     }
-    /**
-     * @since 1.6.0
-     */
     interface HTMLIxEmptyStateElement extends Components.IxEmptyState, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxEmptyStateElementEventMap>(type: K, listener: (this: HTMLIxEmptyStateElement, ev: IxEmptyStateCustomEvent<HTMLIxEmptyStateElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -4100,9 +3856,6 @@ declare global {
     interface HTMLIxIconToggleButtonElementEventMap {
         "pressedChange": boolean;
     }
-    /**
-     * @since 2.0.0
-     */
     interface HTMLIxIconToggleButtonElement extends Components.IxIconToggleButton, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxIconToggleButtonElementEventMap>(type: K, listener: (this: HTMLIxIconToggleButtonElement, ev: IxIconToggleButtonCustomEvent<HTMLIxIconToggleButtonElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -4123,7 +3876,6 @@ declare global {
         "ixBlur": void;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface HTMLIxInputElement extends Components.IxInput, HTMLStencilElement {
@@ -4150,18 +3902,12 @@ declare global {
         prototype: HTMLIxInputGroupElement;
         new (): HTMLIxInputGroupElement;
     };
-    /**
-     * @since 1.6.0
-     */
     interface HTMLIxKeyValueElement extends Components.IxKeyValue, HTMLStencilElement {
     }
     var HTMLIxKeyValueElement: {
         prototype: HTMLIxKeyValueElement;
         new (): HTMLIxKeyValueElement;
     };
-    /**
-     * @since 1.6.0
-     */
     interface HTMLIxKeyValueListElement extends Components.IxKeyValueList, HTMLStencilElement {
     }
     var HTMLIxKeyValueListElement: {
@@ -4174,27 +3920,18 @@ declare global {
         prototype: HTMLIxKpiElement;
         new (): HTMLIxKpiElement;
     };
-    /**
-     * @since 2.6.0
-     */
     interface HTMLIxLayoutAutoElement extends Components.IxLayoutAuto, HTMLStencilElement {
     }
     var HTMLIxLayoutAutoElement: {
         prototype: HTMLIxLayoutAutoElement;
         new (): HTMLIxLayoutAutoElement;
     };
-    /**
-     * @since 2.0.0
-     */
     interface HTMLIxLayoutGridElement extends Components.IxLayoutGrid, HTMLStencilElement {
     }
     var HTMLIxLayoutGridElement: {
         prototype: HTMLIxLayoutGridElement;
         new (): HTMLIxLayoutGridElement;
     };
-    /**
-     * @since 2.0.0
-     */
     interface HTMLIxLinkButtonElement extends Components.IxLinkButton, HTMLStencilElement {
     }
     var HTMLIxLinkButtonElement: {
@@ -4347,9 +4084,6 @@ declare global {
     interface HTMLIxMenuCategoryElementEventMap {
         "closeOtherCategories": any;
     }
-    /**
-     * @since 2.0.0
-     */
     interface HTMLIxMenuCategoryElement extends Components.IxMenuCategory, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxMenuCategoryElementEventMap>(type: K, listener: (this: HTMLIxMenuCategoryElement, ev: IxMenuCategoryCustomEvent<HTMLIxMenuCategoryElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -4447,18 +4181,12 @@ declare global {
         prototype: HTMLIxModalElement;
         new (): HTMLIxModalElement;
     };
-    /**
-     * @since 2.0.0
-     */
     interface HTMLIxModalContentElement extends Components.IxModalContent, HTMLStencilElement {
     }
     var HTMLIxModalContentElement: {
         prototype: HTMLIxModalContentElement;
         new (): HTMLIxModalContentElement;
     };
-    /**
-     * @since 2.0.0
-     */
     interface HTMLIxModalFooterElement extends Components.IxModalFooter, HTMLStencilElement {
     }
     var HTMLIxModalFooterElement: {
@@ -4468,9 +4196,6 @@ declare global {
     interface HTMLIxModalHeaderElementEventMap {
         "closeClick": MouseEvent;
     }
-    /**
-     * @since 2.0.0
-     */
     interface HTMLIxModalHeaderElement extends Components.IxModalHeader, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxModalHeaderElementEventMap>(type: K, listener: (this: HTMLIxModalHeaderElement, ev: IxModalHeaderCustomEvent<HTMLIxModalHeaderElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -4497,7 +4222,6 @@ declare global {
         "ixBlur": void;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface HTMLIxNumberInputElement extends Components.IxNumberInput, HTMLStencilElement {
@@ -4518,9 +4242,6 @@ declare global {
         "pageSelected": number;
         "itemCountChanged": number;
     }
-    /**
-     * @since 1.5.0
-     */
     interface HTMLIxPaginationElement extends Components.IxPagination, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxPaginationElementEventMap>(type: K, listener: (this: HTMLIxPaginationElement, ev: IxPaginationCustomEvent<HTMLIxPaginationElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -4542,9 +4263,6 @@ declare global {
         "hideOnCollapseChanged": HideOnCollapseChangedEvent;
         "slotChanged": SlotChangedEvent;
     }
-    /**
-     * @since 2.1.0
-     */
     interface HTMLIxPaneElement extends Components.IxPane, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxPaneElementEventMap>(type: K, listener: (this: HTMLIxPaneElement, ev: IxPaneCustomEvent<HTMLIxPaneElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -4559,9 +4277,6 @@ declare global {
         prototype: HTMLIxPaneElement;
         new (): HTMLIxPaneElement;
     };
-    /**
-     * @since 2.1.0
-     */
     interface HTMLIxPaneLayoutElement extends Components.IxPaneLayout, HTMLStencilElement {
     }
     var HTMLIxPaneLayoutElement: {
@@ -4574,9 +4289,6 @@ declare global {
         prototype: HTMLIxPillElement;
         new (): HTMLIxPillElement;
     };
-    /**
-     * @since 1.6.0
-     */
     interface HTMLIxPushCardElement extends Components.IxPushCard, HTMLStencilElement {
     }
     var HTMLIxPushCardElement: {
@@ -4588,7 +4300,6 @@ declare global {
         "valueChange": string;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface HTMLIxRadioElement extends Components.IxRadio, HTMLStencilElement {
@@ -4609,7 +4320,6 @@ declare global {
         "valueChange": string;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface HTMLIxRadioGroupElement extends Components.IxRadioGroup, HTMLStencilElement {
@@ -4626,9 +4336,6 @@ declare global {
         prototype: HTMLIxRadioGroupElement;
         new (): HTMLIxRadioGroupElement;
     };
-    /**
-     * @since 2.0.0
-     */
     interface HTMLIxRowElement extends Components.IxRow, HTMLStencilElement {
     }
     var HTMLIxRowElement: {
@@ -4678,9 +4385,6 @@ declare global {
     interface HTMLIxSliderElementEventMap {
         "valueChange": number;
     }
-    /**
-     * @since 2.0.0
-     */
     interface HTMLIxSliderElement extends Components.IxSlider, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxSliderElementEventMap>(type: K, listener: (this: HTMLIxSliderElement, ev: IxSliderCustomEvent<HTMLIxSliderElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -4758,7 +4462,6 @@ declare global {
         "ixBlur": void;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface HTMLIxTextareaElement extends Components.IxTextarea, HTMLStencilElement {
@@ -4846,9 +4549,6 @@ declare global {
     interface HTMLIxToggleButtonElementEventMap {
         "pressedChange": boolean;
     }
-    /**
-     * @since 2.0.0
-     */
     interface HTMLIxToggleButtonElement extends Components.IxToggleButton, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxToggleButtonElementEventMap>(type: K, listener: (this: HTMLIxToggleButtonElement, ev: IxToggleButtonCustomEvent<HTMLIxToggleButtonElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -4863,9 +4563,6 @@ declare global {
         prototype: HTMLIxToggleButtonElement;
         new (): HTMLIxToggleButtonElement;
     };
-    /**
-     * @since 1.4.0
-     */
     interface HTMLIxTooltipElement extends Components.IxTooltip, HTMLStencilElement {
     }
     var HTMLIxTooltipElement: {
@@ -4910,9 +4607,6 @@ declare global {
         prototype: HTMLIxTreeItemElement;
         new (): HTMLIxTreeItemElement;
     };
-    /**
-     * @since 2.0.0
-     */
     interface HTMLIxTypographyElement extends Components.IxTypography, HTMLStencilElement {
     }
     var HTMLIxTypographyElement: {
@@ -5094,9 +4788,6 @@ declare global {
     }
 }
 declare namespace LocalJSX {
-    /**
-     * @since 1.6.0
-     */
     interface IxActionCard {
         /**
           * Card heading
@@ -5119,9 +4810,6 @@ declare namespace LocalJSX {
          */
         "variant"?: ActionCardVariant;
     }
-    /**
-     * @since 2.1.0
-     */
     interface IxApplication {
         /**
           * Define application switch configuration
@@ -5151,17 +4839,14 @@ declare namespace LocalJSX {
         "name"?: string;
         /**
           * Event emitted when the menu toggle button is clicked
-          * @since 2.5.0
          */
         "onMenuToggle"?: (event: IxApplicationHeaderCustomEvent<boolean>) => void;
         /**
           * Event emitted when the app switch button is clicked
-          * @since 3.0.0
          */
         "onOpenAppSwitch"?: (event: IxApplicationHeaderCustomEvent<void>) => void;
         /**
           * Controls the visibility of the menu toggle button based on the context of the application header.  When the application header is utilized outside the application frame, the menu toggle button is displayed. Conversely, if the header is within the application frame, this property is ineffective.
-          * @since 2.5.0
          */
         "showMenu"?: boolean;
     }
@@ -5170,13 +4855,9 @@ declare namespace LocalJSX {
     interface IxApplicationSwitchModal {
         "config"?: AppSwitchConfiguration;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxAvatar {
         /**
           * Optional description text that will be displayed underneath the username. Note: Only working if avatar is part of the ix-application-header
-          * @since 2.1.0
          */
         "extra"?: string;
         /**
@@ -5189,7 +4870,6 @@ declare namespace LocalJSX {
         "initials"?: string;
         /**
           * If set an info card displaying the username will be placed inside the dropdown. Note: Only working if avatar is part of the ix-application-header
-          * @since 2.1.0
          */
         "username"?: string;
     }
@@ -5219,7 +4899,6 @@ declare namespace LocalJSX {
         "collapsed"?: boolean;
         /**
           * Optional icon to be displayed next to the header label
-          * @since 1.5.0
          */
         "icon"?: string;
         /**
@@ -5232,19 +4911,16 @@ declare namespace LocalJSX {
         "onCollapsedChange"?: (event: IxBlindCustomEvent<boolean>) => void;
         /**
           * Secondary label inside blind header
-          * @since 2.0.0
          */
         "sublabel"?: string;
         /**
           * Blind variant
-          * @since 2.0.0
          */
         "variant"?: BlindVariant;
     }
     interface IxBreadcrumb {
         /**
           * Accessibility label for the dropdown button (ellipsis icon) used to access the dropdown list with conditionally hidden previous items
-          * @since 2.0.0
          */
         "ariaLabelPreviousButton"?: string;
         /**
@@ -5300,7 +4976,6 @@ declare namespace LocalJSX {
         "iconSize"?: '12' | '16' | '24';
         /**
           * Loading button
-          * @since 2.0.0
          */
         "loading"?: boolean;
         /**
@@ -5313,16 +4988,12 @@ declare namespace LocalJSX {
         "type"?: 'button' | 'submit';
         /**
           * Button variant
-          * @since 2.3.0 - variant danger
          */
         "variant"?: ButtonVariant;
     }
-    /**
-     * @since 1.6.0
-     */
     interface IxCard {
         /**
-          * @since 2.1.0
+          * Show card in selected state
          */
         "selected"?: boolean;
         /**
@@ -5330,25 +5001,15 @@ declare namespace LocalJSX {
          */
         "variant"?: CardVariant;
     }
-    /**
-     * @since 1.6.0
-     */
     interface IxCardAccordion {
         /**
           * Collapse the card
-          * @since 2.1.0
          */
         "collapse"?: boolean;
         "onAccordionExpand"?: (event: IxCardAccordionCustomEvent<CardAccordionExpandChangeEvent>) => void;
     }
-    /**
-     * @since 1.6.0
-     */
     interface IxCardContent {
     }
-    /**
-     * @since 1.6.0
-     */
     interface IxCardList {
         /**
           * Collapse the list
@@ -5356,7 +5017,6 @@ declare namespace LocalJSX {
         "collapse"?: boolean;
         /**
           * Hide the show all button
-          * @since 2.2.0
          */
         "hideShowAll"?: boolean;
         /**
@@ -5404,9 +5064,6 @@ declare namespace LocalJSX {
          */
         "suppressOverflowHandling"?: boolean;
     }
-    /**
-     * @since 1.6.0
-     */
     interface IxCardTitle {
     }
     interface IxCategoryFilter {
@@ -5479,7 +5136,6 @@ declare namespace LocalJSX {
         "repeatCategories"?: boolean;
         /**
           * If set categories will always be filtered via the respective logical operator. Toggling of the operator will not be available to the user.
-          * @since 2.2.0
          */
         "staticOperator"?: LogicalFilterOperator;
         /**
@@ -5489,7 +5145,6 @@ declare namespace LocalJSX {
         "tmpDisableScrollIntoView"?: boolean;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface IxCheckbox {
@@ -5531,7 +5186,6 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface IxCheckboxGroup {
@@ -5591,7 +5245,6 @@ declare namespace LocalJSX {
         "icon"?: string;
         /**
           * Fire event if close button is clicked
-          * @since 1.5.0
          */
         "onCloseChip"?: (event: IxChipCustomEvent<any>) => void;
         /**
@@ -5615,9 +5268,6 @@ declare namespace LocalJSX {
     | 'success'
     | 'custom';
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxCol {
         /**
           * Size of the column
@@ -5636,9 +5286,6 @@ declare namespace LocalJSX {
          */
         "sizeSm"?: ColumnSize;
     }
-    /**
-     * @since 2.1.0
-     */
     interface IxContent {
     }
     interface IxContentHeader {
@@ -5675,9 +5322,6 @@ declare namespace LocalJSX {
          */
         "itemName": string;
     }
-    /**
-     * @since 2.6.0
-     */
     interface IxCustomField {
         /**
           * Show text below the field component which show additional information
@@ -5712,9 +5356,6 @@ declare namespace LocalJSX {
          */
         "warningText"?: string;
     }
-    /**
-     * @since 2.1.0
-     */
     interface IxDateDropdown {
         /**
           * Controls whether the user is allowed to pick custom date ranges in the component. When set to 'true', the user can select a custom date range using the date picker. When set to 'false', only predefined time date ranges are available for selection.
@@ -5730,7 +5371,6 @@ declare namespace LocalJSX {
         "dateRangeOptions"?: DateDropdownOption[];
         /**
           * Disable the button that opens the dropdown containing the date picker.
-          * @since 2.3.0
          */
         "disabled"?: boolean;
         /**
@@ -5764,7 +5404,6 @@ declare namespace LocalJSX {
         "loading"?: boolean;
         /**
           * Locale identifier (e.g. 'en' or 'de').
-          * @since 2.6.0
          */
         "locale"?: string;
         /**
@@ -5803,12 +5442,10 @@ declare namespace LocalJSX {
         "variant"?: ButtonVariant1;
         /**
           * The index of which day to start the week on, based on the Locale#weekdays array. E.g. if the locale is en-us, weekStartIndex = 1 results in starting the week on monday.
-          * @since 2.6.0
          */
         "weekStartIndex"?: number;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface IxDateInput {
@@ -5842,7 +5479,6 @@ declare namespace LocalJSX {
         "label"?: string;
         /**
           * Locale identifier (e.g. 'en' or 'de').
-          * @since 2.6.0
          */
         "locale"?: string;
         /**
@@ -5904,42 +5540,34 @@ declare namespace LocalJSX {
         "format"?: string;
         /**
           * The selected starting date. If the date-picker-rework is not in range mode this is the selected date. Format has to match the `format` property.
-          * @since 1.1.0
          */
         "from"?: string | undefined;
         /**
           * Text of date select button
-          * @since 2.1.0
          */
         "i18nDone"?: string;
         /**
           * Locale identifier (e.g. 'en' or 'de').
-          * @since 2.1.0
          */
         "locale"?: string;
         /**
           * The latest date that can be selected by the date picker. If not set there will be no restriction.
-          * @since 1.1.0
          */
         "maxDate"?: string;
         /**
           * The earliest date that can be selected by the date picker. If not set there will be no restriction.
-          * @since 1.1.0
          */
         "minDate"?: string;
         /**
           * Triggers if the date selection changes. Note: Since 2.0.0 `dateChange` does not dispatch detail property as `string`
-          * @since 2.1.0
          */
         "onDateChange"?: (event: IxDatePickerCustomEvent<DateChangeEvent>) => void;
         /**
           * Triggers if the date selection changes. Only triggered if date-picker-rework is in range mode.
-          * @since 2.1.0
          */
         "onDateRangeChange"?: (event: IxDatePickerCustomEvent<DateChangeEvent>) => void;
         /**
           * Date selection confirmed via button action
-          * @since 1.1.0
          */
         "onDateSelect"?: (event: IxDatePickerCustomEvent<DateChangeEvent>) => void;
         /**
@@ -5954,13 +5582,11 @@ declare namespace LocalJSX {
         "standaloneAppearance"?: boolean;
         /**
           * The selected end date. If the the date-picker-rework is not in range mode this property has no impact. Format has to match the `format` property.
-          * @since 1.1.0
          */
         "to"?: string | undefined;
         "today"?: string;
         /**
           * The index of which day to start the week on, based on the Locale#weekdays array. E.g. if the locale is en-us, weekStartIndex = 1 results in starting the week on monday.
-          * @since 2.1.0
          */
         "weekStartIndex"?: number;
     }
@@ -5978,17 +5604,14 @@ declare namespace LocalJSX {
     interface IxDatetimePicker {
         /**
           * Date format string. See {@link "https://moment.github.io/luxon/#/formatting?id=table-of-tokens"} for all available tokens.
-          * @since 1.1.0
          */
         "dateFormat"?: string;
         /**
           * The selected starting date. If the picker is not in range mode this is the selected date. Format has to match the `format` property.
-          * @since 1.1.0
          */
         "from"?: string;
         /**
           * Text of date select button
-          * @since 2.1.0
          */
         "i18nDone"?: string;
         /**
@@ -5998,32 +5621,26 @@ declare namespace LocalJSX {
         "i18nTime"?: string;
         /**
           * Format of time string See {@link "https://moment.github.io/luxon/#/formatting?id=table-of-tokens"} for all available tokens.
-          * @since 2.1.0
          */
         "locale"?: string;
         /**
           * The latest date that can be selected by the date picker. If not set there will be no restriction.
-          * @since 1.1.0
          */
         "maxDate"?: string;
         /**
           * The earliest date that can be selected by the date picker. If not set there will be no restriction.
-          * @since 1.1.0
          */
         "minDate"?: string;
         /**
           * Date change
-          * @since 1.1.0
          */
         "onDateChange"?: (event: IxDatetimePickerCustomEvent<DateTimeDateChangeEvent>) => void;
         /**
           * Datetime selection event is fired after confirm button is pressed
-          * @since 1.1.0
          */
         "onDateSelect"?: (event: IxDatetimePickerCustomEvent<DateTimeSelectEvent>) => void;
         /**
           * Time change
-          * @since 1.1.0
          */
         "onTimeChange"?: (event: IxDatetimePickerCustomEvent<string>) => void;
         /**
@@ -6045,7 +5662,6 @@ declare namespace LocalJSX {
         /**
           * Show time reference input Time reference is default aligned with
           * @see { this.timeFormat}
-          * @since 1.1.0
          */
         "showTimeReference"?: boolean;
         /**
@@ -6055,12 +5671,10 @@ declare namespace LocalJSX {
         "showWeekNumbers"?: boolean;
         /**
           * Select time with format string
-          * @since 1.1.0
          */
         "time"?: string;
         /**
           * Time format string. See {@link "https://moment.github.io/luxon/#/formatting?id=table-of-tokens"} for all available tokens.
-          * @since 1.1.0
          */
         "timeFormat"?: string;
         /**
@@ -6069,18 +5683,13 @@ declare namespace LocalJSX {
         "timeReference"?: 'AM' | 'PM';
         /**
           * The selected end date. If the the picker is not in range mode this property has no impact. Format has to match the `format` property.
-          * @since 1.1.0
          */
         "to"?: string;
         /**
           * The index of which day to start the week on, based on the Locale#weekdays array. E.g. if the locale is en-us, weekStartIndex = 1 results in starting the week on monday.
-          * @since 2.1.0
          */
         "weekStartIndex"?: number;
     }
-    /**
-     * @since 1.4.0
-     */
     interface IxDivider {
     }
     interface IxDrawer {
@@ -6162,7 +5771,6 @@ declare namespace LocalJSX {
         "show"?: boolean;
         /**
           * Suppress the automatic placement of the dropdown.
-          * @since 2.0.0
          */
         "suppressAutomaticPlacement"?: boolean;
         "suppressOverflowBehavior"?: boolean;
@@ -6171,13 +5779,9 @@ declare namespace LocalJSX {
          */
         "trigger"?: ElementReference;
     }
-    /**
-     * @since 1.3.0
-     */
     interface IxDropdownButton {
         /**
           * Controls if the dropdown will be closed in response to a click event depending on the position of the event relative to the dropdown.
-          * @since 2.1.0
          */
         "closeBehavior"?: 'inside' | 'outside' | 'both' | boolean;
         /**
@@ -6202,7 +5806,6 @@ declare namespace LocalJSX {
         "outline"?: boolean;
         /**
           * Placement of the dropdown
-          * @since 2.0.0
          */
         "placement"?: AlignedPlacement;
         /**
@@ -6210,9 +5813,6 @@ declare namespace LocalJSX {
          */
         "variant"?: DropdownButtonVariant;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxDropdownHeader {
         /**
           * Display name of the header
@@ -6244,14 +5844,8 @@ declare namespace LocalJSX {
         "onItemClick"?: (event: IxDropdownItemCustomEvent<HTMLIxDropdownItemElement>) => void;
         "suppressChecked"?: boolean;
     }
-    /**
-     * @since 1.4.0
-     */
     interface IxDropdownQuickActions {
     }
-    /**
-     * @since 1.6.0
-     */
     interface IxEmptyState {
         /**
           * Optional empty state action
@@ -6322,7 +5916,6 @@ declare namespace LocalJSX {
     interface IxExpandingSearch {
         /**
           * If true the search field will fill all available horizontal space of it's parent container when expanded.
-          * @since 1.6.0
          */
         "fullWidth"?: boolean;
         /**
@@ -6439,14 +6032,12 @@ declare namespace LocalJSX {
         "onCloseClick"?: (event: IxFilterChipCustomEvent<void>) => void;
         /**
           * If true the filter chip will be in readonly mode
-          * @since 2.0.0
          */
         "readonly"?: boolean;
     }
     interface IxFlipTile {
         /**
           * Height interpreted as REM
-          * @since 1.5.0
          */
         "height"?: number | 'auto';
         /**
@@ -6465,7 +6056,6 @@ declare namespace LocalJSX {
         "state"?: FlipTileState;
         /**
           * Width interpreted as REM
-          * @since 1.5.0
          */
         "width"?: number | 'auto';
     }
@@ -6582,7 +6172,6 @@ declare namespace LocalJSX {
     interface IxIconButton {
         /**
           * Accessibility label for the icon button Will be set as aria-label on the nested HTML button element
-          * @since 2.1.0
          */
         "a11yLabel"?: string;
         /**
@@ -6603,7 +6192,6 @@ declare namespace LocalJSX {
         "iconColor"?: string;
         /**
           * Loading button
-          * @since 2.0.0
          */
         "loading"?: boolean;
         /**
@@ -6624,13 +6212,9 @@ declare namespace LocalJSX {
         "type"?: 'button' | 'submit';
         /**
           * Variant of button
-          * @since 2.3.0 - variant danger
          */
         "variant"?: IconButtonVariant;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxIconToggleButton {
         /**
           * Disable the button
@@ -6670,7 +6254,6 @@ declare namespace LocalJSX {
         "variant"?: ButtonVariant1;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface IxInput {
@@ -6765,9 +6348,6 @@ declare namespace LocalJSX {
      */
     interface IxInputGroup {
     }
-    /**
-     * @since 1.6.0
-     */
     interface IxKeyValue {
         /**
           * Optional key value icon
@@ -6786,9 +6366,6 @@ declare namespace LocalJSX {
          */
         "value"?: string;
     }
-    /**
-     * @since 1.6.0
-     */
     interface IxKeyValueList {
         /**
           * Optional striped key value list style
@@ -6802,9 +6379,6 @@ declare namespace LocalJSX {
         "unit"?: string;
         "value"?: string | number;
     }
-    /**
-     * @since 2.6.0
-     */
     interface IxLayoutAuto {
         /**
           * Defines the layout of the form.
@@ -6814,9 +6388,6 @@ declare namespace LocalJSX {
     columns: number;
   }[];
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxLayoutGrid {
         /**
           * Overwrite the default number of columns. Choose between 2 and 12 columns.
@@ -6831,9 +6402,6 @@ declare namespace LocalJSX {
          */
         "noMargin"?: boolean;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxLinkButton {
         /**
           * Disable the link button
@@ -6961,7 +6529,6 @@ declare namespace LocalJSX {
         "showSettings"?: boolean;
         /**
           * If set the menu will be expanded initially. This will only take effect at the breakpoint 'lg'.
-          * @since 2.2.0
          */
         "startExpanded"?: boolean;
     }
@@ -7034,12 +6601,10 @@ declare namespace LocalJSX {
         "i18nLogout"?: string;
         /**
           * Display a avatar image
-          * @since 1.4.0
          */
         "image"?: string;
         /**
           * Display the initials of the user. Will be overwritten by image
-          * @since 1.4.0
          */
         "initials"?: string;
         /**
@@ -7048,7 +6613,6 @@ declare namespace LocalJSX {
         "onLogoutClick"?: (event: IxMenuAvatarCustomEvent<any>) => void;
         /**
           * Control the visibility of the logout button
-          * @since 2.1.0
          */
         "showLogoutButton"?: boolean;
         /**
@@ -7070,9 +6634,6 @@ declare namespace LocalJSX {
          */
         "onItemClick"?: (event: IxMenuAvatarItemCustomEvent<MouseEvent>) => void;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxMenuCategory {
         /**
           * Icon of the category
@@ -7131,7 +6692,6 @@ declare namespace LocalJSX {
         "isCategory"?: boolean;
         /**
           * Label of the menu item. Will also be used as tooltip text
-          * @since 2.2.0
          */
         "label"?: string;
         /**
@@ -7214,7 +6774,6 @@ declare namespace LocalJSX {
         "centered"?: boolean;
         /**
           * Dismiss modal on backdrop click
-          * @since 2.0.0
          */
         "closeOnBackdropClick"?: boolean;
         /**
@@ -7231,23 +6790,13 @@ declare namespace LocalJSX {
         "onDialogDismiss"?: (event: IxModalCustomEvent<any>) => void;
         /**
           * Modal size
-          * @since 2.0.0
          */
         "size"?: IxModalSize;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxModalContent {
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxModalFooter {
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxModalHeader {
         /**
           * Hide the close button
@@ -7269,7 +6818,6 @@ declare namespace LocalJSX {
     interface IxModalLoading {
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface IxNumberInput {
@@ -7358,9 +6906,6 @@ declare namespace LocalJSX {
          */
         "warningText"?: string;
     }
-    /**
-     * @since 1.5.0
-     */
     interface IxPagination {
         /**
           * Advanced mode
@@ -7403,9 +6948,6 @@ declare namespace LocalJSX {
          */
         "showItemCount"?: boolean;
     }
-    /**
-     * @since 2.1.0
-     */
     interface IxPane {
         /**
           * Toggle the border of the pane. Defaults to the borderless attribute of the pane layout. If used standalone it defaults to false.
@@ -7462,9 +7004,6 @@ declare namespace LocalJSX {
          */
         "variant"?: 'floating' | 'inline';
     }
-    /**
-     * @since 2.1.0
-     */
     interface IxPaneLayout {
         /**
           * Set the default border state for all panes in the layout
@@ -7517,13 +7056,9 @@ declare namespace LocalJSX {
     | 'success'
     | 'custom';
     }
-    /**
-     * @since 1.6.0
-     */
     interface IxPushCard {
         /**
           * Collapse the card
-          * @since 2.1.0
          */
         "collapse"?: boolean;
         /**
@@ -7548,7 +7083,6 @@ declare namespace LocalJSX {
         "variant"?: PushCardVariant;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface IxRadio {
@@ -7582,7 +7116,6 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface IxRadioGroup {
@@ -7627,9 +7160,6 @@ declare namespace LocalJSX {
          */
         "warningText"?: string;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxRow {
     }
     /**
@@ -7646,12 +7176,10 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         /**
           * The maximum width of the dropdown element with value and unit (e.g. "200px" or "12.5rem"). By default the maximum width of the dropdown element is set to 100%.
-          * @since 2.7.0
          */
         "dropdownMaxWidth"?: string;
         /**
           * The width of the dropdown element with value and unit (e.g. "200px" or "12.5rem").
-          * @since 2.7.0
          */
         "dropdownWidth"?: string;
         /**
@@ -7660,17 +7188,14 @@ declare namespace LocalJSX {
         "editable"?: boolean;
         /**
           * Helper text for the select component
-          * @since 2.6.0
          */
         "helperText"?: string;
         /**
           * Hide list header
-          * @since 1.5.0
          */
         "hideListHeader"?: boolean;
         /**
           * Information inside of dropdown if no items where found with current filter text
-          * @since 1.5.0
          */
         "i18nNoMatches"?: string;
         /**
@@ -7687,17 +7212,14 @@ declare namespace LocalJSX {
         "i18nSelectListHeader"?: string;
         /**
           * Info text for the select component
-          * @since 2.6.0
          */
         "infoText"?: string;
         /**
           * Error text for the select component
-          * @since 2.6.0
          */
         "invalidText"?: string;
         /**
           * Label for the select component
-          * @since 2.6.0
          */
         "label"?: string;
         /**
@@ -7706,7 +7228,6 @@ declare namespace LocalJSX {
         "mode"?: 'single' | 'multiple';
         /**
           * A string that represents the element's name attribute, containing a name that identifies the element when submitting the form.
-          * @since 2.6.0
          */
         "name"?: string;
         /**
@@ -7715,7 +7236,6 @@ declare namespace LocalJSX {
         "onAddItem"?: (event: IxSelectCustomEvent<string>) => void;
         /**
           * Event dispatched whenever the text input changes.
-          * @since 2.0.0
          */
         "onInputChange"?: (event: IxSelectCustomEvent<string>) => void;
         /**
@@ -7724,7 +7244,6 @@ declare namespace LocalJSX {
         "onIxBlur"?: (event: IxSelectCustomEvent<void>) => void;
         /**
           * Value changed
-          * @since 2.0.0
          */
         "onValueChange"?: (event: IxSelectCustomEvent<string | string[]>) => void;
         /**
@@ -7733,27 +7252,22 @@ declare namespace LocalJSX {
         "readonly"?: boolean;
         /**
           * A Boolean attribute indicating that an option with a non-empty string value must be selected
-          * @since 2.6.0
          */
         "required"?: boolean;
         /**
           * Show helper, error, info, warning text as tooltip
-          * @since 2.6.0
          */
         "showTextAsTooltip"?: boolean;
         /**
           * Valid text for the select component
-          * @since 2.6.0
          */
         "validText"?: string;
         /**
           * Current selected value. This corresponds to the value property of ix-select-items
-          * @since 2.0.0
          */
         "value"?: string | string[];
         /**
           * Warning text for the select component
-          * @since 2.6.0
          */
         "warningText"?: string;
     }
@@ -7776,9 +7290,6 @@ declare namespace LocalJSX {
          */
         "value": string;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxSlider {
         /**
           * Show control as disabled
@@ -7833,7 +7344,6 @@ declare namespace LocalJSX {
     interface IxSplitButton {
         /**
           * Controls if the dropdown will be closed in response to a click event depending on the position of the event relative to the dropdown.
-          * @since 2.3.0
          */
         "closeBehavior"?: CloseBehavior;
         /**
@@ -7892,7 +7402,6 @@ declare namespace LocalJSX {
         "layout"?: 'auto' | 'stretched';
         /**
           * Emitted when the tab is clicked.
-          * @since 2.0.0
          */
         "onTabClick"?: (event: IxTabItemCustomEvent<TabClickDetail>) => void;
         /**
@@ -7919,7 +7428,6 @@ declare namespace LocalJSX {
         "layout"?: 'auto' | 'stretched';
         /**
           * `selected` property changed
-          * @since 2.0.0
          */
         "onSelectedChange"?: (event: IxTabsCustomEvent<number>) => void;
         /**
@@ -7940,7 +7448,6 @@ declare namespace LocalJSX {
         "small"?: boolean;
     }
     /**
-     * @since 2.6.0
      * @form-ready 2.6.0
      */
     interface IxTextarea {
@@ -8050,7 +7557,6 @@ declare namespace LocalJSX {
         "corners"?: TimePickerCorners;
         /**
           * Format of time string See {@link "https://moment.github.io/luxon/#/formatting?id=table-of-tokens"} for all available tokens.
-          * @since 1.1.0
          */
         "format"?: string;
         /**
@@ -8079,17 +7585,14 @@ declare namespace LocalJSX {
         "standaloneAppearance"?: boolean;
         /**
           * Text of date select button
-          * @since 1.1.0
          */
         "textSelectTime"?: string;
         /**
           * Text for top label
-          * @since 2.1.0
          */
         "textTime"?: string;
         /**
           * Select time with format string Format has to match the `format` property.
-          * @since 1.1.0
          */
         "time"?: string;
         /**
@@ -8182,9 +7685,6 @@ declare namespace LocalJSX {
          */
         "value"?: string;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxToggleButton {
         /**
           * Disable the button
@@ -8219,9 +7719,6 @@ declare namespace LocalJSX {
          */
         "variant"?: ButtonVariant1;
     }
-    /**
-     * @since 1.4.0
-     */
     interface IxTooltip {
         "animationFrame"?: boolean;
         /**
@@ -8235,7 +7732,6 @@ declare namespace LocalJSX {
         "interactive"?: boolean;
         /**
           * Initial placement of the tooltip. If the selected placement doesn't have enough space, the tooltip will be repositioned to another location.
-          * @since 1.5.0
          */
         "placement"?: 'top' | 'right' | 'bottom' | 'left';
         "showDelay"?: number;
@@ -8259,7 +7755,6 @@ declare namespace LocalJSX {
         "onContextChange"?: (event: IxTreeCustomEvent<TreeContext>) => void;
         /**
           * Node clicked event
-          * @since 1.5.0
          */
         "onNodeClicked"?: (event: IxTreeCustomEvent<string>) => void;
         /**
@@ -8268,7 +7763,6 @@ declare namespace LocalJSX {
         "onNodeRemoved"?: (event: IxTreeCustomEvent<any>) => void;
         /**
           * Node toggled event
-          * @since 1.5.0
          */
         "onNodeToggled"?: (event: IxTreeCustomEvent<{ id: string; isExpanded: boolean }>) => void;
         /**
@@ -8313,9 +7807,6 @@ declare namespace LocalJSX {
          */
         "text"?: string;
     }
-    /**
-     * @since 2.0.0
-     */
     interface IxTypography {
         /**
           * Display text bold
@@ -8398,7 +7889,6 @@ declare namespace LocalJSX {
         "placement"?: Side;
         /**
           * Suppress the automatic placement of the dropdown.
-          * @since 2.0.0
          */
         "suppressAutomaticPlacement"?: boolean;
     }
@@ -8565,107 +8055,53 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
-            /**
-             * @since 1.6.0
-             */
             "ix-action-card": LocalJSX.IxActionCard & JSXBase.HTMLAttributes<HTMLIxActionCardElement>;
-            /**
-             * @since 2.1.0
-             */
             "ix-application": LocalJSX.IxApplication & JSXBase.HTMLAttributes<HTMLIxApplicationElement>;
             "ix-application-header": LocalJSX.IxApplicationHeader & JSXBase.HTMLAttributes<HTMLIxApplicationHeaderElement>;
             "ix-application-sidebar": LocalJSX.IxApplicationSidebar & JSXBase.HTMLAttributes<HTMLIxApplicationSidebarElement>;
             "ix-application-switch-modal": LocalJSX.IxApplicationSwitchModal & JSXBase.HTMLAttributes<HTMLIxApplicationSwitchModalElement>;
-            /**
-             * @since 2.0.0
-             */
             "ix-avatar": LocalJSX.IxAvatar & JSXBase.HTMLAttributes<HTMLIxAvatarElement>;
             "ix-basic-navigation": LocalJSX.IxBasicNavigation & JSXBase.HTMLAttributes<HTMLIxBasicNavigationElement>;
             "ix-blind": LocalJSX.IxBlind & JSXBase.HTMLAttributes<HTMLIxBlindElement>;
             "ix-breadcrumb": LocalJSX.IxBreadcrumb & JSXBase.HTMLAttributes<HTMLIxBreadcrumbElement>;
             "ix-breadcrumb-item": LocalJSX.IxBreadcrumbItem & JSXBase.HTMLAttributes<HTMLIxBreadcrumbItemElement>;
             "ix-button": LocalJSX.IxButton & JSXBase.HTMLAttributes<HTMLIxButtonElement>;
-            /**
-             * @since 1.6.0
-             */
             "ix-card": LocalJSX.IxCard & JSXBase.HTMLAttributes<HTMLIxCardElement>;
-            /**
-             * @since 1.6.0
-             */
             "ix-card-accordion": LocalJSX.IxCardAccordion & JSXBase.HTMLAttributes<HTMLIxCardAccordionElement>;
-            /**
-             * @since 1.6.0
-             */
             "ix-card-content": LocalJSX.IxCardContent & JSXBase.HTMLAttributes<HTMLIxCardContentElement>;
-            /**
-             * @since 1.6.0
-             */
             "ix-card-list": LocalJSX.IxCardList & JSXBase.HTMLAttributes<HTMLIxCardListElement>;
-            /**
-             * @since 1.6.0
-             */
             "ix-card-title": LocalJSX.IxCardTitle & JSXBase.HTMLAttributes<HTMLIxCardTitleElement>;
             "ix-category-filter": LocalJSX.IxCategoryFilter & JSXBase.HTMLAttributes<HTMLIxCategoryFilterElement>;
             /**
-             * @since 2.6.0
              * @form-ready 2.6.0
              */
             "ix-checkbox": LocalJSX.IxCheckbox & JSXBase.HTMLAttributes<HTMLIxCheckboxElement>;
             /**
-             * @since 2.6.0
              * @form-ready 2.6.0
              */
             "ix-checkbox-group": LocalJSX.IxCheckboxGroup & JSXBase.HTMLAttributes<HTMLIxCheckboxGroupElement>;
             "ix-chip": LocalJSX.IxChip & JSXBase.HTMLAttributes<HTMLIxChipElement>;
-            /**
-             * @since 2.0.0
-             */
             "ix-col": LocalJSX.IxCol & JSXBase.HTMLAttributes<HTMLIxColElement>;
-            /**
-             * @since 2.1.0
-             */
             "ix-content": LocalJSX.IxContent & JSXBase.HTMLAttributes<HTMLIxContentElement>;
             "ix-content-header": LocalJSX.IxContentHeader & JSXBase.HTMLAttributes<HTMLIxContentHeaderElement>;
             "ix-css-grid": LocalJSX.IxCssGrid & JSXBase.HTMLAttributes<HTMLIxCssGridElement>;
             "ix-css-grid-item": LocalJSX.IxCssGridItem & JSXBase.HTMLAttributes<HTMLIxCssGridItemElement>;
-            /**
-             * @since 2.6.0
-             */
             "ix-custom-field": LocalJSX.IxCustomField & JSXBase.HTMLAttributes<HTMLIxCustomFieldElement>;
-            /**
-             * @since 2.1.0
-             */
             "ix-date-dropdown": LocalJSX.IxDateDropdown & JSXBase.HTMLAttributes<HTMLIxDateDropdownElement>;
             /**
-             * @since 2.6.0
              * @form-ready 2.6.0
              */
             "ix-date-input": LocalJSX.IxDateInput & JSXBase.HTMLAttributes<HTMLIxDateInputElement>;
             "ix-date-picker": LocalJSX.IxDatePicker & JSXBase.HTMLAttributes<HTMLIxDatePickerElement>;
             "ix-date-time-card": LocalJSX.IxDateTimeCard & JSXBase.HTMLAttributes<HTMLIxDateTimeCardElement>;
             "ix-datetime-picker": LocalJSX.IxDatetimePicker & JSXBase.HTMLAttributes<HTMLIxDatetimePickerElement>;
-            /**
-             * @since 1.4.0
-             */
             "ix-divider": LocalJSX.IxDivider & JSXBase.HTMLAttributes<HTMLIxDividerElement>;
             "ix-drawer": LocalJSX.IxDrawer & JSXBase.HTMLAttributes<HTMLIxDrawerElement>;
             "ix-dropdown": LocalJSX.IxDropdown & JSXBase.HTMLAttributes<HTMLIxDropdownElement>;
-            /**
-             * @since 1.3.0
-             */
             "ix-dropdown-button": LocalJSX.IxDropdownButton & JSXBase.HTMLAttributes<HTMLIxDropdownButtonElement>;
-            /**
-             * @since 2.0.0
-             */
             "ix-dropdown-header": LocalJSX.IxDropdownHeader & JSXBase.HTMLAttributes<HTMLIxDropdownHeaderElement>;
             "ix-dropdown-item": LocalJSX.IxDropdownItem & JSXBase.HTMLAttributes<HTMLIxDropdownItemElement>;
-            /**
-             * @since 1.4.0
-             */
             "ix-dropdown-quick-actions": LocalJSX.IxDropdownQuickActions & JSXBase.HTMLAttributes<HTMLIxDropdownQuickActionsElement>;
-            /**
-             * @since 1.6.0
-             */
             "ix-empty-state": LocalJSX.IxEmptyState & JSXBase.HTMLAttributes<HTMLIxEmptyStateElement>;
             "ix-event-list": LocalJSX.IxEventList & JSXBase.HTMLAttributes<HTMLIxEventListElement>;
             "ix-event-list-item": LocalJSX.IxEventListItem & JSXBase.HTMLAttributes<HTMLIxEventListItemElement>;
@@ -8680,12 +8116,8 @@ declare module "@stencil/core" {
             "ix-group-item": LocalJSX.IxGroupItem & JSXBase.HTMLAttributes<HTMLIxGroupItemElement>;
             "ix-helper-text": LocalJSX.IxHelperText & JSXBase.HTMLAttributes<HTMLIxHelperTextElement>;
             "ix-icon-button": LocalJSX.IxIconButton & JSXBase.HTMLAttributes<HTMLIxIconButtonElement>;
-            /**
-             * @since 2.0.0
-             */
             "ix-icon-toggle-button": LocalJSX.IxIconToggleButton & JSXBase.HTMLAttributes<HTMLIxIconToggleButtonElement>;
             /**
-             * @since 2.6.0
              * @form-ready 2.6.0
              */
             "ix-input": LocalJSX.IxInput & JSXBase.HTMLAttributes<HTMLIxInputElement>;
@@ -8694,26 +8126,11 @@ declare module "@stencil/core" {
              * Use the 'ix-input' component instead
              */
             "ix-input-group": LocalJSX.IxInputGroup & JSXBase.HTMLAttributes<HTMLIxInputGroupElement>;
-            /**
-             * @since 1.6.0
-             */
             "ix-key-value": LocalJSX.IxKeyValue & JSXBase.HTMLAttributes<HTMLIxKeyValueElement>;
-            /**
-             * @since 1.6.0
-             */
             "ix-key-value-list": LocalJSX.IxKeyValueList & JSXBase.HTMLAttributes<HTMLIxKeyValueListElement>;
             "ix-kpi": LocalJSX.IxKpi & JSXBase.HTMLAttributes<HTMLIxKpiElement>;
-            /**
-             * @since 2.6.0
-             */
             "ix-layout-auto": LocalJSX.IxLayoutAuto & JSXBase.HTMLAttributes<HTMLIxLayoutAutoElement>;
-            /**
-             * @since 2.0.0
-             */
             "ix-layout-grid": LocalJSX.IxLayoutGrid & JSXBase.HTMLAttributes<HTMLIxLayoutGridElement>;
-            /**
-             * @since 2.0.0
-             */
             "ix-link-button": LocalJSX.IxLinkButton & JSXBase.HTMLAttributes<HTMLIxLinkButtonElement>;
             "ix-map-navigation": LocalJSX.IxMapNavigation & JSXBase.HTMLAttributes<HTMLIxMapNavigationElement>;
             "ix-map-navigation-overlay": LocalJSX.IxMapNavigationOverlay & JSXBase.HTMLAttributes<HTMLIxMapNavigationOverlayElement>;
@@ -8723,9 +8140,6 @@ declare module "@stencil/core" {
             "ix-menu-about-news": LocalJSX.IxMenuAboutNews & JSXBase.HTMLAttributes<HTMLIxMenuAboutNewsElement>;
             "ix-menu-avatar": LocalJSX.IxMenuAvatar & JSXBase.HTMLAttributes<HTMLIxMenuAvatarElement>;
             "ix-menu-avatar-item": LocalJSX.IxMenuAvatarItem & JSXBase.HTMLAttributes<HTMLIxMenuAvatarItemElement>;
-            /**
-             * @since 2.0.0
-             */
             "ix-menu-category": LocalJSX.IxMenuCategory & JSXBase.HTMLAttributes<HTMLIxMenuCategoryElement>;
             "ix-menu-expand-icon": LocalJSX.IxMenuExpandIcon & JSXBase.HTMLAttributes<HTMLIxMenuExpandIconElement>;
             "ix-menu-item": LocalJSX.IxMenuItem & JSXBase.HTMLAttributes<HTMLIxMenuItemElement>;
@@ -8733,70 +8147,39 @@ declare module "@stencil/core" {
             "ix-menu-settings-item": LocalJSX.IxMenuSettingsItem & JSXBase.HTMLAttributes<HTMLIxMenuSettingsItemElement>;
             "ix-message-bar": LocalJSX.IxMessageBar & JSXBase.HTMLAttributes<HTMLIxMessageBarElement>;
             "ix-modal": LocalJSX.IxModal & JSXBase.HTMLAttributes<HTMLIxModalElement>;
-            /**
-             * @since 2.0.0
-             */
             "ix-modal-content": LocalJSX.IxModalContent & JSXBase.HTMLAttributes<HTMLIxModalContentElement>;
-            /**
-             * @since 2.0.0
-             */
             "ix-modal-footer": LocalJSX.IxModalFooter & JSXBase.HTMLAttributes<HTMLIxModalFooterElement>;
-            /**
-             * @since 2.0.0
-             */
             "ix-modal-header": LocalJSX.IxModalHeader & JSXBase.HTMLAttributes<HTMLIxModalHeaderElement>;
             "ix-modal-loading": LocalJSX.IxModalLoading & JSXBase.HTMLAttributes<HTMLIxModalLoadingElement>;
             /**
-             * @since 2.6.0
              * @form-ready 2.6.0
              */
             "ix-number-input": LocalJSX.IxNumberInput & JSXBase.HTMLAttributes<HTMLIxNumberInputElement>;
-            /**
-             * @since 1.5.0
-             */
             "ix-pagination": LocalJSX.IxPagination & JSXBase.HTMLAttributes<HTMLIxPaginationElement>;
-            /**
-             * @since 2.1.0
-             */
             "ix-pane": LocalJSX.IxPane & JSXBase.HTMLAttributes<HTMLIxPaneElement>;
-            /**
-             * @since 2.1.0
-             */
             "ix-pane-layout": LocalJSX.IxPaneLayout & JSXBase.HTMLAttributes<HTMLIxPaneLayoutElement>;
             "ix-pill": LocalJSX.IxPill & JSXBase.HTMLAttributes<HTMLIxPillElement>;
-            /**
-             * @since 1.6.0
-             */
             "ix-push-card": LocalJSX.IxPushCard & JSXBase.HTMLAttributes<HTMLIxPushCardElement>;
             /**
-             * @since 2.6.0
              * @form-ready 2.6.0
              */
             "ix-radio": LocalJSX.IxRadio & JSXBase.HTMLAttributes<HTMLIxRadioElement>;
             /**
-             * @since 2.6.0
              * @form-ready 2.6.0
              */
             "ix-radio-group": LocalJSX.IxRadioGroup & JSXBase.HTMLAttributes<HTMLIxRadioGroupElement>;
-            /**
-             * @since 2.0.0
-             */
             "ix-row": LocalJSX.IxRow & JSXBase.HTMLAttributes<HTMLIxRowElement>;
             /**
              * @form-ready 2.6.0
              */
             "ix-select": LocalJSX.IxSelect & JSXBase.HTMLAttributes<HTMLIxSelectElement>;
             "ix-select-item": LocalJSX.IxSelectItem & JSXBase.HTMLAttributes<HTMLIxSelectItemElement>;
-            /**
-             * @since 2.0.0
-             */
             "ix-slider": LocalJSX.IxSlider & JSXBase.HTMLAttributes<HTMLIxSliderElement>;
             "ix-spinner": LocalJSX.IxSpinner & JSXBase.HTMLAttributes<HTMLIxSpinnerElement>;
             "ix-split-button": LocalJSX.IxSplitButton & JSXBase.HTMLAttributes<HTMLIxSplitButtonElement>;
             "ix-tab-item": LocalJSX.IxTabItem & JSXBase.HTMLAttributes<HTMLIxTabItemElement>;
             "ix-tabs": LocalJSX.IxTabs & JSXBase.HTMLAttributes<HTMLIxTabsElement>;
             /**
-             * @since 2.6.0
              * @form-ready 2.6.0
              */
             "ix-textarea": LocalJSX.IxTextarea & JSXBase.HTMLAttributes<HTMLIxTextareaElement>;
@@ -8808,19 +8191,10 @@ declare module "@stencil/core" {
              * @form-ready 2.6.0
              */
             "ix-toggle": LocalJSX.IxToggle & JSXBase.HTMLAttributes<HTMLIxToggleElement>;
-            /**
-             * @since 2.0.0
-             */
             "ix-toggle-button": LocalJSX.IxToggleButton & JSXBase.HTMLAttributes<HTMLIxToggleButtonElement>;
-            /**
-             * @since 1.4.0
-             */
             "ix-tooltip": LocalJSX.IxTooltip & JSXBase.HTMLAttributes<HTMLIxTooltipElement>;
             "ix-tree": LocalJSX.IxTree & JSXBase.HTMLAttributes<HTMLIxTreeElement>;
             "ix-tree-item": LocalJSX.IxTreeItem & JSXBase.HTMLAttributes<HTMLIxTreeItemElement>;
-            /**
-             * @since 2.0.0
-             */
             "ix-typography": LocalJSX.IxTypography & JSXBase.HTMLAttributes<HTMLIxTypographyElement>;
             "ix-upload": LocalJSX.IxUpload & JSXBase.HTMLAttributes<HTMLIxUploadElement>;
             /**

--- a/packages/core/src/components/action-card/action-card.tsx
+++ b/packages/core/src/components/action-card/action-card.tsx
@@ -12,9 +12,6 @@ import { CardVariant } from '../card/card';
 
 export type ActionCardVariant = CardVariant;
 
-/**
- * @since 1.6.0
- */
 @Component({
   tag: 'ix-action-card',
   styleUrl: 'action-card.scss',

--- a/packages/core/src/components/application-header/application-header.tsx
+++ b/packages/core/src/components/application-header/application-header.tsx
@@ -53,22 +53,16 @@ export class ApplicationHeader {
    *
    * When the application header is utilized outside the application frame, the menu toggle button is displayed.
    * Conversely, if the header is within the application frame, this property is ineffective.
-   *
-   * @since 2.5.0
    */
   @Prop({ mutable: true }) showMenu?: boolean = false;
 
   /**
    * Event emitted when the menu toggle button is clicked
-   *
-   * @since 2.5.0
    */
   @Event() menuToggle!: EventEmitter<boolean>;
 
   /**
    * Event emitted when the app switch button is clicked
-   *
-   * @since 3.0.0
    */
   @Event() openAppSwitch!: EventEmitter<void>;
 

--- a/packages/core/src/components/application/application.tsx
+++ b/packages/core/src/components/application/application.tsx
@@ -20,9 +20,6 @@ import { hasSlottedElements } from '../utils/shadow-dom';
 import { IxTheme, themeSwitcher } from '../utils/theme-switcher';
 import { Disposable } from '../utils/typed-event';
 
-/**
- * @since 2.1.0
- */
 @Component({
   tag: 'ix-application',
   styleUrl: 'application.scss',

--- a/packages/core/src/components/avatar/avatar.tsx
+++ b/packages/core/src/components/avatar/avatar.tsx
@@ -88,9 +88,6 @@ function UserInfo(props: {
   );
 }
 
-/**
- * @since 2.0.0
- */
 @Component({
   tag: 'ix-avatar',
   styleUrl: 'avatar.scss',
@@ -114,16 +111,12 @@ export class Avatar {
   /**
    * If set an info card displaying the username will be placed inside the dropdown.
    * Note: Only working if avatar is part of the ix-application-header
-   *
-   * @since 2.1.0
    */
   @Prop() username?: string;
 
   /**
    * Optional description text that will be displayed underneath the username.
    * Note: Only working if avatar is part of the ix-application-header
-   *
-   * @since 2.1.0
    */
   @Prop() extra?: string;
 

--- a/packages/core/src/components/blind/blind.tsx
+++ b/packages/core/src/components/blind/blind.tsx
@@ -45,19 +45,16 @@ export class Blind {
 
   /**
    * Secondary label inside blind header
-   * @since 2.0.0
    */
   @Prop() sublabel?: string;
 
   /**
    * Optional icon to be displayed next to the header label
-   * @since 1.5.0
    */
   @Prop() icon?: string;
 
   /**
    * Blind variant
-   * @since 2.0.0
    */
   @Prop() variant: BlindVariant = 'filled';
 

--- a/packages/core/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/core/src/components/breadcrumb/breadcrumb.tsx
@@ -58,8 +58,6 @@ export class Breadcrumb {
   /**
    * Accessibility label for the dropdown button (ellipsis icon) used to access the dropdown list
    * with conditionally hidden previous items
-   *
-   * @since 2.0.0
    */
   @Prop() ariaLabelPreviousButton = 'previous';
 

--- a/packages/core/src/components/button/button.tsx
+++ b/packages/core/src/components/button/button.tsx
@@ -21,7 +21,6 @@ export type ButtonVariant = 'danger' | 'primary' | 'secondary';
 export class Button implements IxButtonComponent {
   /**
    * Button variant
-   * @since 2.3.0 - variant danger
    */
   @Prop() variant: ButtonVariant = 'primary';
 
@@ -47,8 +46,6 @@ export class Button implements IxButtonComponent {
 
   /**
    * Loading button
-   *
-   * @since 2.0.0
    */
   @Prop() loading: boolean = false;
 

--- a/packages/core/src/components/card-accordion/card-accordion.tsx
+++ b/packages/core/src/components/card-accordion/card-accordion.tsx
@@ -21,9 +21,6 @@ export type CardAccordionExpandChangeEvent = {
   nativeEvent: Event;
 };
 
-/**
- * @since 1.6.0
- */
 @Component({
   tag: 'ix-card-accordion',
   styleUrl: 'card-accordion.scss',
@@ -32,7 +29,6 @@ export type CardAccordionExpandChangeEvent = {
 export class CardAccordion {
   /**
    * Collapse the card
-   * @since 2.1.0
    */
   @Prop() collapse = false;
 

--- a/packages/core/src/components/card-content/card-content.tsx
+++ b/packages/core/src/components/card-content/card-content.tsx
@@ -1,8 +1,5 @@
 import { Component, h, Host } from '@stencil/core';
 
-/**
- * @since 1.6.0
- */
 @Component({
   tag: 'ix-card-content',
   styleUrl: 'card-content.scss',

--- a/packages/core/src/components/card-list/card-list.tsx
+++ b/packages/core/src/components/card-list/card-list.tsx
@@ -56,9 +56,6 @@ function CardListTitle(props: {
   );
 }
 
-/**
- * @since 1.6.0
- */
 @Component({
   tag: 'ix-card-list',
   styleUrl: 'card-list.scss',
@@ -99,8 +96,6 @@ export class CardList {
 
   /**
    * Hide the show all button
-   *
-   * @since 2.2.0
    */
   @Prop() hideShowAll = false;
 

--- a/packages/core/src/components/card-title/card-title.tsx
+++ b/packages/core/src/components/card-title/card-title.tsx
@@ -2,8 +2,6 @@ import { Component, h, Host } from '@stencil/core';
 
 /**
  * @slot title-actions - Place additional actions inside title
- *
- * @since 1.6.0
  */
 @Component({
   tag: 'ix-card-title',

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -11,9 +11,6 @@ export type CardVariant =
   | 'outline'
   | 'filled';
 
-/**
- * @since 1.6.0
- */
 @Component({
   tag: 'ix-card',
   styleUrl: 'card.scss',
@@ -28,7 +25,7 @@ export class Card {
   @Prop() variant: CardVariant = 'outline';
 
   /**
-   * @since 2.1.0
+   * Show card in selected state
    */
   @Prop() selected: boolean = false;
 

--- a/packages/core/src/components/category-filter/category-filter.tsx
+++ b/packages/core/src/components/category-filter/category-filter.tsx
@@ -125,8 +125,6 @@ export class CategoryFilter {
   /**
    * If set categories will always be filtered via the respective logical operator.
    * Toggling of the operator will not be available to the user.
-   *
-   * @since 2.2.0
    */
   @Prop() staticOperator?: LogicalFilterOperator;
 

--- a/packages/core/src/components/checkbox-group/checkbox-group.tsx
+++ b/packages/core/src/components/checkbox-group/checkbox-group.tsx
@@ -7,10 +7,6 @@ import {
 } from '../utils/input';
 import { IxComponent } from '../utils/internal';
 
-/**
- * @since 2.6.0
- * @form-ready 2.6.0
- */
 @Component({
   tag: 'ix-checkbox-group',
   styleUrl: 'checkbox-group.scss',

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -24,10 +24,6 @@ import { HookValidationLifecycle, IxFormComponent } from '../utils/input';
 import { makeRef } from '../utils/make-ref';
 import { a11yBoolean } from '../utils/a11y';
 
-/**
- * @since 2.6.0
- * @form-ready 2.6.0
- */
 @Component({
   tag: 'ix-checkbox',
   styleUrl: 'checkbox.scss',

--- a/packages/core/src/components/chip/chip.tsx
+++ b/packages/core/src/components/chip/chip.tsx
@@ -76,14 +76,13 @@ export class Chip {
   /**
    * Display a tooltip. By default, no tooltip will be displayed.
    * Add the attribute to display the text content of the component as a tooltip or use a string to display a custom text.
+   *
    * @since 3.0.0
    */
   @Prop() tooltipText: string | boolean = false;
 
   /**
    * Fire event if close button is clicked
-   *
-   * @since 1.5.0
    */
   @Event() closeChip!: EventEmitter;
 

--- a/packages/core/src/components/col/col.tsx
+++ b/packages/core/src/components/col/col.tsx
@@ -27,9 +27,6 @@ export type ColumnSize =
   | '12'
   | 'auto';
 
-/**
- * @since 2.0.0
- */
 @Component({
   tag: 'ix-col',
   styleUrl: 'col.scss',

--- a/packages/core/src/components/content/content.tsx
+++ b/packages/core/src/components/content/content.tsx
@@ -11,7 +11,6 @@ import { Component, Element, h, Host, State } from '@stencil/core';
 import { hasSlottedElements } from '../utils/shadow-dom';
 
 /**
- * @since 2.1.0
  * @slot header - Display content at the top of the content page
  */
 @Component({

--- a/packages/core/src/components/custom-field/custom-field.tsx
+++ b/packages/core/src/components/custom-field/custom-field.tsx
@@ -16,9 +16,6 @@ import {
 } from '../utils/input';
 import { IxComponent } from '../utils/internal';
 
-/**
- * @since 2.6.0
- */
 @Component({
   tag: 'ix-custom-field',
   styleUrl: 'custom-field.scss',

--- a/packages/core/src/components/date-dropdown/date-dropdown.tsx
+++ b/packages/core/src/components/date-dropdown/date-dropdown.tsx
@@ -41,9 +41,6 @@ export type DateRangeChangeEvent = {
   to?: string;
 };
 
-/**
- * @since 2.1.0
- */
 @Component({
   tag: 'ix-date-dropdown',
   styleUrl: 'date-dropdown.scss',
@@ -58,8 +55,6 @@ export class DateDropdown
 
   /**
    * Disable the button that opens the dropdown containing the date picker.
-   *
-   * @since 2.3.0
    */
   @Prop() disabled = false;
 
@@ -184,16 +179,12 @@ export class DateDropdown
 
   /**
    * Locale identifier (e.g. 'en' or 'de').
-   *
-   * @since 2.6.0
    */
   @Prop() locale?: string;
 
   /**
    * The index of which day to start the week on, based on the Locale#weekdays array.
    * E.g. if the locale is en-us, weekStartIndex = 1 results in starting the week on monday.
-   *
-   * @since 2.6.0
    */
   @Prop() weekStartIndex = 0;
 

--- a/packages/core/src/components/date-input/date-input.tsx
+++ b/packages/core/src/components/date-input/date-input.tsx
@@ -44,8 +44,6 @@ export type DateInputValidityState = {
 };
 
 /**
- * @since 2.6.0
- * @form-ready 2.6.0
  * @slot start - Element will be displayed at the start of the input
  * @slot end - Element will be displayed at the end of the input
  */
@@ -76,8 +74,6 @@ export class DateInput implements IxInputFieldComponent<string | undefined> {
 
   /**
    * Locale identifier (e.g. 'en' or 'de').
-   *
-   * @since 2.6.0
    */
   @Prop() locale?: string;
 

--- a/packages/core/src/components/date-picker/date-picker.tsx
+++ b/packages/core/src/components/date-picker/date-picker.tsx
@@ -68,8 +68,6 @@ export class DatePicker implements IxDatePickerComponent {
   /**
    * The selected starting date. If the date-picker-rework is not in range mode this is the selected date.
    * Format has to match the `format` property.
-   *
-   * @since 1.1.0
    */
   @Prop() from: string | undefined;
 
@@ -92,8 +90,6 @@ export class DatePicker implements IxDatePickerComponent {
   /**
    * The selected end date. If the the date-picker-rework is not in range mode this property has no impact.
    * Format has to match the `format` property.
-   *
-   * @since 1.1.0
    */
   @Prop() to: string | undefined;
 
@@ -116,38 +112,28 @@ export class DatePicker implements IxDatePickerComponent {
   /**
    * The earliest date that can be selected by the date picker.
    * If not set there will be no restriction.
-   *
-   * @since 1.1.0
    */
   @Prop() minDate = '';
 
   /**
    * The latest date that can be selected by the date picker.
    * If not set there will be no restriction.
-   *
-   * @since 1.1.0
    */
   @Prop() maxDate = '';
 
   /**
    * Text of date select button
-   *
-   * @since 2.1.0
    */
   @Prop({ attribute: 'i18n-done' }) i18nDone = 'Done';
 
   /**
    * The index of which day to start the week on, based on the Locale#weekdays array.
    * E.g. if the locale is en-us, weekStartIndex = 1 results in starting the week on monday.
-   *
-   * @since 2.1.0
    */
   @Prop() weekStartIndex = 0;
 
   /**
    * Locale identifier (e.g. 'en' or 'de').
-   *
-   * @since 2.1.0
    */
   @Prop() locale?: string;
 
@@ -172,23 +158,17 @@ export class DatePicker implements IxDatePickerComponent {
   /**
    * Triggers if the date selection changes.
    * Note: Since 2.0.0 `dateChange` does not dispatch detail property as `string`
-   *
-   * @since 2.1.0
    */
   @Event() dateChange!: EventEmitter<DateChangeEvent>;
 
   /**
    * Triggers if the date selection changes.
    * Only triggered if date-picker-rework is in range mode.
-   *
-   * @since 2.1.0
    */
   @Event() dateRangeChange!: EventEmitter<DateChangeEvent>;
 
   /**
    * Date selection confirmed via button action
-   *
-   * @since 1.1.0
    */
   @Event() dateSelect!: EventEmitter<DateChangeEvent>;
 

--- a/packages/core/src/components/datetime-picker/datetime-picker.tsx
+++ b/packages/core/src/components/datetime-picker/datetime-picker.tsx
@@ -52,63 +52,47 @@ export class DatetimePicker
   /**
    * The earliest date that can be selected by the date picker.
    * If not set there will be no restriction.
-   *
-   * @since 1.1.0
    */
   @Prop() minDate?: string;
 
   /**
    * The latest date that can be selected by the date picker.
    * If not set there will be no restriction.
-   *
-   * @since 1.1.0
    */
   @Prop() maxDate?: string;
 
   /**
    * Date format string.
    * See {@link "https://moment.github.io/luxon/#/formatting?id=table-of-tokens"} for all available tokens.
-   *
-   * @since 1.1.0
    */
   @Prop() dateFormat: string = 'yyyy/LL/dd';
 
   /**
    * Time format string.
    * See {@link "https://moment.github.io/luxon/#/formatting?id=table-of-tokens"} for all available tokens.
-   *
-   * @since 1.1.0
    */
   @Prop() timeFormat: string = 'HH:mm:ss';
 
   /**
    * The selected starting date. If the picker is not in range mode this is the selected date.
    * Format has to match the `format` property.
-   *
-   * @since 1.1.0
    */
   @Prop() from?: string;
 
   /**
    * The selected end date. If the the picker is not in range mode this property has no impact.
    * Format has to match the `format` property.
-   *
-   * @since 1.1.0
    */
   @Prop() to?: string;
 
   /**
    * Select time with format string
-   *
-   * @since 1.1.0
    */
   @Prop() time?: string;
 
   /**
    * Show time reference input
    * Time reference is default aligned with @see {this.timeFormat}
-   *
-   * @since 1.1.0
    */
   @Prop() showTimeReference: boolean = false;
 
@@ -119,8 +103,6 @@ export class DatetimePicker
 
   /**
    * Text of date select button
-   *
-   * @since 2.1.0
    */
   @Prop({ attribute: 'i18n-done' }) i18nDone: string = 'Done';
 
@@ -134,16 +116,12 @@ export class DatetimePicker
   /**
    * The index of which day to start the week on, based on the Locale#weekdays array.
    * E.g. if the locale is en-us, weekStartIndex = 1 results in starting the week on monday.
-   *
-   * @since 2.1.0
    */
   @Prop() weekStartIndex = 0;
 
   /**
    * Format of time string
    * See {@link "https://moment.github.io/luxon/#/formatting?id=table-of-tokens"} for all available tokens.
-   *
-   * @since 2.1.0
    */
   @Prop() locale?: string;
 
@@ -155,24 +133,17 @@ export class DatetimePicker
   @Prop() showWeekNumbers = false;
 
   /**
-
    * Time change
-   *
-   * @since 1.1.0
    */
   @Event() timeChange!: EventEmitter<string>;
 
   /**
    * Date change
-   *
-   * @since 1.1.0
    */
   @Event() dateChange!: EventEmitter<DateTimeDateChangeEvent>;
 
   /**
    * Datetime selection event is fired after confirm button is pressed
-   *
-   * @since 1.1.0
    */
   @Event() dateSelect!: EventEmitter<DateTimeSelectEvent>;
 

--- a/packages/core/src/components/divider/divider.tsx
+++ b/packages/core/src/components/divider/divider.tsx
@@ -8,9 +8,6 @@
  */
 import { Component, h, Host } from '@stencil/core';
 
-/**
- * @since 1.4.0
- */
 @Component({
   tag: 'ix-divider',
   styleUrl: 'divider.scss',

--- a/packages/core/src/components/dropdown-button/dropdown-button.tsx
+++ b/packages/core/src/components/dropdown-button/dropdown-button.tsx
@@ -15,9 +15,6 @@ import { makeRef } from '../utils/make-ref';
 
 export type DropdownButtonVariant = ButtonVariant;
 
-/**
- * @since 1.3.0
- */
 @Component({
   tag: 'ix-dropdown-button',
   styleUrl: 'dropdown-button.scss',
@@ -58,14 +55,11 @@ export class DropdownButton {
 
   /**
    * Controls if the dropdown will be closed in response to a click event depending on the position of the event relative to the dropdown.
-   * @since 2.1.0
    */
   @Prop() closeBehavior: 'inside' | 'outside' | 'both' | boolean = 'both';
 
   /**
    * Placement of the dropdown
-   *
-   * @since 2.0.0
    */
   @Prop() placement?: AlignedPlacement;
 

--- a/packages/core/src/components/dropdown-header/dropdown-header.tsx
+++ b/packages/core/src/components/dropdown-header/dropdown-header.tsx
@@ -9,9 +9,6 @@
 
 import { Component, h, Host, Prop } from '@stencil/core';
 
-/**
- * @since 2.0.0
- */
 @Component({
   tag: 'ix-dropdown-header',
   styleUrl: 'dropdown-header.scss',

--- a/packages/core/src/components/dropdown-quick-actions/dropdown-quick-actions.tsx
+++ b/packages/core/src/components/dropdown-quick-actions/dropdown-quick-actions.tsx
@@ -8,9 +8,6 @@
  */
 import { Component, h, Host } from '@stencil/core';
 
-/**
- * @since 1.4.0
- */
 @Component({
   tag: 'ix-dropdown-quick-actions',
   styleUrl: 'dropdown-quick-actions.scss',

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -56,8 +56,6 @@ export class Dropdown implements ComponentInterface, DropdownInterface {
 
   /**
    * Suppress the automatic placement of the dropdown.
-   *
-   * @since 2.0.0
    */
   @Prop() suppressAutomaticPlacement = false;
 

--- a/packages/core/src/components/empty-state/empty-state.tsx
+++ b/packages/core/src/components/empty-state/empty-state.tsx
@@ -11,9 +11,6 @@ import { Component, Event, EventEmitter, h, Host, Prop } from '@stencil/core';
 
 export type EmptyStateLayout = 'large' | 'compact' | 'compactBreak';
 
-/**
- * @since 1.6.0
- */
 @Component({
   tag: 'ix-empty-state',
   styleUrl: 'empty-state.scss',

--- a/packages/core/src/components/expanding-search/expanding-search.tsx
+++ b/packages/core/src/components/expanding-search/expanding-search.tsx
@@ -45,7 +45,6 @@ export class ExpandingSearch
 
   /**
    * If true the search field will fill all available horizontal space of it's parent container when expanded.
-   * @since 1.6.0
    */
   @Prop() fullWidth = false;
 

--- a/packages/core/src/components/filter-chip/filter-chip.tsx
+++ b/packages/core/src/components/filter-chip/filter-chip.tsx
@@ -33,7 +33,6 @@ export class FilterChip {
 
   /**
    * If true the filter chip will be in readonly mode
-   * @since 2.0.0
    */
   @Prop() readonly = false;
 

--- a/packages/core/src/components/flip-tile/flip-tile.tsx
+++ b/packages/core/src/components/flip-tile/flip-tile.tsx
@@ -37,13 +37,11 @@ export class FlipTile {
 
   /**
    * Height interpreted as REM
-   * @since 1.5.0
    */
   @Prop() height: number | 'auto' = 15.125;
 
   /**
    * Width interpreted as REM
-   * @since 1.5.0
    */
   @Prop() width: number | 'auto' = 16;
 

--- a/packages/core/src/components/icon-button/icon-button.tsx
+++ b/packages/core/src/components/icon-button/icon-button.tsx
@@ -26,14 +26,11 @@ export class IconButton {
   /**
    * Accessibility label for the icon button
    * Will be set as aria-label on the nested HTML button element
-   *
-   * @since 2.1.0
    */
   @Prop({ attribute: 'a11y-label' }) a11yLabel?: string;
 
   /**
    * Variant of button
-   * @since 2.3.0 - variant danger
    */
   @Prop() variant: IconButtonVariant = 'secondary';
 
@@ -80,8 +77,6 @@ export class IconButton {
 
   /**
    * Loading button
-   *
-   * @since 2.0.0
    */
   @Prop() loading = false;
 

--- a/packages/core/src/components/icon-toggle-button/icon-toggle-button.tsx
+++ b/packages/core/src/components/icon-toggle-button/icon-toggle-button.tsx
@@ -22,9 +22,6 @@ import { ButtonVariant } from '../button/button';
 import { BaseIconButton } from '../icon-button/base-icon-button';
 import { a11yBoolean } from '../utils/a11y';
 
-/**
- * @since 2.0.0
- */
 @Component({
   tag: 'ix-icon-toggle-button',
   shadow: true,

--- a/packages/core/src/components/input-group/input-group.tsx
+++ b/packages/core/src/components/input-group/input-group.tsx
@@ -11,7 +11,7 @@ import { Component, Element, h, Host, State } from '@stencil/core';
 import { getSlottedElements } from '../utils/shadow-dom';
 
 /**
- * @deprecated since 3.0.0. Will be removed with 4.0.0.
+ * @deprecated Will be removed with 4.0.0
  * Use the 'ix-input' component instead
  */
 @Component({

--- a/packages/core/src/components/input/input.tsx
+++ b/packages/core/src/components/input/input.tsx
@@ -42,8 +42,6 @@ import {
 let inputIds = 0;
 
 /**
- * @since 2.6.0
- * @form-ready 2.6.0
  * @slot start - Element will be displayed at the start of the input
  * @slot end - Element will be displayed at the end of the input
  */

--- a/packages/core/src/components/input/number-input.tsx
+++ b/packages/core/src/components/input/number-input.tsx
@@ -40,8 +40,6 @@ import {
 let numberInputIds = 0;
 
 /**
- * @since 2.6.0
- * @form-ready 2.6.0
  * @slot start - Element will be displayed at the start of the input
  * @slot end - Element will be displayed at the end of the input
  */

--- a/packages/core/src/components/input/textarea.tsx
+++ b/packages/core/src/components/input/textarea.tsx
@@ -34,10 +34,6 @@ export type TextareaResizeBehavior =
   | 'vertical'
   | 'none';
 
-/**
- * @since 2.6.0
- * @form-ready 2.6.0
- */
 @Component({
   tag: 'ix-textarea',
   styleUrl: 'textarea.scss',

--- a/packages/core/src/components/key-value-list/key-value-list.tsx
+++ b/packages/core/src/components/key-value-list/key-value-list.tsx
@@ -9,9 +9,6 @@
 
 import { Component, h, Host, Prop } from '@stencil/core';
 
-/**
- * @since 1.6.0
- */
 @Component({
   tag: 'ix-key-value-list',
   styleUrl: 'key-value-list.scss',

--- a/packages/core/src/components/key-value/key-value.tsx
+++ b/packages/core/src/components/key-value/key-value.tsx
@@ -13,8 +13,6 @@ export type KeyValueLabelPosition = 'top' | 'left';
 
 /**
  * @slot custom-value - Optional custom value at key value instead of text value
- *
- * @since 1.6.0
  */
 @Component({
   tag: 'ix-key-value',

--- a/packages/core/src/components/layout-auto/layout-auto.tsx
+++ b/packages/core/src/components/layout-auto/layout-auto.tsx
@@ -1,9 +1,6 @@
 import { Component, Element, Host, Prop, Watch, h } from '@stencil/core';
 import { IxComponent } from '../utils/internal';
 
-/**
- * @since 2.6.0
- */
 @Component({
   tag: 'ix-layout-auto',
   styleUrl: 'layout-auto.scss',

--- a/packages/core/src/components/layout-grid/layout-grid.tsx
+++ b/packages/core/src/components/layout-grid/layout-grid.tsx
@@ -9,9 +9,6 @@
 
 import { Component, h, Host, Prop } from '@stencil/core';
 
-/**
- * @since 2.0.0
- */
 @Component({
   tag: 'ix-layout-grid',
   styleUrl: 'layout-grid.scss',

--- a/packages/core/src/components/link-button/link-button.tsx
+++ b/packages/core/src/components/link-button/link-button.tsx
@@ -10,9 +10,6 @@
 import { iconChevronRightSmall } from '@siemens/ix-icons/icons';
 import { Component, h, Host, Prop } from '@stencil/core';
 
-/**
- * @since 2.0.0
- */
 @Component({
   tag: 'ix-link-button',
   styleUrl: 'link-button.scss',

--- a/packages/core/src/components/map-navigation/map-navigation.tsx
+++ b/packages/core/src/components/map-navigation/map-navigation.tsx
@@ -109,7 +109,6 @@ export class MapNavigation {
    * Change the visibility of the sidebar
    *
    * @param show new visibility state
-   * @since 1.6.0
    */
   @Method()
   async toggleSidebar(show?: boolean) {

--- a/packages/core/src/components/menu-avatar/menu-avatar.tsx
+++ b/packages/core/src/components/menu-avatar/menu-avatar.tsx
@@ -39,15 +39,11 @@ export class MenuAvatar {
 
   /**
    * Display a avatar image
-   *
-   * @since 1.4.0
    */
   @Prop() image?: string;
 
   /**
    * Display the initials of the user. Will be overwritten by image
-   *
-   * @since 1.4.0
    */
   @Prop() initials?: string;
 
@@ -58,13 +54,11 @@ export class MenuAvatar {
 
   /**
    *  Control the visibility of the logout button
-   *  @since 2.1.0
    */
   @Prop() showLogoutButton: boolean = true;
 
   /**
    * Control the visibility of the dropdown menu
-   * @since 2.1.0
    */
   @State() showContextMenu: boolean = false;
 

--- a/packages/core/src/components/menu-category/menu-category.tsx
+++ b/packages/core/src/components/menu-category/menu-category.tsx
@@ -26,9 +26,6 @@ import { iconChevronDownSmall } from '@siemens/ix-icons/icons';
 const DefaultIxMenuItemHeight = 40;
 const DefaultAnimationTimeout = 150;
 
-/**
- * @since 2.0.0
- */
 @Component({
   tag: 'ix-menu-category',
   styleUrl: 'menu-category.scss',

--- a/packages/core/src/components/menu-item/menu-item.tsx
+++ b/packages/core/src/components/menu-item/menu-item.tsx
@@ -25,8 +25,6 @@ import { iconDocument } from '@siemens/ix-icons/icons';
 export class MenuItem {
   /**
    * Label of the menu item. Will also be used as tooltip text
-   *
-   * @since 2.2.0
    */
   @Prop() label?: string;
 

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -92,8 +92,6 @@ export class Menu {
 
   /**
    *  If set the menu will be expanded initially. This will only take effect at the breakpoint 'lg'.
-   *
-   *  @since 2.2.0
    */
   @Prop() startExpanded = false;
 

--- a/packages/core/src/components/modal-content/modal-content.tsx
+++ b/packages/core/src/components/modal-content/modal-content.tsx
@@ -9,9 +9,6 @@
 
 import { Component, h, Host } from '@stencil/core';
 
-/**
- * @since 2.0.0
- */
 @Component({
   tag: 'ix-modal-content',
   styleUrl: 'modal-content.scss',

--- a/packages/core/src/components/modal-footer/modal-footer.tsx
+++ b/packages/core/src/components/modal-footer/modal-footer.tsx
@@ -9,9 +9,6 @@
 
 import { Component, h, Host } from '@stencil/core';
 
-/**
- * @since 2.0.0
- */
 @Component({
   tag: 'ix-modal-footer',
   styleUrl: 'modal-footer.scss',

--- a/packages/core/src/components/modal-header/modal-header.tsx
+++ b/packages/core/src/components/modal-header/modal-header.tsx
@@ -20,9 +20,6 @@ import {
 import { closestPassShadow } from '../utils/shadow-dom';
 import { iconClose } from '@siemens/ix-icons/icons';
 
-/**
- * @since 2.0.0
- */
 @Component({
   tag: 'ix-modal-header',
   styleUrl: 'modal-header.scss',

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -39,8 +39,6 @@ export class Modal {
 
   /**
    * Modal size
-   *
-   * @since 2.0.0
    */
   @Prop() size: IxModalSize = '360';
 
@@ -56,8 +54,6 @@ export class Modal {
 
   /**
    * Dismiss modal on backdrop click
-   *
-   * @since 2.0.0
    */
   @Prop() closeOnBackdropClick = false;
 

--- a/packages/core/src/components/pagination/pagination.tsx
+++ b/packages/core/src/components/pagination/pagination.tsx
@@ -23,9 +23,6 @@ import {
   iconChevronRightSmall,
 } from '@siemens/ix-icons/icons';
 
-/**
- * @since 1.5.0
- */
 @Component({
   tag: 'ix-pagination',
   styleUrl: 'pagination.scss',

--- a/packages/core/src/components/pane-layout/pane-layout.tsx
+++ b/packages/core/src/components/pane-layout/pane-layout.tsx
@@ -22,9 +22,6 @@ import { Composition } from '../pane/pane';
 import { applicationLayoutService } from '../utils/application-layout';
 import { matchBreakpoint } from '../utils/breakpoints';
 
-/**
- * @since 2.1.0
- */
 @Component({
   tag: 'ix-pane-layout',
   styleUrl: 'pane-layout.scss',

--- a/packages/core/src/components/pane/pane.tsx
+++ b/packages/core/src/components/pane/pane.tsx
@@ -52,9 +52,6 @@ export type BorderlessChangedEvent = {
   borderless: boolean;
 };
 
-/**
- * @since 2.1.0
- */
 @Component({
   tag: 'ix-pane',
   styleUrl: 'pane.scss',

--- a/packages/core/src/components/push-card/push-card.tsx
+++ b/packages/core/src/components/push-card/push-card.tsx
@@ -12,9 +12,6 @@ import { CardVariant } from '../card/card';
 
 export type PushCardVariant = CardVariant;
 
-/**
- * @since 1.6.0
- */
 @Component({
   tag: 'ix-push-card',
   styleUrl: 'push-card.scss',
@@ -48,7 +45,6 @@ export class PushCard {
 
   /**
    * Collapse the card
-   * @since 2.1.0
    */
   @Prop() collapse: boolean = true;
 

--- a/packages/core/src/components/radio-group/radio-group.tsx
+++ b/packages/core/src/components/radio-group/radio-group.tsx
@@ -25,10 +25,6 @@ import {
   IxFormValidationState,
 } from '../utils/input';
 
-/**
- * @since 2.6.0
- * @form-ready 2.6.0
- */
 @Component({
   tag: 'ix-radio-group',
   styleUrl: 'radio-group.scss',

--- a/packages/core/src/components/radio/radio.tsx
+++ b/packages/core/src/components/radio/radio.tsx
@@ -23,10 +23,6 @@ import { makeRef } from '../utils/make-ref';
 import { IxFormComponent } from '../utils/input';
 import { a11yBoolean } from '../utils/a11y';
 
-/**
- * @since 2.6.0
- * @form-ready 2.6.0
- */
 @Component({
   tag: 'ix-radio',
   styleUrl: 'radio.scss',

--- a/packages/core/src/components/row/row.tsx
+++ b/packages/core/src/components/row/row.tsx
@@ -9,9 +9,6 @@
 
 import { Component, h, Host } from '@stencil/core';
 
-/**
- * @since 2.0.0
- */
 @Component({
   tag: 'ix-row',
   styleUrl: 'row.scss',

--- a/packages/core/src/components/select/select.tsx
+++ b/packages/core/src/components/select/select.tsx
@@ -39,9 +39,6 @@ import { OnListener } from '../utils/listener';
 import { makeRef } from '../utils/make-ref';
 import { createMutationObserver } from '../utils/mutation-observer';
 
-/**
- * @form-ready 2.6.0
- */
 @Component({
   tag: 'ix-select',
   styleUrl: 'select.scss',
@@ -55,71 +52,52 @@ export class Select implements IxInputFieldComponent<string | string[]> {
   /**
    * A string that represents the element's name attribute,
    * containing a name that identifies the element when submitting the form.
-   *
-   * @since 2.6.0
    */
   @Prop({ reflect: true }) name?: string;
 
   /**
    * A Boolean attribute indicating that an option with a non-empty string value must be selected
-   *
-   * @since 2.6.0
    */
   @Prop({ reflect: true }) required: boolean = false;
 
   /**
    * Label for the select component
-   *
-   * @since 2.6.0
    */
   @Prop() label?: string;
 
   /**
    * Warning text for the select component
-   *
-   * @since 2.6.0
    **/
   @Prop() warningText?: string;
 
   /**
    * Info text for the select component
-   *
-   * @since 2.6.0
    **/
   @Prop() infoText?: string;
 
   /**
    * Error text for the select component
-   *
-   * @since 2.6.0
    **/
   @Prop() invalidText?: string;
 
   /**
    * Valid text for the select component
-   *
-   * @since 2.6.0
    **/
   @Prop() validText?: string;
 
   /**
    * Helper text for the select component
-   *
-   * @since 2.6.0
    **/
   @Prop() helperText?: string;
 
   /**
    * Show helper, error, info, warning text as tooltip
-   *
-   * @since 2.6.0
    */
   @Prop() showTextAsTooltip?: boolean;
 
   /**
    * Current selected value.
    * This corresponds to the value property of ix-select-items
-   * @since 2.0.0
    */
   @Prop({ mutable: true }) value: string | string[] = [];
 
@@ -165,44 +143,32 @@ export class Select implements IxInputFieldComponent<string | string[]> {
 
   /**
    * Information inside of dropdown if no items where found with current filter text
-   *
-   * @since 1.5.0
    */
   @Prop() i18nNoMatches = 'No matches';
 
   /**
    * Hide list header
-   *
-   * @since 1.5.0
    */
   @Prop() hideListHeader = false;
 
   /**
    * The width of the dropdown element with value and unit (e.g. "200px" or "12.5rem").
-   *
-   * @since 2.7.0
    */
   @Prop() dropdownWidth?: string;
 
   /**
    * The maximum width of the dropdown element with value and unit (e.g. "200px" or "12.5rem").
    * By default the maximum width of the dropdown element is set to 100%.
-   *
-   * @since 2.7.0
-   *
    */
   @Prop() dropdownMaxWidth?: string;
 
   /**
    * Value changed
-   * @since 2.0.0
    */
   @Event() valueChange!: EventEmitter<string | string[]>;
 
   /**
    * Event dispatched whenever the text input changes.
-   *
-   * @since 2.0.0
    */
   @Event() inputChange!: EventEmitter<string>;
 

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -35,8 +35,6 @@ function between(min: number, value: number, max: number) {
 }
 
 /**
- * @since 2.0.0
- *
  * @slot label-start - Element will be displayed at the start of the slider
  * @slot label-end - Element will be displayed at the end of the slider
  */

--- a/packages/core/src/components/split-button/split-button.tsx
+++ b/packages/core/src/components/split-button/split-button.tsx
@@ -39,7 +39,6 @@ export class SplitButton {
 
   /**
    * Controls if the dropdown will be closed in response to a click event depending on the position of the event relative to the dropdown.
-   * @since 2.3.0
    */
   @Prop() closeBehavior: CloseBehavior = 'both';
 

--- a/packages/core/src/components/tab-item/tab-item.tsx
+++ b/packages/core/src/components/tab-item/tab-item.tsx
@@ -61,8 +61,6 @@ export class TabItem {
 
   /**
    * Emitted when the tab is clicked.
-   *
-   * @since 2.0.0
    */
   @Event() tabClick!: EventEmitter<TabClickDetail>;
 

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -60,8 +60,6 @@ export class Tabs {
 
   /**
    * `selected` property changed
-   *
-   * @since 2.0.0
    */
   @Event() selectedChange!: EventEmitter<number>;
 

--- a/packages/core/src/components/time-picker/time-picker.tsx
+++ b/packages/core/src/components/time-picker/time-picker.tsx
@@ -50,8 +50,6 @@ export class TimePicker {
   /**
    * Format of time string
    * See {@link "https://moment.github.io/luxon/#/formatting?id=table-of-tokens"} for all available tokens.
-   *
-   * @since 1.1.0
    */
   @Prop() format: string = 'TT';
 
@@ -83,8 +81,6 @@ export class TimePicker {
   /**
    * Select time with format string
    * Format has to match the `format` property.
-   *
-   * @since 1.1.0
    */
   @Prop() time: string = DateTime.now().toFormat(this.format);
 
@@ -103,15 +99,11 @@ export class TimePicker {
 
   /**
    * Text of date select button
-   *
-   * @since 1.1.0
    */
   @Prop() textSelectTime = 'Done';
 
   /**
    * Text for top label
-   *
-   * @since 2.1.0
    */
   @Prop() textTime: string = 'Time';
 

--- a/packages/core/src/components/toggle-button/toggle-button.tsx
+++ b/packages/core/src/components/toggle-button/toggle-button.tsx
@@ -20,9 +20,6 @@ import { BaseButton, BaseButtonProps } from '../button/base-button';
 import { ButtonVariant } from '../button/button';
 import { a11yBoolean } from '../utils/a11y';
 
-/**
- * @since 2.0.0
- */
 @Component({
   tag: 'ix-toggle-button',
   shadow: true,

--- a/packages/core/src/components/toggle/toggle.tsx
+++ b/packages/core/src/components/toggle/toggle.tsx
@@ -22,9 +22,6 @@ import {
 import { a11yBoolean } from '../utils/a11y';
 import { IxFormComponent } from '../utils/input';
 
-/**
- * @form-ready 2.6.0
- * */
 @Component({
   tag: 'ix-toggle',
   styleUrl: 'toggle.scss',

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -45,8 +45,6 @@ let tooltipInstance = 0;
 /**
  * @slot title-icon - Icon of tooltip title
  * @slot title-content - Content of tooltip title
- *
- * @since 1.4.0
  */
 @Component({
   tag: 'ix-tooltip',
@@ -72,7 +70,6 @@ export class Tooltip {
   /**
    * Initial placement of the tooltip.
    * If the selected placement doesn't have enough space, the tooltip will be repositioned to another location.
-   * @since 1.5.0
    */
   @Prop() placement: 'top' | 'right' | 'bottom' | 'left' = 'top';
 

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -77,13 +77,11 @@ export class Tree {
 
   /**
    * Node toggled event
-   * @since 1.5.0
    */
   @Event() nodeToggled!: EventEmitter<{ id: string; isExpanded: boolean }>;
 
   /**
    * Node clicked event
-   * @since 1.5.0
    */
   @Event() nodeClicked!: EventEmitter<string>;
 

--- a/packages/core/src/components/typography/typography.tsx
+++ b/packages/core/src/components/typography/typography.tsx
@@ -64,9 +64,6 @@ export type TypographyFormat =
 
 export type TextDecoration = 'none' | 'underline' | 'line-through';
 
-/**
- * @since 2.0.0
- */
 @Component({
   tag: 'ix-typography',
   styleUrl: 'typography.scss',

--- a/packages/core/src/components/validation-tooltip/validation-tooltip.tsx
+++ b/packages/core/src/components/validation-tooltip/validation-tooltip.tsx
@@ -46,8 +46,6 @@ export class ValidationTooltip {
 
   /**
    * Suppress the automatic placement of the dropdown.
-   *
-   * @since 2.0.0
    */
   @Prop() suppressAutomaticPlacement = false;
 

--- a/packages/documentation/src/components/UI/CopyButton/index.tsx
+++ b/packages/documentation/src/components/UI/CopyButton/index.tsx
@@ -49,6 +49,7 @@ const CopyButton = ({
       >
         {React.createElement('ix-icon', {
           name: iconCopy,
+          size: '16',
         })}
         {label ?? 'Copy'}
       </Button>


### PR DESCRIPTION
## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Remove all `@since` annotations before v3
- Fix iconsize of copy icon

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
