### PR TITLE
fix: define ix-icons component as internal component

### DIFF
--- a/.changeset/warm-walls-help.md
+++ b/.changeset/warm-walls-help.md
@@ -1,0 +1,9 @@
+---
+'@siemens/ix-angular': patch
+'@siemens/ix-react': patch
+'@siemens/ix-vue': patch
+---
+
+Ensure ix-icon custom component is defined during library usage
+
+Fixes #2003

--- a/packages/angular/standalone/src/internal-components.ts
+++ b/packages/angular/standalone/src/internal-components.ts
@@ -11,9 +11,15 @@ import { defineCustomElement as defineIxApplicationSwitchModal } from '@siemens/
 import { defineCustomElement as defineIxBurgerMenu } from '@siemens/ix/components/ix-menu-expand-icon.js';
 import { defineCustomElement as defineIxDateTimeCard } from '@siemens/ix/components/ix-date-time-card.js';
 import { defineCustomElement as defineIxModalLoading } from '@siemens/ix/components/ix-modal-loading.js';
+import { defineCustomElement as defineIxIcon } from '@siemens/ix-icons/components/ix-icon.js';
 
+/**
+ * Define custom elements during usage of the library to ensure that all
+ * components are registered before they are used.
+ */
 defineIxApplicationSwitchModal();
 defineIxApplicationSidebar();
 defineIxDateTimeCard();
 defineIxBurgerMenu();
 defineIxModalLoading();
+defineIxIcon();

--- a/packages/react/src/internal-components.ts
+++ b/packages/react/src/internal-components.ts
@@ -13,9 +13,15 @@ import { defineCustomElement as defineIxApplicationSwitchModal } from '@siemens/
 import { defineCustomElement as defineIxBurgerMenu } from '@siemens/ix/components/ix-menu-expand-icon.js';
 import { defineCustomElement as defineIxDateTimeCard } from '@siemens/ix/components/ix-date-time-card.js';
 import { defineCustomElement as defineIxModalLoading } from '@siemens/ix/components/ix-modal-loading.js';
+import { defineCustomElement as defineIxIcon } from '@siemens/ix-icons/components/ix-icon.js';
 
+/**
+ * Define custom elements during usage of the library to ensure that all
+ * components are registered before they are used.
+ */
 defineIxApplicationSwitchModal();
 defineIxApplicationSidebar();
 defineIxDateTimeCard();
 defineIxBurgerMenu();
 defineIxModalLoading();
+defineIxIcon();

--- a/packages/vue/src/internal-components.ts
+++ b/packages/vue/src/internal-components.ts
@@ -12,10 +12,16 @@ import { defineCustomElement as defineIxBurgerMenu } from '@siemens/ix/component
 import { defineCustomElement as defineIxDateTimeCard } from '@siemens/ix/components/ix-date-time-card.js';
 import { defineCustomElement as defineIxModalLoading } from '@siemens/ix/components/ix-modal-loading.js';
 import { defineCustomElement as defineIxFieldLabel } from '@siemens/ix/components/ix-field-label.js';
+import { defineCustomElement as defineIxIcon } from '@siemens/ix-icons/components/ix-icon.js';
 
+/**
+ * Define custom elements during usage of the library to ensure that all
+ * components are registered before they are used.
+ */
 defineIxApplicationSwitchModal();
 defineIxApplicationSidebar();
 defineIxDateTimeCard();
 defineIxBurgerMenu();
 defineIxModalLoading();
 defineIxFieldLabel();
+defineIxIcon();


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #2003 

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Other components, such as IxIconButton, may internally use `<ix-icon>`, but if you never directly import/use IxIcon (e.g React), the underlying web component registration may never happen. This leads to <ix-icon> not being defined as a custom element, causing rendering issues when its dependent components attempt to use it.

https://github.com/siemens/ix/blob/6b9a8fc5922f936a96e3f09e8ea11e0720aa5383/packages/react/src/ix-icon.tsx#L22-L28

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
