### PR TITLE
Added trim to helper text to elimintae empty strings and blank spaces…

### DIFF
--- a/packages/core/src/components/field-wrapper/helper-text-util.tsx
+++ b/packages/core/src/components/field-wrapper/helper-text-util.tsx
@@ -27,8 +27,8 @@ export function hasAnyText({
   validText?: string;
   helperText?: string;
 }) {
-  return invalidText || warningText || infoText || validText || helperText;
-}
+  return (invalidText?.trim() || warningText?.trim() || infoText?.trim() ||
+  validText?.trim() || helperText?.trim());}
 
 export function renderHelperText({
   isInvalid,
@@ -51,17 +51,17 @@ export function renderHelperText({
   validText?: string;
   helperText?: string;
 }) {
-  if (isInvalid && invalidText !== undefined) {
+  if (isInvalid && invalidText?.trim() !== '') {
     return (
       <ix-typography textColor="alarm" class="bottom-text">
         <ix-icon class="text-icon invalid" name={iconError} size="16"></ix-icon>
 
-        {invalidText}
+        {invalidText.trim()}
       </ix-typography>
     );
   }
 
-  if (isWarning && warningText !== undefined) {
+  if (isWarning && warningText?.trim() !== '') {
     return (
       <ix-typography textColor="std" class="bottom-text">
         <ix-icon
@@ -69,33 +69,33 @@ export function renderHelperText({
           name={iconWarning}
           size="16"
         ></ix-icon>
-        {warningText}
+        {warningText.trim()}
       </ix-typography>
     );
   }
 
-  if (isInfo && infoText !== undefined) {
+  if (isInfo && infoText?.trim() !== '') {
     return (
       <ix-typography textColor="std" class="bottom-text">
         <ix-icon class="text-icon info" name={iconInfo} size="16"></ix-icon>
-        {infoText}
+        {infoText.trim()}
       </ix-typography>
     );
   }
 
-  if (isValid && validText !== undefined) {
+  if (isValid && validText?.trim() !== '') {
     return (
       <ix-typography textColor="std" class="bottom-text">
         <ix-icon class="text-icon valid" name={iconSuccess} size="16"></ix-icon>
-        {validText}
+        {validText.trim()}
       </ix-typography>
     );
   }
 
   return (
-    helperText && (
+    helperText?.trim() && (
       <ix-typography class="bottom-text" textColor="soft">
-        {helperText}
+        {helperText.trim()}
       </ix-typography>
     )
   );


### PR DESCRIPTION

## 💡 What is the current behavior?
Helpertext and other state based texts aren't trimmed, and cause formatting issue when empty strings/space is passed as text.

GitHub Issue Number: #<ISSUE NUMBER>
Jira ticket- https://agileworld.siemens.cloud/jira/browse/IX-2329

## 🆕 What is the new behavior?

Added trim to helper text util function to prevent empty strings and strings with just a space from passing as text options

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support
