### PR TITLE
fix(core/message): use icon imports within predefined messages

### DIFF
--- a/.changeset/sour-games-unite.md
+++ b/.changeset/sour-games-unite.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix': patch
+---
+
+Show correct icons within predefined message modals

--- a/.changeset/sour-games-unite.md
+++ b/.changeset/sour-games-unite.md
@@ -3,3 +3,5 @@
 ---
 
 Show correct icons within predefined message modals
+
+Fixes #1886

--- a/packages/core/src/components/modal/test/modal.ct.ts
+++ b/packages/core/src/components/modal/test/modal.ct.ts
@@ -238,7 +238,6 @@ regressionTest.describe('message utils', () => {
       await setupModalEnvironment(page);
       await page.evaluate(
         ([functionName]) => {
-          console.log(name);
           (window.showMessage as any)[functionName]('title', 'message', 'okay');
         },
         [name]

--- a/packages/core/src/components/utils/modal/message.ts
+++ b/packages/core/src/components/utils/modal/message.ts
@@ -7,6 +7,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {
+  iconError,
+  iconInfo,
+  iconQuestion,
+  iconSuccess,
+  iconWarning,
+} from '@siemens/ix-icons/icons';
 import { getCoreDelegate } from '../delegate';
 import { TypedEvent } from '../typed-event';
 import { ModalConfig } from './modal';
@@ -177,7 +184,7 @@ showMessage.info = (
   return showMessage({
     message,
     messageTitle: title,
-    icon: 'info',
+    icon: iconInfo,
     actions: createConfirmButtons(
       textOkay,
       textCancel,
@@ -198,7 +205,7 @@ showMessage.warning = (
   return showMessage({
     message,
     messageTitle: title,
-    icon: 'warning',
+    icon: iconWarning,
     iconColor: 'color-warning',
     actions: createConfirmButtons(
       textOkay,
@@ -220,7 +227,7 @@ showMessage.error = (
   return showMessage({
     message,
     messageTitle: title,
-    icon: 'error',
+    icon: iconError,
     iconColor: 'color-alarm',
     actions: createConfirmButtons(
       textOkay,
@@ -242,7 +249,7 @@ showMessage.success = (
   return showMessage({
     message,
     messageTitle: title,
-    icon: 'success',
+    icon: iconSuccess,
     iconColor: 'color-success',
     actions: createConfirmButtons(
       textOkay,
@@ -264,7 +271,7 @@ showMessage.question = (
   return showMessage({
     message,
     messageTitle: title,
-    icon: 'question',
+    icon: iconQuestion,
     actions: createConfirmButtons(
       textOkay,
       textCancel,


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: Fixes #1886

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Util functions still used the legacy icon reference by string.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated (`pnpm run docs`)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
