### PR TITLE
fix(core/chip): Text can be placed inside Chip with center alignment

### DIFF
--- a/packages/core/src/components/chip/chip.scss
+++ b/packages/core/src/components/chip/chip.scss
@@ -25,3 +25,10 @@
 }
 
 @include chip-container;
+
+:host {
+  .container {
+    height: 100%;
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## 💡 What is the current behavior?

- Text within ix-chip automatically aligns left when width property is set

GitHub Issue Number: #1854 

## 🆕 What is the new behavior?

- Text within ix-chip automatically aligns center when width property is set

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

