### PR TITLE
Modified group to not occupy space for context menu when no slot used

### DIFF
--- a/packages/core/src/components/group/group.tsx
+++ b/packages/core/src/components/group/group.tsx
@@ -91,6 +91,8 @@ export class Group {
 
   @State() showExpandCollapsedIcon = false;
 
+  @State() hasDropdown = false;
+
   private observer: MutationObserver = null!;
 
   @Watch('selected')
@@ -182,11 +184,27 @@ export class Group {
     }
   }
 
+  private checkDropdownSlot() {
+    const slot = this.hostElement.querySelector('slot[name="dropdown"]');
+    if (slot) {
+      const assigned = (slot as HTMLSlotElement).assignedElements({
+        flatten: true,
+      });
+      this.hasDropdown = assigned.length > 0;
+    } else {
+      this.hasDropdown = !!this.hostElement.querySelector('[slot="dropdown"]');
+    }
+  }
+
   componentWillRender() {
     this.groupItems.forEach((item, index) => {
       item.selected = index === this.index;
       item.index = index;
     });
+  }
+
+  componentWillLoad() {
+    this.checkDropdownSlot();
   }
 
   componentDidLoad() {
@@ -265,9 +283,11 @@ export class Group {
               <slot name="header"></slot>
             </div>
           </div>
-          <ix-group-context-menu>
-            <slot name="dropdown"></slot>
-          </ix-group-context-menu>
+          {this.hasDropdown && (
+            <ix-group-context-menu>
+              <slot name="dropdown"></slot>
+            </ix-group-context-menu>
+          )}
         </div>
         <div
           class={{

--- a/packages/core/src/components/group/test/group.ct.ts
+++ b/packages/core/src/components/group/test/group.ct.ts
@@ -150,3 +150,38 @@ regressionTest(
     await expect(group).not.toHaveAttribute('selected');
   }
 );
+
+regressionTest(
+  'group context menu presence with dropdown slot',
+  async ({ mount, page }) => {
+    await mount(`
+      <ix-group>
+        <ix-dropdown slot="dropdown">
+          <ix-dropdown-item label="Item 1"></ix-dropdown-item>
+          <ix-dropdown-item label="Item 2"></ix-dropdown-item>
+        </ix-dropdown>
+        <ix-group-item text="Example text 1"></ix-group-item>
+        <ix-group-item text="Example text 2"></ix-group-item>
+        <ix-group-item text="Example text 3"></ix-group-item>
+      </ix-group>
+    `);
+
+    const contextMenu = page.locator('ix-group-context-menu');
+    await expect(contextMenu).toHaveCount(1);
+  }
+);
+
+regressionTest(
+  'absence of group context menu when no dropdown slot',
+  async ({ mount, page }) => {
+    await mount(`
+      <ix-group>
+        <ix-group-item text="Example text 1"></ix-group-item>
+        <ix-group-item text="Example text 2"></ix-group-item>
+        <ix-group-item text="Example text 3"></ix-group-item>
+      </ix-group>
+    `);
+    const contextMenu = page.locator('ix-group-context-menu');
+    await expect(contextMenu).toHaveCount(0);
+  }
+);


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?

when group used as per docu, context menu is occupying empty space even though not configured

GitHub Issue Number: #1486 

## 🆕 What is the new behavior?

Context menu doesnot  occupy space when not configured

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [X] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [X] 🧐 Static code analysis passes (`pnpm lint`)
- [X] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
