### PR TITLE
Update blind.scss

### DIFF
--- a/packages/core/src/components/blind/blind.scss
+++ b/packages/core/src/components/blind/blind.scss
@@ -72,8 +72,8 @@
 
   .blind-header-wrapper {
     position: relative;
-    min-height: 3rem;
-    height: 3rem;
+    min-height: min-height: var(--ix-blind-min-height, 3rem);
+    height: min-height: var(--ix-blind-height, 3rem);
     overflow: hidden;
   }
 
@@ -111,8 +111,8 @@
     pointer-events: all;
 
     padding-left: 2.5rem;
-    min-height: 3rem;
-    height: 3rem;
+    min-height: min-height: var(--ix-blind-min-height, 3rem);
+    height: min-height: var(--ix-blind-height, 3rem);
     width: calc(100% - 2 * var(--theme-blind--border-thickness));
     border: solid var(--theme-blind--border-thickness) transparent;
     border-radius: var(--theme-blind--border-radius)


### PR DESCRIPTION
Make min-height of <ix-blind> Component Customizable via CSS Variable

Hi Siemens IX team,

Thank you for your work on the IX component library! We use your components extensively and appreciate the quality and consistency.

I am reaching out with a feature request regarding the <ix-blind> component. Currently, the component enforces a minimum height of 3rem via internal styles. For certain use cases in our application, we would like to be able to reduce this minimum height to achieve a more compact layout.

This approach would provide greater flexibility while preserving backward compatibility.

Thank you for considering this request! Please let me know if you need more details or a specific use case description.

Best regards,
Sergii

-
-

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)
