### PR TITLE
fix(core): dont render ix-icon when icon is not set on ix-pill and ix-chip 

### DIFF
--- a/.changeset/nine-baboons-own.md
+++ b/.changeset/nine-baboons-own.md
@@ -1,0 +1,8 @@
+---
+'@siemens/ix': patch
+---
+
+skip render of ix-icon on ix-pill and ix-chip when `iconName` is not set.
+
+Fixes #1885
+Fixes #1879

--- a/.changeset/nine-baboons-own.md
+++ b/.changeset/nine-baboons-own.md
@@ -2,7 +2,7 @@
 '@siemens/ix': patch
 ---
 
-skip render of ix-icon on ix-pill and ix-chip when `iconName` is not set.
+skip render of ix-icon on `ix-pill` and `ix-chip` when `icon` is not set.
 
 Fixes #1885
 Fixes #1879

--- a/packages/core/src/components/chip/chip-mixin.scss
+++ b/packages/core/src/components/chip/chip-mixin.scss
@@ -33,12 +33,6 @@ $border-radius: 100px;
       margin-right: $tiny-space;
     }
 
-    .hidden {
-      display: none;
-      width: 0;
-      margin-right: 0;
-    }
-
     .close-button-container {
       display: inline-flex;
       margin-left: auto;

--- a/packages/core/src/components/chip/chip.tsx
+++ b/packages/core/src/components/chip/chip.tsx
@@ -171,14 +171,15 @@ export class Chip {
             icon: !!this.icon,
           }}
         >
-          <ix-icon
-            class={{
-              'with-icon': true,
-              hidden: !this.icon,
-            }}
-            name={this.icon}
-            size={'24'}
-          />
+          {this.icon && (
+            <ix-icon
+              class={{
+                'with-icon': true,
+              }}
+              name={this.icon}
+              size={'24'}
+            />
+          )}
           <span class="slot-container">
             <slot></slot>
           </span>

--- a/packages/core/src/components/pill/pill.tsx
+++ b/packages/core/src/components/pill/pill.tsx
@@ -138,14 +138,15 @@ export class Pill implements IxComponent {
             'with-gap': !this.iconOnly,
           }}
         >
-          <ix-icon
-            class={{
-              'with-icon': true,
-              hidden: this.icon === undefined || this.icon === '',
-            }}
-            name={this.icon}
-            size={'16'}
-          />
+          {this.icon && (
+            <ix-icon
+              class={{
+                'with-icon': true,
+              }}
+              name={this.icon}
+              size={'16'}
+            />
+          )}
           <span class="slot-container">
             <slot onSlotchange={() => this.checkIfContentAvailable()}></slot>
           </span>


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When icon is not set on ix-chip or ix-pill warnings are printed on the console.

GitHub Issue Number: Fixes #1885, Fixes #1879

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Instead of hiding the ix-icon element, it's not rendered if icon is not set on ix-pill and ix-chip

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
