### PR TITLE
chore(core): enable strict tsconfig

### DIFF
--- a/packages/core/component-doc.json
+++ b/packages/core/component-doc.json
@@ -34,10 +34,10 @@
       "props": [
         {
           "name": "heading",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -48,6 +48,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -57,10 +60,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string | undefined",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -72,6 +75,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": false,
@@ -105,10 +111,10 @@
         },
         {
           "name": "subheading",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -119,6 +125,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -215,10 +224,10 @@
       "props": [
         {
           "name": "appSwitchConfig",
-          "type": "{ currentAppId: string; apps: { id: string; name: string; description: string; url: string; target: AppSwitchConfigurationTarget; iconSrc: string; }[]; i18nAppSwitch?: string; i18nLoadingApps?: string; }",
+          "type": "undefined | { currentAppId: string; apps: { id: string; name: string; description: string; url: string; target: AppSwitchConfigurationTarget; iconSrc: string; }[]; i18nAppSwitch?: string | undefined; i18nLoadingApps?: string | undefined; }",
           "complexType": {
             "original": "AppSwitchConfiguration",
-            "resolved": "{ currentAppId: string; apps: { id: string; name: string; description: string; url: string; target: AppSwitchConfigurationTarget; iconSrc: string; }[]; i18nAppSwitch?: string; i18nLoadingApps?: string; }",
+            "resolved": "undefined | { currentAppId: string; apps: { id: string; name: string; description: string; url: string; target: AppSwitchConfigurationTarget; iconSrc: string; }[]; i18nAppSwitch?: string | undefined; i18nLoadingApps?: string | undefined; }",
             "references": {
               "AppSwitchConfiguration": {
                 "location": "import",
@@ -234,7 +243,16 @@
           "docsTags": [],
           "values": [
             {
-              "type": "{ currentAppId: string; apps: { id: string; name: string; description: string; url: string; target: AppSwitchConfigurationTarget; iconSrc: string; }[]; i18nAppSwitch?: string; i18nLoadingApps?: string; }"
+              "type": "undefined"
+            },
+            {
+              "type": "{ currentAppId: string; apps: { id: string; name: string; description: string; url: string; target: AppSwitchConfigurationTarget; iconSrc: string; }[]; i18nAppSwitch?: string"
+            },
+            {
+              "type": "undefined; i18nLoadingApps?: string"
+            },
+            {
+              "type": "undefined; }"
             }
           ],
           "optional": true,
@@ -281,10 +299,10 @@
         },
         {
           "name": "forceBreakpoint",
-          "type": "\"lg\" | \"md\" | \"sm\"",
+          "type": "\"lg\" | \"md\" | \"sm\" | undefined",
           "complexType": {
             "original": "Breakpoint | undefined",
-            "resolved": "\"lg\" | \"md\" | \"sm\"",
+            "resolved": "\"lg\" | \"md\" | \"sm\" | undefined",
             "references": {
               "Breakpoint": {
                 "location": "import",
@@ -310,6 +328,9 @@
             {
               "value": "sm",
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": false,
@@ -319,10 +340,10 @@
         },
         {
           "name": "theme",
-          "type": "\"classic\" | \"classic-dark\" | \"classic-light\" | string & Record<never, never>",
+          "type": "\"classic\" | \"classic-dark\" | \"classic-light\" | string & Record<never, never> | undefined",
           "complexType": {
             "original": "IxTheme",
-            "resolved": "\"classic\" | \"classic-dark\" | \"classic-light\" | string & Record<never, never>",
+            "resolved": "\"classic\" | \"classic-dark\" | \"classic-light\" | string & Record<never, never> | undefined",
             "references": {
               "IxTheme": {
                 "location": "import",
@@ -351,6 +372,9 @@
             },
             {
               "type": "string & Record<never, never>"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -441,10 +465,10 @@
       "props": [
         {
           "name": "name",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -455,6 +479,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -464,10 +491,10 @@
         },
         {
           "name": "showMenu",
-          "type": "boolean",
+          "type": "boolean | undefined",
           "complexType": {
             "original": "boolean",
-            "resolved": "boolean",
+            "resolved": "boolean | undefined",
             "references": {}
           },
           "mutable": true,
@@ -479,6 +506,9 @@
           "values": [
             {
               "type": "boolean"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -568,10 +598,10 @@
       "props": [
         {
           "name": "extra",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -582,6 +612,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -591,10 +624,10 @@
         },
         {
           "name": "image",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -605,6 +638,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -614,10 +650,10 @@
         },
         {
           "name": "initials",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -628,6 +664,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -637,10 +676,10 @@
         },
         {
           "name": "username",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -651,6 +690,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -703,10 +745,10 @@
       "props": [
         {
           "name": "applicationName",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -717,6 +759,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -768,10 +813,10 @@
         },
         {
           "name": "forceBreakpoint",
-          "type": "\"lg\" | \"md\" | \"sm\"",
+          "type": "\"lg\" | \"md\" | \"sm\" | undefined",
           "complexType": {
             "original": "Breakpoint | undefined",
-            "resolved": "\"lg\" | \"md\" | \"sm\"",
+            "resolved": "\"lg\" | \"md\" | \"sm\" | undefined",
             "references": {
               "Breakpoint": {
                 "location": "import",
@@ -797,6 +842,9 @@
             {
               "value": "sm",
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": false,
@@ -884,10 +932,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -898,6 +946,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -907,10 +958,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -921,6 +972,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -930,10 +984,10 @@
         },
         {
           "name": "sublabel",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -944,6 +998,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -1233,10 +1290,10 @@
       "props": [
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -1247,6 +1304,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -1256,10 +1316,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -1270,6 +1330,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -1398,10 +1461,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -1412,6 +1475,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -1899,10 +1965,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -1913,6 +1979,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -1951,10 +2020,10 @@
         },
         {
           "name": "showAllCount",
-          "type": "number",
+          "type": "number | undefined",
           "complexType": {
             "original": "number",
-            "resolved": "number",
+            "resolved": "number | undefined",
             "references": {}
           },
           "mutable": false,
@@ -1965,6 +2034,9 @@
           "values": [
             {
               "type": "number"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -2139,10 +2211,10 @@
       "props": [
         {
           "name": "categories",
-          "type": "{ [id: string]: { label: string; options: string[]; }; }",
+          "type": "undefined | { [id: string]: { label: string; options: string[]; }; }",
           "complexType": {
             "original": "{\n    [id: string]: {\n      label: string;\n      options: string[];\n    };\n  }",
-            "resolved": "{ [id: string]: { label: string; options: string[]; }; }",
+            "resolved": "undefined | { [id: string]: { label: string; options: string[]; }; }",
             "references": {}
           },
           "mutable": false,
@@ -2151,6 +2223,9 @@
           "docs": "Configuration object hash used to populate the dropdown menu for type-ahead and quick selection functionality.\nEach ID maps to an object with a label and an array of options to select from.",
           "docsTags": [],
           "values": [
+            {
+              "type": "undefined"
+            },
             {
               "type": "{ [id: string]: { label: string; options: string[]; }; }"
             }
@@ -2186,10 +2261,10 @@
         },
         {
           "name": "filterState",
-          "type": "FilterState",
+          "type": "FilterState | undefined",
           "complexType": {
             "original": "FilterState",
-            "resolved": "FilterState",
+            "resolved": "FilterState | undefined",
             "references": {
               "FilterState": {
                 "location": "import",
@@ -2206,6 +2281,9 @@
           "values": [
             {
               "type": "FilterState"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -2263,10 +2341,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -2277,6 +2355,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -2310,10 +2391,10 @@
         },
         {
           "name": "nonSelectableCategories",
-          "type": "{ [id: string]: string; }",
+          "type": "undefined | { [id: string]: string; }",
           "complexType": {
             "original": "{\n    [id: string]: string;\n  }",
-            "resolved": "{ [id: string]: string; }",
+            "resolved": "undefined | { [id: string]: string; }",
             "references": {}
           },
           "mutable": false,
@@ -2323,6 +2404,9 @@
           "docsTags": [],
           "default": "{}",
           "values": [
+            {
+              "type": "undefined"
+            },
             {
               "type": "{ [id: string]: string; }"
             }
@@ -2334,10 +2418,10 @@
         },
         {
           "name": "placeholder",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -2348,6 +2432,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -2405,10 +2492,10 @@
         },
         {
           "name": "staticOperator",
-          "type": "LogicalFilterOperator.EQUAL | LogicalFilterOperator.NOT_EQUAL",
+          "type": "LogicalFilterOperator.EQUAL | LogicalFilterOperator.NOT_EQUAL | undefined",
           "complexType": {
             "original": "LogicalFilterOperator",
-            "resolved": "LogicalFilterOperator.EQUAL | LogicalFilterOperator.NOT_EQUAL",
+            "resolved": "LogicalFilterOperator.EQUAL | LogicalFilterOperator.NOT_EQUAL | undefined",
             "references": {
               "LogicalFilterOperator": {
                 "location": "import",
@@ -2428,6 +2515,9 @@
             },
             {
               "type": "LogicalFilterOperator.NOT_EQUAL"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -2437,10 +2527,10 @@
         },
         {
           "name": "suggestions",
-          "type": "string[]",
+          "type": "string[] | undefined",
           "complexType": {
             "original": "string[]",
-            "resolved": "string[]",
+            "resolved": "string[] | undefined",
             "references": {}
           },
           "mutable": false,
@@ -2451,6 +2541,9 @@
           "values": [
             {
               "type": "string[]"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -2635,10 +2728,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -2649,6 +2742,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -2658,10 +2754,10 @@
         },
         {
           "name": "name",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -2672,6 +2768,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -2846,10 +2945,10 @@
         },
         {
           "name": "helperText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -2860,6 +2959,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -2869,10 +2971,10 @@
         },
         {
           "name": "infoText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -2883,6 +2985,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -2892,10 +2997,10 @@
         },
         {
           "name": "invalidText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -2906,6 +3011,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -2915,10 +3023,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -2929,6 +3037,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -2962,10 +3073,10 @@
         },
         {
           "name": "validText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -2976,6 +3087,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -2985,10 +3099,10 @@
         },
         {
           "name": "warningText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -2999,6 +3113,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -3070,10 +3187,10 @@
         },
         {
           "name": "background",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string | undefined",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -3084,6 +3201,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": false,
@@ -3093,10 +3213,10 @@
         },
         {
           "name": "chipColor",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string | undefined",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -3107,6 +3227,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": false,
@@ -3140,10 +3263,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -3154,6 +3277,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -3321,10 +3447,10 @@
       "props": [
         {
           "name": "size",
-          "type": "\"1\" | \"10\" | \"11\" | \"12\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" | \"auto\"",
+          "type": "\"1\" | \"10\" | \"11\" | \"12\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" | \"auto\" | undefined",
           "complexType": {
             "original": "ColumnSize",
-            "resolved": "\"1\" | \"10\" | \"11\" | \"12\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" | \"auto\"",
+            "resolved": "\"1\" | \"10\" | \"11\" | \"12\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" | \"auto\" | undefined",
             "references": {
               "ColumnSize": {
                 "location": "local",
@@ -3390,6 +3516,9 @@
             {
               "value": "auto",
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -3399,10 +3528,10 @@
         },
         {
           "name": "sizeLg",
-          "type": "\"1\" | \"10\" | \"11\" | \"12\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" | \"auto\"",
+          "type": "\"1\" | \"10\" | \"11\" | \"12\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" | \"auto\" | undefined",
           "complexType": {
             "original": "ColumnSize",
-            "resolved": "\"1\" | \"10\" | \"11\" | \"12\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" | \"auto\"",
+            "resolved": "\"1\" | \"10\" | \"11\" | \"12\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" | \"auto\" | undefined",
             "references": {
               "ColumnSize": {
                 "location": "local",
@@ -3468,6 +3597,9 @@
             {
               "value": "auto",
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -3477,10 +3609,10 @@
         },
         {
           "name": "sizeMd",
-          "type": "\"1\" | \"10\" | \"11\" | \"12\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" | \"auto\"",
+          "type": "\"1\" | \"10\" | \"11\" | \"12\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" | \"auto\" | undefined",
           "complexType": {
             "original": "ColumnSize",
-            "resolved": "\"1\" | \"10\" | \"11\" | \"12\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" | \"auto\"",
+            "resolved": "\"1\" | \"10\" | \"11\" | \"12\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" | \"auto\" | undefined",
             "references": {
               "ColumnSize": {
                 "location": "local",
@@ -3546,6 +3678,9 @@
             {
               "value": "auto",
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -3555,10 +3690,10 @@
         },
         {
           "name": "sizeSm",
-          "type": "\"1\" | \"10\" | \"11\" | \"12\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" | \"auto\"",
+          "type": "\"1\" | \"10\" | \"11\" | \"12\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" | \"auto\" | undefined",
           "complexType": {
             "original": "ColumnSize",
-            "resolved": "\"1\" | \"10\" | \"11\" | \"12\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" | \"auto\"",
+            "resolved": "\"1\" | \"10\" | \"11\" | \"12\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" | \"auto\" | undefined",
             "references": {
               "ColumnSize": {
                 "location": "local",
@@ -3624,6 +3759,9 @@
             {
               "value": "auto",
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -3732,10 +3870,10 @@
         },
         {
           "name": "headerSubtitle",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string | undefined",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -3747,6 +3885,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": false,
@@ -3756,10 +3897,10 @@
         },
         {
           "name": "headerTitle",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -3770,6 +3911,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -3870,10 +4014,10 @@
       "props": [
         {
           "name": "helperText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -3884,6 +4028,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -3893,10 +4040,10 @@
         },
         {
           "name": "infoText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -3907,6 +4054,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -3916,10 +4066,10 @@
         },
         {
           "name": "invalidText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -3930,6 +4080,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -3939,10 +4092,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -3953,6 +4106,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -3986,10 +4142,10 @@
         },
         {
           "name": "showTextAsTooltip",
-          "type": "boolean",
+          "type": "boolean | undefined",
           "complexType": {
             "original": "boolean",
-            "resolved": "boolean",
+            "resolved": "boolean | undefined",
             "references": {}
           },
           "mutable": false,
@@ -4000,6 +4156,9 @@
           "values": [
             {
               "type": "boolean"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -4009,10 +4168,10 @@
         },
         {
           "name": "validText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -4023,6 +4182,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -4032,10 +4194,10 @@
         },
         {
           "name": "warningText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -4046,6 +4208,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -4384,10 +4549,10 @@
         },
         {
           "name": "locale",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -4398,6 +4563,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -4650,11 +4818,11 @@
       "events": [
         {
           "event": "dateRangeChange",
-          "detail": "{ id: string; from?: string; to?: string; }",
+          "detail": "{ id: string; from?: string | undefined; to?: string | undefined; }",
           "bubbles": true,
           "complexType": {
             "original": "DateRangeChangeEvent",
-            "resolved": "{ id: string; from?: string; to?: string; }",
+            "resolved": "{ id: string; from?: string | undefined; to?: string | undefined; }",
             "references": {
               "DateRangeChangeEvent": {
                 "location": "local",
@@ -4787,10 +4955,10 @@
         },
         {
           "name": "helperText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -4801,6 +4969,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -4834,10 +5005,10 @@
         },
         {
           "name": "infoText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -4848,6 +5019,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -4857,10 +5031,10 @@
         },
         {
           "name": "invalidText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -4871,6 +5045,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -4880,10 +5057,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -4894,6 +5071,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -4903,10 +5083,10 @@
         },
         {
           "name": "locale",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -4917,6 +5097,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -4926,10 +5109,10 @@
         },
         {
           "name": "name",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -4940,6 +5123,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -4949,10 +5135,10 @@
         },
         {
           "name": "placeholder",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -4963,6 +5149,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -4996,10 +5185,10 @@
         },
         {
           "name": "required",
-          "type": "boolean",
+          "type": "boolean | undefined",
           "complexType": {
             "original": "boolean",
-            "resolved": "boolean",
+            "resolved": "boolean | undefined",
             "references": {}
           },
           "mutable": false,
@@ -5010,6 +5199,9 @@
           "values": [
             {
               "type": "boolean"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -5019,10 +5211,10 @@
         },
         {
           "name": "showTextAsTooltip",
-          "type": "boolean",
+          "type": "boolean | undefined",
           "complexType": {
             "original": "boolean",
-            "resolved": "boolean",
+            "resolved": "boolean | undefined",
             "references": {}
           },
           "mutable": false,
@@ -5033,6 +5225,9 @@
           "values": [
             {
               "type": "boolean"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -5071,10 +5266,10 @@
         },
         {
           "name": "validText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -5085,6 +5280,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -5094,10 +5292,10 @@
         },
         {
           "name": "value",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": true,
@@ -5109,6 +5307,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -5118,10 +5319,10 @@
         },
         {
           "name": "warningText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -5132,6 +5333,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -5193,11 +5397,11 @@
       "events": [
         {
           "event": "validityStateChange",
-          "detail": "{ patternMismatch: boolean; invalidReason?: string; }",
+          "detail": "{ patternMismatch: boolean; invalidReason?: string | undefined; }",
           "bubbles": true,
           "complexType": {
             "original": "DateInputValidityState",
-            "resolved": "{ patternMismatch: boolean; invalidReason?: string; }",
+            "resolved": "{ patternMismatch: boolean; invalidReason?: string | undefined; }",
             "references": {
               "DateInputValidityState": {
                 "location": "local",
@@ -5213,11 +5417,11 @@
         },
         {
           "event": "valueChange",
-          "detail": "string",
+          "detail": "string | undefined",
           "bubbles": true,
           "complexType": {
             "original": "string | undefined",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "cancelable": false,
@@ -5356,10 +5560,10 @@
         },
         {
           "name": "from",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string | undefined",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -5370,6 +5574,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": false,
@@ -5403,10 +5610,10 @@
         },
         {
           "name": "locale",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -5417,6 +5624,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -5527,10 +5737,10 @@
         },
         {
           "name": "to",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string | undefined",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -5541,6 +5751,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": false,
@@ -5577,11 +5790,11 @@
         {
           "name": "getCurrentDate",
           "returns": {
-            "type": "Promise<{ from: string; to: string; }>",
+            "type": "Promise<{ from: string | undefined; to: string | undefined; }>",
             "docs": ""
           },
           "complexType": {
-            "signature": "() => Promise<{ from: string; to: string; }>",
+            "signature": "() => Promise<{ from: string | undefined; to: string | undefined; }>",
             "parameters": [],
             "references": {
               "Promise": {
@@ -5589,9 +5802,9 @@
                 "id": "global::Promise"
               }
             },
-            "return": "Promise<{ from: string; to: string; }>"
+            "return": "Promise<{ from: string | undefined; to: string | undefined; }>"
           },
-          "signature": "getCurrentDate() => Promise<{ from: string; to: string; }>",
+          "signature": "getCurrentDate() => Promise<{ from: string | undefined; to: string | undefined; }>",
           "parameters": [],
           "docs": "Get the currently selected date-range.",
           "docsTags": []
@@ -5600,11 +5813,11 @@
       "events": [
         {
           "event": "dateChange",
-          "detail": "{ from?: string; to?: string; }",
+          "detail": "{ from?: string | undefined; to?: string | undefined; }",
           "bubbles": true,
           "complexType": {
             "original": "DateChangeEvent",
-            "resolved": "{ from?: string; to?: string; }",
+            "resolved": "{ from?: string | undefined; to?: string | undefined; }",
             "references": {
               "DateChangeEvent": {
                 "location": "local",
@@ -5620,11 +5833,11 @@
         },
         {
           "event": "dateRangeChange",
-          "detail": "{ from?: string; to?: string; }",
+          "detail": "{ from?: string | undefined; to?: string | undefined; }",
           "bubbles": true,
           "complexType": {
             "original": "DateChangeEvent",
-            "resolved": "{ from?: string; to?: string; }",
+            "resolved": "{ from?: string | undefined; to?: string | undefined; }",
             "references": {
               "DateChangeEvent": {
                 "location": "local",
@@ -5640,11 +5853,11 @@
         },
         {
           "event": "dateSelect",
-          "detail": "{ from?: string; to?: string; }",
+          "detail": "{ from?: string | undefined; to?: string | undefined; }",
           "bubbles": true,
           "complexType": {
             "original": "DateChangeEvent",
-            "resolved": "{ from?: string; to?: string; }",
+            "resolved": "{ from?: string | undefined; to?: string | undefined; }",
             "references": {
               "DateChangeEvent": {
                 "location": "local",
@@ -5740,10 +5953,10 @@
         },
         {
           "name": "from",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -5754,6 +5967,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -5816,10 +6032,10 @@
         },
         {
           "name": "locale",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -5830,6 +6046,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -5839,10 +6058,10 @@
         },
         {
           "name": "maxDate",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -5853,6 +6072,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -5862,10 +6084,10 @@
         },
         {
           "name": "minDate",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -5876,6 +6098,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -6039,10 +6264,10 @@
         },
         {
           "name": "time",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -6053,6 +6278,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -6086,10 +6314,10 @@
         },
         {
           "name": "timeReference",
-          "type": "\"AM\" | \"PM\"",
+          "type": "\"AM\" | \"PM\" | undefined",
           "complexType": {
             "original": "'AM' | 'PM'",
-            "resolved": "\"AM\" | \"PM\"",
+            "resolved": "\"AM\" | \"PM\" | undefined",
             "references": {}
           },
           "mutable": false,
@@ -6105,6 +6333,9 @@
             {
               "value": "PM",
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -6114,10 +6345,10 @@
         },
         {
           "name": "to",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -6128,6 +6359,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -6164,11 +6398,11 @@
       "events": [
         {
           "event": "dateChange",
-          "detail": "string | { from?: string; to?: string; }",
+          "detail": "string | { from?: string | undefined; to?: string | undefined; }",
           "bubbles": true,
           "complexType": {
             "original": "DateTimeDateChangeEvent",
-            "resolved": "string | { from?: string; to?: string; }",
+            "resolved": "string | { from?: string | undefined; to?: string | undefined; }",
             "references": {
               "DateTimeDateChangeEvent": {
                 "location": "local",
@@ -6184,11 +6418,11 @@
         },
         {
           "event": "dateSelect",
-          "detail": "{ from?: string; to?: string; time: string; }",
+          "detail": "{ from?: string | undefined; to?: string | undefined; time: string; }",
           "bubbles": true,
           "complexType": {
             "original": "DateTimeSelectEvent",
-            "resolved": "{ from?: string; to?: string; time: string; }",
+            "resolved": "{ from?: string | undefined; to?: string | undefined; time: string; }",
             "references": {
               "DateTimeSelectEvent": {
                 "location": "local",
@@ -6441,7 +6675,7 @@
             "parameters": [
               {
                 "name": "show",
-                "type": "boolean",
+                "type": "boolean | undefined",
                 "docs": "Overwrite toggle state with boolean"
               }
             ],
@@ -6457,7 +6691,7 @@
           "parameters": [
             {
               "name": "show",
-              "type": "boolean",
+              "type": "boolean | undefined",
               "docs": "Overwrite toggle state with boolean"
             }
           ],
@@ -6573,10 +6807,10 @@
       "props": [
         {
           "name": "anchor",
-          "type": "HTMLElement | Promise<HTMLElement> | string",
+          "type": "HTMLElement | Promise<HTMLElement> | string | undefined",
           "complexType": {
             "original": "ElementReference",
-            "resolved": "HTMLElement | Promise<HTMLElement> | string",
+            "resolved": "HTMLElement | Promise<HTMLElement> | string | undefined",
             "references": {
               "ElementReference": {
                 "location": "import",
@@ -6599,6 +6833,9 @@
             },
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -6650,10 +6887,10 @@
         },
         {
           "name": "header",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -6664,6 +6901,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -6809,10 +7049,10 @@
         },
         {
           "name": "trigger",
-          "type": "HTMLElement | Promise<HTMLElement> | string",
+          "type": "HTMLElement | Promise<HTMLElement> | string | undefined",
           "complexType": {
             "original": "ElementReference",
-            "resolved": "HTMLElement | Promise<HTMLElement> | string",
+            "resolved": "HTMLElement | Promise<HTMLElement> | string | undefined",
             "references": {
               "ElementReference": {
                 "location": "import",
@@ -6835,6 +7075,9 @@
             },
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -7013,10 +7256,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -7027,6 +7270,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -7036,10 +7282,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -7050,6 +7296,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -7083,10 +7332,10 @@
         },
         {
           "name": "placement",
-          "type": "\"bottom-end\" | \"bottom-start\" | \"left-end\" | \"left-start\" | \"right-end\" | \"right-start\" | \"top-end\" | \"top-start\"",
+          "type": "\"bottom-end\" | \"bottom-start\" | \"left-end\" | \"left-start\" | \"right-end\" | \"right-start\" | \"top-end\" | \"top-start\" | undefined",
           "complexType": {
             "original": "AlignedPlacement",
-            "resolved": "\"bottom-end\" | \"bottom-start\" | \"left-end\" | \"left-start\" | \"right-end\" | \"right-start\" | \"top-end\" | \"top-start\"",
+            "resolved": "\"bottom-end\" | \"bottom-start\" | \"left-end\" | \"left-start\" | \"right-end\" | \"right-start\" | \"top-end\" | \"top-start\" | undefined",
             "references": {
               "AlignedPlacement": {
                 "location": "import",
@@ -7132,6 +7381,9 @@
             {
               "value": "top-start",
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -7210,10 +7462,10 @@
       "props": [
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -7224,6 +7476,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -7355,10 +7610,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -7369,6 +7624,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -7378,10 +7636,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -7392,6 +7650,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -7459,10 +7720,10 @@
       "props": [
         {
           "name": "action",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -7473,6 +7734,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -7505,10 +7769,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -7519,6 +7783,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -7567,10 +7834,10 @@
         },
         {
           "name": "subHeader",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -7581,6 +7848,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -7805,10 +8075,10 @@
         },
         {
           "name": "itemColor",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -7824,6 +8094,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -7959,10 +8232,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -7973,6 +8246,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -8143,10 +8419,10 @@
       "props": [
         {
           "name": "htmlFor",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -8157,6 +8433,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -8166,10 +8445,10 @@
         },
         {
           "name": "required",
-          "type": "boolean",
+          "type": "boolean | undefined",
           "complexType": {
             "original": "boolean",
-            "resolved": "boolean",
+            "resolved": "boolean | undefined",
             "references": {}
           },
           "mutable": true,
@@ -8180,6 +8459,9 @@
           "values": [
             {
               "type": "boolean"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -8384,10 +8666,10 @@
         },
         {
           "name": "state",
-          "type": "FlipTileState.Alarm | FlipTileState.Info | FlipTileState.None | FlipTileState.Primary | FlipTileState.Warning",
+          "type": "FlipTileState.Alarm | FlipTileState.Info | FlipTileState.None | FlipTileState.Primary | FlipTileState.Warning | undefined",
           "complexType": {
             "original": "FlipTileState",
-            "resolved": "FlipTileState.Alarm | FlipTileState.Info | FlipTileState.None | FlipTileState.Primary | FlipTileState.Warning",
+            "resolved": "FlipTileState.Alarm | FlipTileState.Info | FlipTileState.None | FlipTileState.Primary | FlipTileState.Warning | undefined",
             "references": {
               "FlipTileState": {
                 "location": "import",
@@ -8416,6 +8698,9 @@
             },
             {
               "type": "FlipTileState.Warning"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -8582,10 +8867,10 @@
         },
         {
           "name": "header",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -8596,6 +8881,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -8605,10 +8893,10 @@
         },
         {
           "name": "index",
-          "type": "number",
+          "type": "number | undefined",
           "complexType": {
             "original": "number",
-            "resolved": "number",
+            "resolved": "number | undefined",
             "references": {}
           },
           "mutable": true,
@@ -8619,6 +8907,9 @@
           "values": [
             {
               "type": "number"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -8652,10 +8943,10 @@
         },
         {
           "name": "subHeader",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -8666,6 +8957,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -8839,10 +9133,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -8853,6 +9147,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -8862,10 +9159,10 @@
         },
         {
           "name": "index",
-          "type": "number",
+          "type": "number | undefined",
           "complexType": {
             "original": "number",
-            "resolved": "number",
+            "resolved": "number | undefined",
             "references": {}
           },
           "mutable": false,
@@ -8876,6 +9173,9 @@
           "values": [
             {
               "type": "number"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -8885,10 +9185,10 @@
         },
         {
           "name": "secondaryText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -8899,6 +9199,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -8956,10 +9259,10 @@
         },
         {
           "name": "text",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -8970,6 +9273,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -9035,10 +9341,10 @@
       "props": [
         {
           "name": "helperText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -9049,6 +9355,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -9058,10 +9367,10 @@
         },
         {
           "name": "htmlFor",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -9072,6 +9381,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -9081,10 +9393,10 @@
         },
         {
           "name": "infoText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -9095,6 +9407,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -9104,10 +9419,10 @@
         },
         {
           "name": "invalidText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -9118,6 +9433,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -9127,10 +9445,10 @@
         },
         {
           "name": "validText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -9141,6 +9459,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -9150,10 +9471,10 @@
         },
         {
           "name": "warningText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -9164,6 +9485,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -9324,10 +9648,10 @@
       "props": [
         {
           "name": "a11yLabel",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -9338,6 +9662,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -9395,10 +9722,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -9409,6 +9736,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -9418,10 +9748,10 @@
         },
         {
           "name": "iconColor",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -9432,6 +9762,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -9692,10 +10025,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -9706,6 +10039,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -9963,10 +10299,10 @@
       "props": [
         {
           "name": "allowedCharactersPattern",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -9977,6 +10313,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -10010,10 +10349,10 @@
         },
         {
           "name": "helperText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -10024,6 +10363,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -10033,10 +10375,10 @@
         },
         {
           "name": "infoText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -10047,6 +10389,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -10056,10 +10401,10 @@
         },
         {
           "name": "invalidText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -10070,6 +10415,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -10079,10 +10427,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -10093,6 +10441,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -10102,10 +10453,10 @@
         },
         {
           "name": "maxLength",
-          "type": "number",
+          "type": "number | undefined",
           "complexType": {
             "original": "number",
-            "resolved": "number",
+            "resolved": "number | undefined",
             "references": {}
           },
           "mutable": false,
@@ -10116,6 +10467,9 @@
           "values": [
             {
               "type": "number"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -10125,10 +10479,10 @@
         },
         {
           "name": "minLength",
-          "type": "number",
+          "type": "number | undefined",
           "complexType": {
             "original": "number",
-            "resolved": "number",
+            "resolved": "number | undefined",
             "references": {}
           },
           "mutable": false,
@@ -10139,6 +10493,9 @@
           "values": [
             {
               "type": "number"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -10148,10 +10505,10 @@
         },
         {
           "name": "name",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -10162,6 +10519,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -10171,10 +10531,10 @@
         },
         {
           "name": "pattern",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -10185,6 +10545,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -10194,10 +10557,10 @@
         },
         {
           "name": "placeholder",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -10208,6 +10571,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -10265,10 +10631,10 @@
         },
         {
           "name": "showTextAsTooltip",
-          "type": "boolean",
+          "type": "boolean | undefined",
           "complexType": {
             "original": "boolean",
-            "resolved": "boolean",
+            "resolved": "boolean | undefined",
             "references": {}
           },
           "mutable": false,
@@ -10279,6 +10645,9 @@
           "values": [
             {
               "type": "boolean"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -10329,10 +10698,10 @@
         },
         {
           "name": "validText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -10343,6 +10712,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -10376,10 +10748,10 @@
         },
         {
           "name": "warningText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -10390,6 +10762,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -10589,10 +10964,10 @@
       "props": [
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -10603,6 +10978,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -10670,10 +11048,10 @@
         },
         {
           "name": "value",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -10684,6 +11062,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -10770,10 +11151,10 @@
       "props": [
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -10784,6 +11165,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -10855,10 +11239,10 @@
         },
         {
           "name": "unit",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -10869,6 +11253,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -10878,10 +11265,10 @@
         },
         {
           "name": "value",
-          "type": "number | string",
+          "type": "number | string | undefined",
           "complexType": {
             "original": "string | number",
-            "resolved": "number | string",
+            "resolved": "number | string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -10895,6 +11282,9 @@
             },
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -11156,10 +11546,10 @@
         },
         {
           "name": "url",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -11170,6 +11560,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -11229,10 +11622,10 @@
       "props": [
         {
           "name": "applicationName",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -11243,6 +11636,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -11276,10 +11672,10 @@
         },
         {
           "name": "navigationTitle",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -11290,6 +11686,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -11348,12 +11747,12 @@
               },
               {
                 "name": "icon",
-                "type": "string",
+                "type": "string | undefined",
                 "docs": ""
               },
               {
                 "name": "color",
-                "type": "string",
+                "type": "string | undefined",
                 "docs": ""
               }
             ],
@@ -11383,12 +11782,12 @@
             },
             {
               "name": "icon",
-              "type": "string",
+              "type": "string | undefined",
               "docs": ""
             },
             {
               "name": "color",
-              "type": "string",
+              "type": "string | undefined",
               "docs": ""
             }
           ],
@@ -11428,7 +11827,7 @@
             "parameters": [
               {
                 "name": "show",
-                "type": "boolean",
+                "type": "boolean | undefined",
                 "docs": "new visibility state"
               }
             ],
@@ -11444,7 +11843,7 @@
           "parameters": [
             {
               "name": "show",
-              "type": "boolean",
+              "type": "boolean | undefined",
               "docs": "new visibility state"
             }
           ],
@@ -11524,10 +11923,10 @@
       "props": [
         {
           "name": "color",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -11544,6 +11943,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -11553,10 +11955,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -11567,6 +11969,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -11576,10 +11981,10 @@
         },
         {
           "name": "iconColor",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -11590,6 +11995,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -11599,10 +12007,10 @@
         },
         {
           "name": "name",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -11613,6 +12021,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -11708,10 +12119,10 @@
         },
         {
           "name": "applicationName",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -11722,6 +12133,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -12093,7 +12507,7 @@
             "parameters": [
               {
                 "name": "show",
-                "type": "boolean",
+                "type": "boolean | undefined",
                 "docs": ""
               }
             ],
@@ -12109,7 +12523,7 @@
           "parameters": [
             {
               "name": "show",
-              "type": "boolean",
+              "type": "boolean | undefined",
               "docs": ""
             }
           ],
@@ -12132,7 +12546,7 @@
             "parameters": [
               {
                 "name": "show",
-                "type": "boolean",
+                "type": "boolean | undefined",
                 "docs": ""
               }
             ],
@@ -12148,7 +12562,7 @@
           "parameters": [
             {
               "name": "show",
-              "type": "boolean",
+              "type": "boolean | undefined",
               "docs": ""
             }
           ],
@@ -12335,10 +12749,10 @@
       "props": [
         {
           "name": "activeTabLabel",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": true,
@@ -12349,6 +12763,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -12446,10 +12863,10 @@
       "props": [
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -12460,6 +12877,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -12530,10 +12950,10 @@
       "props": [
         {
           "name": "aboutItemLabel",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -12544,6 +12964,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -12577,10 +13000,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -12591,6 +13014,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -12725,10 +13151,10 @@
       "props": [
         {
           "name": "bottom",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -12739,6 +13165,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -12772,10 +13201,10 @@
         },
         {
           "name": "image",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -12786,6 +13215,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -12795,10 +13227,10 @@
         },
         {
           "name": "initials",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -12809,6 +13241,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -12842,10 +13277,10 @@
         },
         {
           "name": "top",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -12856,6 +13291,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -12915,10 +13353,10 @@
       "props": [
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -12929,6 +13367,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -12938,10 +13379,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -12952,6 +13393,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -13025,10 +13469,10 @@
       "props": [
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -13039,6 +13483,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -13048,10 +13495,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -13062,6 +13509,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -13071,10 +13521,10 @@
         },
         {
           "name": "notifications",
-          "type": "number",
+          "type": "number | undefined",
           "complexType": {
             "original": "number",
-            "resolved": "number",
+            "resolved": "number | undefined",
             "references": {}
           },
           "mutable": false,
@@ -13085,6 +13535,9 @@
           "values": [
             {
               "type": "number"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -13244,10 +13697,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": true,
@@ -13263,6 +13716,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -13272,10 +13728,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -13286,6 +13742,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -13295,10 +13754,10 @@
         },
         {
           "name": "notifications",
-          "type": "number",
+          "type": "number | undefined",
           "complexType": {
             "original": "number",
-            "resolved": "number",
+            "resolved": "number | undefined",
             "references": {}
           },
           "mutable": false,
@@ -13309,6 +13768,9 @@
           "values": [
             {
               "type": "number"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -13360,10 +13822,10 @@
       "props": [
         {
           "name": "activeTabLabel",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": true,
@@ -13374,6 +13836,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -13471,10 +13936,10 @@
       "props": [
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -13485,6 +13950,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -13732,10 +14200,10 @@
         },
         {
           "name": "beforeDismiss",
-          "type": "(reason?: any) => boolean | Promise<boolean>",
+          "type": "((reason?: any) => boolean | Promise<boolean>) | undefined",
           "complexType": {
             "original": "(reason?: any) => boolean | Promise<boolean>",
-            "resolved": "(reason?: any) => boolean | Promise<boolean>",
+            "resolved": "((reason?: any) => boolean | Promise<boolean>) | undefined",
             "references": {
               "Promise": {
                 "location": "global",
@@ -13750,10 +14218,13 @@
           "docsTags": [],
           "values": [
             {
-              "type": "(reason?: any) => boolean"
+              "type": "((reason?: any) => boolean"
             },
             {
-              "type": "Promise<boolean>"
+              "type": "Promise<boolean>)"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -13939,7 +14410,7 @@
             "parameters": [
               {
                 "name": "reason",
-                "type": "T",
+                "type": "T | undefined",
                 "docs": ""
               }
             ],
@@ -13959,7 +14430,7 @@
           "parameters": [
             {
               "name": "reason",
-              "type": "T",
+              "type": "T | undefined",
               "docs": ""
             }
           ],
@@ -14138,10 +14609,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -14152,6 +14623,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -14161,10 +14635,10 @@
         },
         {
           "name": "iconColor",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -14175,6 +14649,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -14262,10 +14739,10 @@
       "props": [
         {
           "name": "allowedCharactersPattern",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -14276,6 +14753,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -14309,10 +14789,10 @@
         },
         {
           "name": "helperText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -14323,6 +14803,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -14332,10 +14815,10 @@
         },
         {
           "name": "infoText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -14346,6 +14829,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -14355,10 +14841,10 @@
         },
         {
           "name": "invalidText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -14369,6 +14855,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -14378,10 +14867,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -14392,6 +14881,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -14401,10 +14893,10 @@
         },
         {
           "name": "max",
-          "type": "number | string",
+          "type": "number | string | undefined",
           "complexType": {
             "original": "string | number",
-            "resolved": "number | string",
+            "resolved": "number | string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -14418,6 +14910,9 @@
             },
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -14427,10 +14922,10 @@
         },
         {
           "name": "min",
-          "type": "number | string",
+          "type": "number | string | undefined",
           "complexType": {
             "original": "string | number",
-            "resolved": "number | string",
+            "resolved": "number | string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -14444,6 +14939,9 @@
             },
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -14453,10 +14951,10 @@
         },
         {
           "name": "name",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -14467,6 +14965,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -14476,10 +14977,10 @@
         },
         {
           "name": "pattern",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -14490,6 +14991,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -14499,10 +15003,10 @@
         },
         {
           "name": "placeholder",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -14513,6 +15017,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -14570,10 +15077,10 @@
         },
         {
           "name": "showStepperButtons",
-          "type": "boolean",
+          "type": "boolean | undefined",
           "complexType": {
             "original": "boolean",
-            "resolved": "boolean",
+            "resolved": "boolean | undefined",
             "references": {}
           },
           "mutable": false,
@@ -14584,6 +15091,9 @@
           "values": [
             {
               "type": "boolean"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -14593,10 +15103,10 @@
         },
         {
           "name": "showTextAsTooltip",
-          "type": "boolean",
+          "type": "boolean | undefined",
           "complexType": {
             "original": "boolean",
-            "resolved": "boolean",
+            "resolved": "boolean | undefined",
             "references": {}
           },
           "mutable": false,
@@ -14607,6 +15117,9 @@
           "values": [
             {
               "type": "boolean"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -14616,10 +15129,10 @@
         },
         {
           "name": "step",
-          "type": "number | string",
+          "type": "number | string | undefined",
           "complexType": {
             "original": "string | number",
-            "resolved": "number | string",
+            "resolved": "number | string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -14638,6 +15151,9 @@
             },
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -14647,10 +15163,10 @@
         },
         {
           "name": "validText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -14661,6 +15177,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -14694,10 +15213,10 @@
         },
         {
           "name": "warningText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -14708,6 +15227,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -15236,10 +15758,10 @@
         },
         {
           "name": "heading",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -15250,6 +15772,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -15283,10 +15808,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -15297,6 +15822,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -15624,10 +16152,10 @@
         },
         {
           "name": "background",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string | undefined",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -15638,6 +16166,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": false,
@@ -15647,10 +16178,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -15661,6 +16192,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -15694,10 +16228,10 @@
         },
         {
           "name": "pillColor",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string | undefined",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -15708,6 +16242,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": false,
@@ -15864,10 +16401,10 @@
         },
         {
           "name": "heading",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -15878,6 +16415,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -15887,10 +16427,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -15901,6 +16441,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -15910,10 +16453,10 @@
         },
         {
           "name": "notification",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -15924,6 +16467,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -15933,10 +16479,10 @@
         },
         {
           "name": "subheading",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -15947,6 +16493,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -16101,10 +16650,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -16115,6 +16664,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -16124,10 +16676,10 @@
         },
         {
           "name": "name",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -16138,6 +16690,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -16176,10 +16731,10 @@
         },
         {
           "name": "value",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -16190,6 +16745,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -16316,10 +16874,10 @@
         },
         {
           "name": "helperText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -16330,6 +16888,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -16339,10 +16900,10 @@
         },
         {
           "name": "infoText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -16353,6 +16914,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -16362,10 +16926,10 @@
         },
         {
           "name": "invalidText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -16376,6 +16940,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -16385,10 +16952,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -16399,6 +16966,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -16408,10 +16978,10 @@
         },
         {
           "name": "showTextAsTooltip",
-          "type": "boolean",
+          "type": "boolean | undefined",
           "complexType": {
             "original": "boolean",
-            "resolved": "boolean",
+            "resolved": "boolean | undefined",
             "references": {}
           },
           "mutable": false,
@@ -16422,6 +16992,9 @@
           "values": [
             {
               "type": "boolean"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -16431,10 +17004,10 @@
         },
         {
           "name": "validText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -16445,6 +17018,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -16454,10 +17030,10 @@
         },
         {
           "name": "value",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -16468,6 +17044,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -16477,10 +17056,10 @@
         },
         {
           "name": "warningText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -16491,6 +17070,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -16671,10 +17253,10 @@
         },
         {
           "name": "dropdownMaxWidth",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -16685,6 +17267,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -16694,10 +17279,10 @@
         },
         {
           "name": "dropdownWidth",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -16708,6 +17293,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -16741,10 +17329,10 @@
         },
         {
           "name": "helperText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -16755,6 +17343,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -16884,10 +17475,10 @@
         },
         {
           "name": "infoText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -16898,6 +17489,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -16907,10 +17501,10 @@
         },
         {
           "name": "invalidText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -16921,6 +17515,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -16930,10 +17527,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -16944,6 +17541,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -16982,10 +17582,10 @@
         },
         {
           "name": "name",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -16996,6 +17596,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -17053,10 +17656,10 @@
         },
         {
           "name": "showTextAsTooltip",
-          "type": "boolean",
+          "type": "boolean | undefined",
           "complexType": {
             "original": "boolean",
-            "resolved": "boolean",
+            "resolved": "boolean | undefined",
             "references": {}
           },
           "mutable": false,
@@ -17067,6 +17670,9 @@
           "values": [
             {
               "type": "boolean"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -17076,10 +17682,10 @@
         },
         {
           "name": "validText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -17090,6 +17696,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -17126,10 +17735,10 @@
         },
         {
           "name": "warningText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -17140,6 +17749,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -17310,10 +17922,10 @@
       "props": [
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -17324,6 +17936,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -17463,10 +18078,10 @@
         },
         {
           "name": "error",
-          "type": "boolean | string",
+          "type": "boolean | string | undefined",
           "complexType": {
             "original": "boolean | string",
-            "resolved": "boolean | string",
+            "resolved": "boolean | string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -17480,6 +18095,9 @@
             },
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -17489,10 +18107,10 @@
         },
         {
           "name": "marker",
-          "type": "number[]",
+          "type": "number[] | undefined",
           "complexType": {
             "original": "SliderMarker",
-            "resolved": "number[]",
+            "resolved": "number[] | undefined",
             "references": {
               "SliderMarker": {
                 "location": "local",
@@ -17509,6 +18127,9 @@
           "values": [
             {
               "type": "number[]"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -17965,10 +18586,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -17979,6 +18600,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -17988,10 +18612,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -18002,6 +18626,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -18094,10 +18721,10 @@
         },
         {
           "name": "splitIcon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -18108,6 +18735,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -18210,10 +18840,10 @@
       "props": [
         {
           "name": "counter",
-          "type": "number",
+          "type": "number | undefined",
           "complexType": {
             "original": "number",
-            "resolved": "number",
+            "resolved": "number | undefined",
             "references": {}
           },
           "mutable": false,
@@ -18224,6 +18854,9 @@
           "values": [
             {
               "type": "number"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -18694,10 +19327,10 @@
         },
         {
           "name": "helperText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -18708,6 +19341,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -18717,10 +19353,10 @@
         },
         {
           "name": "infoText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -18731,6 +19367,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -18740,10 +19379,10 @@
         },
         {
           "name": "invalidText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -18754,6 +19393,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -18763,10 +19405,10 @@
         },
         {
           "name": "label",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -18777,6 +19419,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -18786,10 +19431,10 @@
         },
         {
           "name": "maxLength",
-          "type": "number",
+          "type": "number | undefined",
           "complexType": {
             "original": "number",
-            "resolved": "number",
+            "resolved": "number | undefined",
             "references": {}
           },
           "mutable": false,
@@ -18800,6 +19445,9 @@
           "values": [
             {
               "type": "number"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -18809,10 +19457,10 @@
         },
         {
           "name": "minLength",
-          "type": "number",
+          "type": "number | undefined",
           "complexType": {
             "original": "number",
-            "resolved": "number",
+            "resolved": "number | undefined",
             "references": {}
           },
           "mutable": false,
@@ -18823,6 +19471,9 @@
           "values": [
             {
               "type": "number"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -18832,10 +19483,10 @@
         },
         {
           "name": "name",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -18846,6 +19497,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -18855,10 +19509,10 @@
         },
         {
           "name": "placeholder",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -18869,6 +19523,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -18969,10 +19626,10 @@
         },
         {
           "name": "showTextAsTooltip",
-          "type": "boolean",
+          "type": "boolean | undefined",
           "complexType": {
             "original": "boolean",
-            "resolved": "boolean",
+            "resolved": "boolean | undefined",
             "references": {}
           },
           "mutable": false,
@@ -18983,6 +19640,9 @@
           "values": [
             {
               "type": "boolean"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -18992,10 +19652,10 @@
         },
         {
           "name": "textareaCols",
-          "type": "number",
+          "type": "number | undefined",
           "complexType": {
             "original": "number",
-            "resolved": "number",
+            "resolved": "number | undefined",
             "references": {}
           },
           "mutable": false,
@@ -19006,6 +19666,9 @@
           "values": [
             {
               "type": "number"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -19015,10 +19678,10 @@
         },
         {
           "name": "textareaHeight",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -19029,6 +19692,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -19038,10 +19704,10 @@
         },
         {
           "name": "textareaRows",
-          "type": "number",
+          "type": "number | undefined",
           "complexType": {
             "original": "number",
-            "resolved": "number",
+            "resolved": "number | undefined",
             "references": {}
           },
           "mutable": false,
@@ -19052,6 +19718,9 @@
           "values": [
             {
               "type": "number"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -19061,10 +19730,10 @@
         },
         {
           "name": "textareaWidth",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -19075,6 +19744,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -19084,10 +19756,10 @@
         },
         {
           "name": "validText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -19098,6 +19770,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -19131,10 +19806,10 @@
         },
         {
           "name": "warningText",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -19145,6 +19820,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -19590,10 +20268,10 @@
         },
         {
           "name": "timeReference",
-          "type": "\"AM\" | \"PM\"",
+          "type": "\"AM\" | \"PM\" | undefined",
           "complexType": {
             "original": "'AM' | 'PM' | undefined",
-            "resolved": "\"AM\" | \"PM\"",
+            "resolved": "\"AM\" | \"PM\" | undefined",
             "references": {}
           },
           "mutable": false,
@@ -19609,6 +20287,9 @@
             {
               "value": "PM",
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": false,
@@ -19621,11 +20302,11 @@
         {
           "name": "getCurrentTime",
           "returns": {
-            "type": "Promise<string>",
+            "type": "Promise<string | undefined>",
             "docs": ""
           },
           "complexType": {
-            "signature": "() => Promise<string>",
+            "signature": "() => Promise<string | undefined>",
             "parameters": [],
             "references": {
               "Promise": {
@@ -19633,9 +20314,9 @@
                 "id": "global::Promise"
               }
             },
-            "return": "Promise<string>"
+            "return": "Promise<string | undefined>"
           },
-          "signature": "getCurrentTime() => Promise<string>",
+          "signature": "getCurrentTime() => Promise<string | undefined>",
           "parameters": [],
           "docs": "Get the current time based on the wanted format",
           "docsTags": []
@@ -19756,10 +20437,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -19770,6 +20451,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -19779,10 +20463,10 @@
         },
         {
           "name": "iconColor",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -19793,6 +20477,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -19802,10 +20489,10 @@
         },
         {
           "name": "toastTitle",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -19816,6 +20503,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -20180,10 +20870,10 @@
         },
         {
           "name": "name",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -20194,6 +20884,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -20430,10 +21123,10 @@
         },
         {
           "name": "icon",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -20444,6 +21137,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -20639,10 +21335,10 @@
       "props": [
         {
           "name": "for",
-          "type": "ElementReference[] | HTMLElement | Promise<HTMLElement> | string",
+          "type": "ElementReference[] | HTMLElement | Promise<HTMLElement> | string | undefined",
           "complexType": {
             "original": "ElementReference | ElementReference[]",
-            "resolved": "ElementReference[] | HTMLElement | Promise<HTMLElement> | string",
+            "resolved": "ElementReference[] | HTMLElement | Promise<HTMLElement> | string | undefined",
             "references": {
               "ElementReference": {
                 "location": "import",
@@ -20668,6 +21364,9 @@
             },
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -20738,10 +21437,10 @@
         },
         {
           "name": "titleContent",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -20752,6 +21451,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -20860,10 +21562,10 @@
         },
         {
           "name": "renderItem",
-          "type": "<T = any>(index: number, data: T, dataList: T[], context: TreeContext, update: (callback: UpdateCallback) => void) => HTMLElement",
+          "type": "(<T = any>(index: number, data: T, dataList: T[], context: TreeContext, update: (callback: UpdateCallback) => void) => HTMLElement) | undefined",
           "complexType": {
             "original": "<T = any>(\n    index: number,\n    data: T,\n    dataList: Array<T>,\n    context: TreeContext,\n    update: (callback: UpdateCallback) => void\n  ) => HTMLElement",
-            "resolved": "<T = any>(index: number, data: T, dataList: T[], context: TreeContext, update: (callback: UpdateCallback) => void) => HTMLElement",
+            "resolved": "(<T = any>(index: number, data: T, dataList: T[], context: TreeContext, update: (callback: UpdateCallback) => void) => HTMLElement) | undefined",
             "references": {
               "T": {
                 "location": "global",
@@ -20896,7 +21598,10 @@
           "docsTags": [],
           "values": [
             {
-              "type": "<T = any>(index: number, data: T, dataList: T[], context: TreeContext, update: (callback: UpdateCallback) => void) => HTMLElement"
+              "type": "(<T = any>(index: number, data: T, dataList: T[], context: TreeContext, update: (callback: UpdateCallback) => void) => HTMLElement)"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -20929,10 +21634,10 @@
         },
         {
           "name": "toggleOnItemClick",
-          "type": "boolean",
+          "type": "boolean | undefined",
           "complexType": {
             "original": "boolean",
-            "resolved": "boolean",
+            "resolved": "boolean | undefined",
             "references": {}
           },
           "mutable": false,
@@ -20948,6 +21653,9 @@
           "values": [
             {
               "type": "boolean"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -21056,10 +21764,10 @@
       "props": [
         {
           "name": "context",
-          "type": "TreeItemContext",
+          "type": "TreeItemContext | undefined",
           "complexType": {
             "original": "TreeItemContext",
-            "resolved": "TreeItemContext",
+            "resolved": "TreeItemContext | undefined",
             "references": {
               "TreeItemContext": {
                 "location": "import",
@@ -21076,6 +21784,9 @@
           "values": [
             {
               "type": "TreeItemContext"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -21109,10 +21820,10 @@
         },
         {
           "name": "text",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -21123,6 +21834,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -21315,10 +22029,10 @@
         },
         {
           "name": "format",
-          "type": "TypographyFormatLabel | TypographyFormatBody | TypographyFormatDisplay | TypographyFormatHeading | TypographyFormatCode",
+          "type": "TypographyFormat | undefined",
           "complexType": {
             "original": "TypographyFormat",
-            "resolved": "TypographyFormatLabel | TypographyFormatBody | TypographyFormatDisplay | TypographyFormatHeading | TypographyFormatCode",
+            "resolved": "TypographyFormat | undefined",
             "references": {
               "TypographyFormat": {
                 "location": "local",
@@ -21334,19 +22048,10 @@
           "docsTags": [],
           "values": [
             {
-              "type": "TypographyFormatLabel"
+              "type": "TypographyFormat"
             },
             {
-              "type": "TypographyFormatBody"
-            },
-            {
-              "type": "TypographyFormatDisplay"
-            },
-            {
-              "type": "TypographyFormatHeading"
-            },
-            {
-              "type": "TypographyFormatCode"
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -21356,10 +22061,10 @@
         },
         {
           "name": "textColor",
-          "type": "\"alarm\" | \"alarm-contrast\" | \"contrast\" | \"critical-contrast\" | \"info-contrast\" | \"inv-contrast\" | \"inv-soft\" | \"inv-std\" | \"inv-weak\" | \"neutral-contrast\" | \"primary-contrast\" | \"soft\" | \"std\" | \"success-contrast\" | \"warning-contrast\" | \"weak\"",
+          "type": "\"alarm\" | \"alarm-contrast\" | \"contrast\" | \"critical-contrast\" | \"info-contrast\" | \"inv-contrast\" | \"inv-soft\" | \"inv-std\" | \"inv-weak\" | \"neutral-contrast\" | \"primary-contrast\" | \"soft\" | \"std\" | \"success-contrast\" | \"warning-contrast\" | \"weak\" | undefined",
           "complexType": {
             "original": "TypographyColors",
-            "resolved": "\"alarm\" | \"alarm-contrast\" | \"contrast\" | \"critical-contrast\" | \"info-contrast\" | \"inv-contrast\" | \"inv-soft\" | \"inv-std\" | \"inv-weak\" | \"neutral-contrast\" | \"primary-contrast\" | \"soft\" | \"std\" | \"success-contrast\" | \"warning-contrast\" | \"weak\"",
+            "resolved": "\"alarm\" | \"alarm-contrast\" | \"contrast\" | \"critical-contrast\" | \"info-contrast\" | \"inv-contrast\" | \"inv-soft\" | \"inv-std\" | \"inv-weak\" | \"neutral-contrast\" | \"primary-contrast\" | \"soft\" | \"std\" | \"success-contrast\" | \"warning-contrast\" | \"weak\" | undefined",
             "references": {
               "TypographyColors": {
                 "location": "local",
@@ -21437,6 +22142,9 @@
             {
               "value": "weak",
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -21520,10 +22228,10 @@
       "props": [
         {
           "name": "accept",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -21534,6 +22242,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,
@@ -21896,10 +22607,10 @@
       "props": [
         {
           "name": "message",
-          "type": "string",
+          "type": "string | undefined",
           "complexType": {
             "original": "string",
-            "resolved": "string",
+            "resolved": "string | undefined",
             "references": {}
           },
           "mutable": false,
@@ -21910,6 +22621,9 @@
           "values": [
             {
               "type": "string"
+            },
+            {
+              "type": "undefined"
             }
           ],
           "optional": true,

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -796,7 +796,7 @@ export namespace Components {
         /**
           * Get the currently selected date-range.
          */
-        "getCurrentDate": () => Promise<{ from: string; to: string; }>;
+        "getCurrentDate": () => Promise<{ from: string | undefined; to: string | undefined; }>;
         /**
           * Text of date select button
          */
@@ -2690,7 +2690,7 @@ export namespace Components {
         /**
           * Get the current time based on the wanted format
          */
-        "getCurrentTime": () => Promise<string>;
+        "getCurrentTime": () => Promise<string | undefined>;
         /**
           * Show hour input
          */

--- a/packages/core/src/components/checkbox-group/checkbox-group.tsx
+++ b/packages/core/src/components/checkbox-group/checkbox-group.tsx
@@ -77,7 +77,7 @@ export class CheckboxGroup
   @State() isWarning = false;
 
   private touched = false;
-  private readonly groupRef = makeRef<HTMLIxCheckboxGroupElement>();
+  private readonly groupRef = makeRef<HTMLElement>();
 
   get checkboxElements(): HTMLIxCheckboxElement[] {
     return Array.from(this.hostElement.querySelectorAll('ix-checkbox'));

--- a/packages/core/src/components/date-input/date-input.tsx
+++ b/packages/core/src/components/date-input/date-input.tsx
@@ -165,7 +165,7 @@ export class DateInput implements IxInputFieldComponent<string | undefined> {
   @Event() ixBlur!: EventEmitter<void>;
 
   @State() show = false;
-  @State() from: string | null = null;
+  @State() from?: string | null = null;
   @State() isInputInvalid = false;
   @State() isInvalid = false;
   @State() isValid = false;
@@ -187,7 +187,11 @@ export class DateInput implements IxInputFieldComponent<string | undefined> {
   private disposableChangesAndVisibilityObservers?: DisposableChangesAndVisibilityObservers;
 
   updateFormInternalValue(value: string | undefined): void {
-    this.formInternals.setFormValue(value);
+    if (value) {
+      this.formInternals.setFormValue(value);
+    } else {
+      this.formInternals.setFormValue(null);
+    }
     this.value = value;
   }
 

--- a/packages/core/src/components/input/input.tsx
+++ b/packages/core/src/components/input/input.tsx
@@ -241,8 +241,9 @@ export class Input implements IxInputFieldComponent<string> {
    * Returns the validity state of the input field.
    */
   @Method()
-  getValidityState(): Promise<ValidityState> {
-    return Promise.resolve(this.inputRef.current.validity);
+  async getValidityState(): Promise<ValidityState> {
+    const input = await this.inputRef.waitForCurrent();
+    return Promise.resolve(input.validity);
   }
 
   /**

--- a/packages/core/src/components/radio-group/radio-group.tsx
+++ b/packages/core/src/components/radio-group/radio-group.tsx
@@ -102,7 +102,7 @@ export class RadiobuttonGroup
   @State() isWarning = false;
 
   private touched = false;
-  private readonly groupRef = makeRef<HTMLIxRadioGroupElement>();
+  private readonly groupRef = makeRef<HTMLElement>();
 
   private readonly observer = new MutationObserver(() => {
     this.ensureOnlyLastRadioChecked();

--- a/packages/core/src/components/radio/radio.tsx
+++ b/packages/core/src/components/radio/radio.tsx
@@ -85,7 +85,7 @@ export class Radio implements IxFormComponent<string> {
   /**
    * Event emitted when the radio is blurred
    */
-  @Event() ixBlur: EventEmitter<void>;
+  @Event() ixBlur!: EventEmitter<void>;
 
   private classMutationObserver?: ClassMutationObserver;
 

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -125,7 +125,7 @@ export class Slider {
 
   @Watch('showTooltip')
   onShowTooltipChange() {
-    if (this.showTooltip) {
+    if (this.showTooltip && this.pseudoThumb) {
       this.tooltip?.showTooltip(this.pseudoThumb);
       return;
     }

--- a/packages/core/tsconfig.lib.json
+++ b/packages/core/tsconfig.lib.json
@@ -18,7 +18,8 @@
     "baseUrl": ".",
     "paths": {
       "@utils/test": ["src/tests/utils/test"]
-    }
+    },
+    "strict": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "playwright.config.ts", "playwright-ct.config.ts"]


### PR DESCRIPTION
## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Enable `strict: true` inside tsconfig of `@siemens/ix`

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
