### PR TITLE
add change event to input

### DIFF
--- a/packages/angular-standalone-test-app/src/preview-examples/input.html
+++ b/packages/angular-standalone-test-app/src/preview-examples/input.html
@@ -7,4 +7,4 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 -->
 
-<ix-input placeholder="Enter your Username"></ix-input>
+<ix-input placeholder="Enter your Username" (ixChange)="onChange()" (ixBlur)="onBlur()"></ix-input>

--- a/packages/angular-standalone-test-app/src/preview-examples/input.ts
+++ b/packages/angular-standalone-test-app/src/preview-examples/input.ts
@@ -19,4 +19,11 @@ import {
   imports: [IxInput, IxTextValueAccessorDirective],
   templateUrl: './input.html',
 })
-export default class Input {}
+export default class Input {
+    onBlur() {
+    console.log('blur');
+  }
+  onChange() {
+    console.log('change');
+  }
+}

--- a/packages/angular-test-app/src/preview-examples/input.html
+++ b/packages/angular-test-app/src/preview-examples/input.html
@@ -8,5 +8,5 @@ LICENSE file in the root directory of this source tree.
 -->
 
 <ix-input
-  placeholder='Enter your Username'
+  placeholder='Enter your Username' (ixChange)="onChange()" (ixBlur)="onBlur()"
 ></ix-input>

--- a/packages/angular-test-app/src/preview-examples/input.ts
+++ b/packages/angular-test-app/src/preview-examples/input.ts
@@ -13,4 +13,11 @@ import { Component } from '@angular/core';
   selector: 'app-example',
   templateUrl: './input.html'
 })
-export default class Input {}
+export default class Input {
+  onBlur() {
+    console.log('blur');
+  }
+  onChange() {
+    console.log('change');
+  }
+}

--- a/packages/angular/src/components.ts
+++ b/packages/angular/src/components.ts
@@ -1277,7 +1277,7 @@ export class IxInput {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['valueChange', 'validityStateChange', 'ixBlur']);
+    proxyOutputs(this, this.el, ['valueChange', 'validityStateChange', 'ixBlur', 'ixChange']);
   }
 }
 
@@ -1295,6 +1295,10 @@ export declare interface IxInput extends Components.IxInput {
    * Event emitted when the text field loses focus.
    */
   ixBlur: EventEmitter<CustomEvent<void>>;
+  /**
+   * Event emitted when the value of the text field changed.
+   */
+  ixChange: EventEmitter<CustomEvent<void>>;
 }
 
 
@@ -1969,7 +1973,7 @@ export class IxNumberInput {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['valueChange', 'validityStateChange', 'ixBlur']);
+    proxyOutputs(this, this.el, ['valueChange', 'validityStateChange', 'ixBlur', 'ixChange']);
   }
 }
 
@@ -1987,6 +1991,10 @@ export declare interface IxNumberInput extends Components.IxNumberInput {
    * Event emitted when the input field loses focus
    */
   ixBlur: EventEmitter<CustomEvent<void>>;
+  /**
+   * Event emitted when the value of the input field changed
+   */
+  ixChange: EventEmitter<CustomEvent<void>>;
 }
 
 
@@ -2454,7 +2462,7 @@ export class IxTextarea {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['valueChange', 'validityStateChange', 'ixBlur']);
+    proxyOutputs(this, this.el, ['valueChange', 'validityStateChange', 'ixBlur', 'ixChange']);
   }
 }
 
@@ -2472,6 +2480,10 @@ export declare interface IxTextarea extends Components.IxTextarea {
    * Event emitted when the textarea field loses focus.
    */
   ixBlur: EventEmitter<CustomEvent<void>>;
+  /**
+   * Event emitted when the value of the text field changed.
+   */
+  ixChange: EventEmitter<CustomEvent<void>>;
 }
 
 

--- a/packages/angular/standalone/src/components.ts
+++ b/packages/angular/standalone/src/components.ts
@@ -1476,7 +1476,7 @@ export class IxInput {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['valueChange', 'validityStateChange', 'ixBlur']);
+    proxyOutputs(this, this.el, ['valueChange', 'validityStateChange', 'ixBlur', 'ixChange']);
   }
 }
 
@@ -1494,6 +1494,10 @@ export declare interface IxInput extends Components.IxInput {
    * Event emitted when the text field loses focus.
    */
   ixBlur: EventEmitter<CustomEvent<void>>;
+  /**
+   * Event emitted when the value of the text field changed.
+   */
+  ixChange: EventEmitter<CustomEvent<void>>;
 }
 
 
@@ -2218,7 +2222,7 @@ export class IxNumberInput {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['valueChange', 'validityStateChange', 'ixBlur']);
+    proxyOutputs(this, this.el, ['valueChange', 'validityStateChange', 'ixBlur', 'ixChange']);
   }
 }
 
@@ -2236,6 +2240,10 @@ export declare interface IxNumberInput extends Components.IxNumberInput {
    * Event emitted when the input field loses focus
    */
   ixBlur: EventEmitter<CustomEvent<void>>;
+  /**
+   * Event emitted when the value of the input field changed
+   */
+  ixChange: EventEmitter<CustomEvent<void>>;
 }
 
 
@@ -2737,7 +2745,7 @@ export class IxTextarea {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['valueChange', 'validityStateChange', 'ixBlur']);
+    proxyOutputs(this, this.el, ['valueChange', 'validityStateChange', 'ixBlur', 'ixChange']);
   }
 }
 
@@ -2755,6 +2763,10 @@ export declare interface IxTextarea extends Components.IxTextarea {
    * Event emitted when the textarea field loses focus.
    */
   ixBlur: EventEmitter<CustomEvent<void>>;
+  /**
+   * Event emitted when the value of the text field changed.
+   */
+  ixChange: EventEmitter<CustomEvent<void>>;
 }
 
 

--- a/packages/core/component-doc.json
+++ b/packages/core/component-doc.json
@@ -11916,6 +11916,20 @@
           "docsTags": []
         },
         {
+          "event": "ixChange",
+          "detail": "void",
+          "bubbles": true,
+          "complexType": {
+            "original": "void",
+            "resolved": "void",
+            "references": {}
+          },
+          "cancelable": true,
+          "composed": true,
+          "docs": "Event emitted when the value of the text field changed.",
+          "docsTags": []
+        },
+        {
           "event": "validityStateChange",
           "detail": "ValidityState",
           "bubbles": true,
@@ -16596,6 +16610,20 @@
           "cancelable": true,
           "composed": true,
           "docs": "Event emitted when the input field loses focus",
+          "docsTags": []
+        },
+        {
+          "event": "ixChange",
+          "detail": "void",
+          "bubbles": true,
+          "complexType": {
+            "original": "void",
+            "resolved": "void",
+            "references": {}
+          },
+          "cancelable": true,
+          "composed": true,
+          "docs": "Event emitted when the value of the input field changed",
           "docsTags": []
         },
         {
@@ -21928,6 +21956,20 @@
           "cancelable": true,
           "composed": true,
           "docs": "Event emitted when the textarea field loses focus.",
+          "docsTags": []
+        },
+        {
+          "event": "ixChange",
+          "detail": "void",
+          "bubbles": true,
+          "complexType": {
+            "original": "void",
+            "resolved": "void",
+            "references": {}
+          },
+          "cancelable": true,
+          "composed": true,
+          "docs": "Event emitted when the value of the text field changed.",
           "docsTags": []
         },
         {

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -4384,6 +4384,7 @@ declare global {
         "validityStateChange": DateInputValidityState;
         "ixFocus": void;
         "ixBlur": void;
+        "ixChange": void;
     }
     /**
      * @form-ready 
@@ -4706,6 +4707,7 @@ declare global {
         "valueChange": string;
         "validityStateChange": ValidityState;
         "ixBlur": void;
+        "ixChange": void;
     }
     /**
      * @form-ready 
@@ -5052,6 +5054,7 @@ declare global {
         "valueChange": number;
         "validityStateChange": ValidityState;
         "ixBlur": void;
+        "ixChange": void;
     }
     /**
      * @form-ready 
@@ -5189,6 +5192,7 @@ declare global {
         "inputChange": string;
         "addItem": string;
         "ixBlur": void;
+        "ixChange": void;
     }
     /**
      * @form-ready 
@@ -5302,6 +5306,7 @@ declare global {
         "valueChange": string;
         "validityStateChange": ValidityState;
         "ixBlur": void;
+        "ixChange": void;
     }
     /**
      * @form-ready 
@@ -5331,6 +5336,7 @@ declare global {
         "validityStateChange": TimeInputValidityState;
         "ixFocus": void;
         "ixBlur": void;
+        "ixChange": void;
     }
     /**
      * @since 3.2.0
@@ -6497,6 +6503,7 @@ declare namespace LocalJSX {
          */
         "name"?: string;
         "onIxBlur"?: (event: IxDateInputCustomEvent<void>) => void;
+        "onIxChange"?: (event: IxDateInputCustomEvent<void>) => void;
         "onIxFocus"?: (event: IxDateInputCustomEvent<void>) => void;
         /**
           * Validation state change event.
@@ -7454,6 +7461,10 @@ declare namespace LocalJSX {
          */
         "onIxBlur"?: (event: IxInputCustomEvent<void>) => void;
         /**
+          * Event emitted when the value of the text field changed.
+         */
+        "onIxChange"?: (event: IxInputCustomEvent<void>) => void;
+        /**
           * Event emitted when the validity state of the text field changes.
          */
         "onValidityStateChange"?: (event: IxInputCustomEvent<ValidityState>) => void;
@@ -8102,6 +8113,10 @@ declare namespace LocalJSX {
          */
         "onIxBlur"?: (event: IxNumberInputCustomEvent<void>) => void;
         /**
+          * Event emitted when the value of the input field changed
+         */
+        "onIxChange"?: (event: IxNumberInputCustomEvent<void>) => void;
+        /**
           * Event emitted when the validity state of the input field changes
          */
         "onValidityStateChange"?: (event: IxNumberInputCustomEvent<ValidityState>) => void;
@@ -8604,6 +8619,7 @@ declare namespace LocalJSX {
           * Blur input
          */
         "onIxBlur"?: (event: IxSelectCustomEvent<void>) => void;
+        "onIxChange"?: (event: IxSelectCustomEvent<void>) => void;
         /**
           * Value changed
          */
@@ -8888,6 +8904,10 @@ declare namespace LocalJSX {
          */
         "onIxBlur"?: (event: IxTextareaCustomEvent<void>) => void;
         /**
+          * Event emitted when the value of the text field changed.
+         */
+        "onIxChange"?: (event: IxTextareaCustomEvent<void>) => void;
+        /**
           * Event emitted when the validity state of the textarea field changes.
          */
         "onValidityStateChange"?: (event: IxTextareaCustomEvent<ValidityState>) => void;
@@ -9041,6 +9061,7 @@ declare namespace LocalJSX {
          */
         "name"?: string;
         "onIxBlur"?: (event: IxTimeInputCustomEvent<void>) => void;
+        "onIxChange"?: (event: IxTimeInputCustomEvent<void>) => void;
         "onIxFocus"?: (event: IxTimeInputCustomEvent<void>) => void;
         /**
           * Validation state change event.

--- a/packages/core/src/components/date-input/date-input.tsx
+++ b/packages/core/src/components/date-input/date-input.tsx
@@ -198,6 +198,9 @@ export class DateInput implements IxInputFieldComponent<string | undefined> {
   /** @internal */
   @Event() ixBlur!: EventEmitter<void>;
 
+  /** @internal */
+  @Event() ixChange!: EventEmitter<void>;
+
   @State() show = false;
   @State() from?: string | null = null;
   @State() isInputInvalid = false;

--- a/packages/core/src/components/input/input.fc.tsx
+++ b/packages/core/src/components/input/input.fc.tsx
@@ -29,6 +29,7 @@ export function TextareaElement(
     valueChange: (value: string) => void;
     updateFormInternalValue: (value: string) => void;
     onBlur: () => void;
+    onChange: () => void;
     ariaAttributes?: A11yAttributes;
   }>
 ) {
@@ -53,6 +54,7 @@ export function TextareaElement(
         props.valueChange(target.value);
       }}
       onBlur={() => props.onBlur()}
+      onChange={() => props.onChange()}
       style={{
         resize: props.resizeBehavior,
         height: props.textareaHeight,
@@ -84,6 +86,7 @@ export function InputElement(
     valueChange: (value: string) => void;
     updateFormInternalValue: (value: string) => void;
     onBlur: () => void;
+    onChange: () => void;
     ariaAttributes?: A11yAttributes;
   }>
 ) {
@@ -114,6 +117,7 @@ export function InputElement(
         props.valueChange(target.value);
       }}
       onBlur={() => props.onBlur()}
+      onChange={() => props.onChange()}
       {...props.ariaAttributes}
     ></input>
   );

--- a/packages/core/src/components/input/input.tsx
+++ b/packages/core/src/components/input/input.tsx
@@ -37,6 +37,7 @@ import {
   getAriaAttributesForInput,
   mapValidationResult,
   onInputBlur,
+  onInputChange,
 } from './input.util';
 
 let inputIds = 0;
@@ -160,6 +161,11 @@ export class Input implements IxInputFieldComponent<string> {
    * Event emitted when the text field loses focus.
    */
   @Event() ixBlur!: EventEmitter<void>;
+
+  /**
+   * Event emitted when the value of the text field changed.
+   */
+  @Event() ixChange!: EventEmitter<void>;
 
   @State() isInvalid = false;
   @State() isValid = false;
@@ -315,6 +321,7 @@ export class Input implements IxInputFieldComponent<string> {
                 onInputBlur(this, this.inputRef.current);
                 this.touched = true;
               }}
+              onChange={() => onInputChange(this, this.inputRef.current)}
               ariaAttributes={inputAria}
             ></InputElement>
             <SlotEnd

--- a/packages/core/src/components/input/input.util.ts
+++ b/packages/core/src/components/input/input.util.ts
@@ -76,6 +76,17 @@ export async function checkInternalValidity<T>(
   comp.hostElement.classList.toggle('ix-invalid--validity-invalid', !valid);
 }
 
+export function onInputChange<T>(
+  comp: IxInputFieldComponent<T>,
+  input?: HTMLInputElement | HTMLTextAreaElement | null
+) {
+  comp.ixChange.emit();
+
+  if (!input) {
+    throw new Error('Input element is not available');
+  }
+}
+
 export function onInputBlur<T>(
   comp: IxFormComponent<T>,
   input?: HTMLInputElement | HTMLTextAreaElement | null

--- a/packages/core/src/components/input/number-input.tsx
+++ b/packages/core/src/components/input/number-input.tsx
@@ -35,6 +35,7 @@ import {
   DisposableChangesAndVisibilityObservers,
   mapValidationResult,
   onInputBlur,
+  onInputChange,
 } from './input.util';
 
 let numberInputIds = 0;
@@ -165,6 +166,11 @@ export class NumberInput implements IxInputFieldComponent<number> {
    * Event emitted when the input field loses focus
    */
   @Event() ixBlur!: EventEmitter<void>;
+
+  /**
+   * Event emitted when the value of the input field changed
+   */
+  @Event() ixChange!: EventEmitter<void>;
 
   @State() isInvalid = false;
   @State() isValid = false;
@@ -319,6 +325,7 @@ export class NumberInput implements IxInputFieldComponent<number> {
                 onInputBlur(this, this.inputRef.current);
                 this.touched = true;
               }}
+              onChange={() => onInputChange(this, this.inputRef.current)}
             ></InputElement>
             <SlotEnd
               slotEndRef={this.slotEndRef}

--- a/packages/core/src/components/input/textarea.tsx
+++ b/packages/core/src/components/input/textarea.tsx
@@ -26,7 +26,7 @@ import {
 } from '../utils/input';
 import { makeRef } from '../utils/make-ref';
 import { TextareaElement } from './input.fc';
-import { mapValidationResult, onInputBlur } from './input.util';
+import { mapValidationResult, onInputBlur, onInputChange } from './input.util';
 import type { TextareaResizeBehavior } from './textarea.types';
 
 /**
@@ -158,6 +158,11 @@ export class Textarea implements IxInputFieldComponent<string> {
    */
   @Event() ixBlur!: EventEmitter<void>;
 
+  /**
+   * Event emitted when the value of the text field changed.
+   */
+  @Event() ixChange!: EventEmitter<void>;
+
   @State() isInvalid = false;
   @State() isValid = false;
   @State() isInfo = false;
@@ -274,6 +279,7 @@ export class Textarea implements IxInputFieldComponent<string> {
                 onInputBlur(this, this.textAreaRef.current);
                 this.touched = true;
               }}
+              onChange={() => onInputChange(this, this.textAreaRef.current)}
             ></TextareaElement>
           </div>
         </ix-field-wrapper>

--- a/packages/core/src/components/select/select.tsx
+++ b/packages/core/src/components/select/select.tsx
@@ -185,6 +185,9 @@ export class Select implements IxInputFieldComponent<string | string[]> {
    */
   @Event() ixBlur!: EventEmitter<void>;
 
+  /** @internal */
+  @Event() ixChange!: EventEmitter<void>;
+
   @State() dropdownShow = false;
   @State() selectedLabels: (string | undefined)[] = [];
   @State() isDropdownEmpty = false;

--- a/packages/core/src/components/time-input/time-input.tsx
+++ b/packages/core/src/components/time-input/time-input.tsx
@@ -206,6 +206,9 @@ export class TimeInput implements IxInputFieldComponent<string> {
   /** @internal */
   @Event() ixBlur!: EventEmitter<void>;
 
+  /** @internal */
+  @Event() ixChange!: EventEmitter<void>;
+
   @State() show = false;
   @State() time: string | null = null;
   @State() isInputInvalid = false;

--- a/packages/core/src/components/utils/input/index.ts
+++ b/packages/core/src/components/utils/input/index.ts
@@ -89,6 +89,8 @@ export interface IxInputFieldComponent<T = string>
   // Annotate as @Prop()
   readonly: boolean;
 
+  ixChange: EventEmitter<void>;
+
   // Annotate as @Method()
   getNativeInputElement(): Promise<HTMLInputElement | HTMLTextAreaElement>;
 

--- a/packages/html-test-app/src/preview-examples/input.html
+++ b/packages/html-test-app/src/preview-examples/input.html
@@ -18,5 +18,10 @@ LICENSE file in the root directory of this source tree.
     <ix-input placeholder="Enter your Username"></ix-input>
 
     <script type="module" src="./init.js"></script>
+    <script>
+      const ixInput = document.getElementsByTagName('ix-input')[0];
+      ixInput.addEventListener('ixBlur', function() { console.log('blur')});
+      ixInput.addEventListener('ixChange', function() { console.log('change')});
+    </script>
   </body>
 </html>

--- a/packages/react-test-app/src/preview-examples/input.tsx
+++ b/packages/react-test-app/src/preview-examples/input.tsx
@@ -10,5 +10,5 @@
 import { IxInput } from '@siemens/ix-react';
 
 export default () => {
-  return <IxInput placeholder="Enter your Username"></IxInput>;
+  return <IxInput placeholder="Enter your Username" onIxBlur={() => console.log('blur')} onIxChange={() => console.log('change')}></IxInput>;
 };

--- a/packages/react/src/components.server.ts
+++ b/packages/react/src/components.server.ts
@@ -1182,7 +1182,8 @@ export const IxIconToggleButton: StencilReactComponent<IxIconToggleButtonElement
 export type IxInputEvents = {
     onValueChange: EventName<CustomEvent<string>>,
     onValidityStateChange: EventName<IxInputCustomEvent<ValidityState>>,
-    onIxBlur: EventName<CustomEvent<void>>
+    onIxBlur: EventName<CustomEvent<void>>,
+    onIxChange: EventName<CustomEvent<void>>
 };
 
 export const IxInput: StencilReactComponent<IxInputElement, IxInputEvents> = /*@__PURE__*/ createComponent<IxInputElement, IxInputEvents>({
@@ -1215,7 +1216,8 @@ export const IxInput: StencilReactComponent<IxInputElement, IxInputEvents> = /*@
     events: {
         onValueChange: 'valueChange',
         onValidityStateChange: 'validityStateChange',
-        onIxBlur: 'ixBlur'
+        onIxBlur: 'ixBlur',
+        onIxChange: 'ixChange'
     } as IxInputEvents,
     defineCustomElement: defineIxInput
 });
@@ -1705,7 +1707,8 @@ export const IxModalHeader: StencilReactComponent<IxModalHeaderElement, IxModalH
 export type IxNumberInputEvents = {
     onValueChange: EventName<CustomEvent<number>>,
     onValidityStateChange: EventName<IxNumberInputCustomEvent<ValidityState>>,
-    onIxBlur: EventName<CustomEvent<void>>
+    onIxBlur: EventName<CustomEvent<void>>,
+    onIxChange: EventName<CustomEvent<void>>
 };
 
 export const IxNumberInput: StencilReactComponent<IxNumberInputElement, IxNumberInputEvents> = /*@__PURE__*/ createComponent<IxNumberInputElement, IxNumberInputEvents>({
@@ -1739,7 +1742,8 @@ export const IxNumberInput: StencilReactComponent<IxNumberInputElement, IxNumber
     events: {
         onValueChange: 'valueChange',
         onValidityStateChange: 'validityStateChange',
-        onIxBlur: 'ixBlur'
+        onIxBlur: 'ixBlur',
+        onIxChange: 'ixChange'
     } as IxNumberInputEvents,
     defineCustomElement: defineIxNumberInput
 });
@@ -2138,7 +2142,8 @@ export const IxTabs: StencilReactComponent<IxTabsElement, IxTabsEvents> = /*@__P
 export type IxTextareaEvents = {
     onValueChange: EventName<CustomEvent<string>>,
     onValidityStateChange: EventName<IxTextareaCustomEvent<ValidityState>>,
-    onIxBlur: EventName<CustomEvent<void>>
+    onIxBlur: EventName<CustomEvent<void>>,
+    onIxChange: EventName<CustomEvent<void>>
 };
 
 export const IxTextarea: StencilReactComponent<IxTextareaElement, IxTextareaEvents> = /*@__PURE__*/ createComponent<IxTextareaElement, IxTextareaEvents>({
@@ -2173,7 +2178,8 @@ export const IxTextarea: StencilReactComponent<IxTextareaElement, IxTextareaEven
     events: {
         onValueChange: 'valueChange',
         onValidityStateChange: 'validityStateChange',
-        onIxBlur: 'ixBlur'
+        onIxBlur: 'ixBlur',
+        onIxChange: 'ixChange'
     } as IxTextareaEvents,
     defineCustomElement: defineIxTextarea
 });

--- a/packages/react/src/components.ts
+++ b/packages/react/src/components.ts
@@ -713,7 +713,8 @@ export const IxIconToggleButton: StencilReactComponent<IxIconToggleButtonElement
 export type IxInputEvents = {
     onValueChange: EventName<CustomEvent<string>>,
     onValidityStateChange: EventName<IxInputCustomEvent<ValidityState>>,
-    onIxBlur: EventName<CustomEvent<void>>
+    onIxBlur: EventName<CustomEvent<void>>,
+    onIxChange: EventName<CustomEvent<void>>
 };
 
 export const IxInput: StencilReactComponent<IxInputElement, IxInputEvents> = /*@__PURE__*/ createComponent<IxInputElement, IxInputEvents>({
@@ -724,7 +725,8 @@ export const IxInput: StencilReactComponent<IxInputElement, IxInputEvents> = /*@
     events: {
         onValueChange: 'valueChange',
         onValidityStateChange: 'validityStateChange',
-        onIxBlur: 'ixBlur'
+        onIxBlur: 'ixBlur',
+        onIxChange: 'ixChange'
     } as IxInputEvents,
     defineCustomElement: defineIxInput
 });
@@ -1044,7 +1046,8 @@ export const IxModalHeader: StencilReactComponent<IxModalHeaderElement, IxModalH
 export type IxNumberInputEvents = {
     onValueChange: EventName<CustomEvent<number>>,
     onValidityStateChange: EventName<IxNumberInputCustomEvent<ValidityState>>,
-    onIxBlur: EventName<CustomEvent<void>>
+    onIxBlur: EventName<CustomEvent<void>>,
+    onIxChange: EventName<CustomEvent<void>>
 };
 
 export const IxNumberInput: StencilReactComponent<IxNumberInputElement, IxNumberInputEvents> = /*@__PURE__*/ createComponent<IxNumberInputElement, IxNumberInputEvents>({
@@ -1055,7 +1058,8 @@ export const IxNumberInput: StencilReactComponent<IxNumberInputElement, IxNumber
     events: {
         onValueChange: 'valueChange',
         onValidityStateChange: 'validityStateChange',
-        onIxBlur: 'ixBlur'
+        onIxBlur: 'ixBlur',
+        onIxChange: 'ixChange'
     } as IxNumberInputEvents,
     defineCustomElement: defineIxNumberInput
 });
@@ -1271,7 +1275,8 @@ export const IxTabs: StencilReactComponent<IxTabsElement, IxTabsEvents> = /*@__P
 export type IxTextareaEvents = {
     onValueChange: EventName<CustomEvent<string>>,
     onValidityStateChange: EventName<IxTextareaCustomEvent<ValidityState>>,
-    onIxBlur: EventName<CustomEvent<void>>
+    onIxBlur: EventName<CustomEvent<void>>,
+    onIxChange: EventName<CustomEvent<void>>
 };
 
 export const IxTextarea: StencilReactComponent<IxTextareaElement, IxTextareaEvents> = /*@__PURE__*/ createComponent<IxTextareaElement, IxTextareaEvents>({
@@ -1282,7 +1287,8 @@ export const IxTextarea: StencilReactComponent<IxTextareaElement, IxTextareaEven
     events: {
         onValueChange: 'valueChange',
         onValidityStateChange: 'validityStateChange',
-        onIxBlur: 'ixBlur'
+        onIxBlur: 'ixBlur',
+        onIxChange: 'ixChange'
     } as IxTextareaEvents,
     defineCustomElement: defineIxTextarea
 });

--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -413,12 +413,14 @@ export const IxDateInput: StencilVueComponent<JSX.IxDateInput, JSX.IxDateInput["
   'valueChange',
   'validityStateChange',
   'ixFocus',
-  'ixBlur'
+  'ixBlur',
+  'ixChange'
 ], [
   'valueChange',
   'validityStateChange',
   'ixFocus',
-  'ixBlur'
+  'ixBlur',
+  'ixChange'
 ],
 'value', 'valueChange');
 
@@ -723,11 +725,13 @@ export const IxInput: StencilVueComponent<JSX.IxInput, JSX.IxInput["value"]> = /
   'allowedCharactersPattern',
   'valueChange',
   'validityStateChange',
-  'ixBlur'
+  'ixBlur',
+  'ixChange'
 ], [
   'valueChange',
   'validityStateChange',
-  'ixBlur'
+  'ixBlur',
+  'ixChange'
 ],
 'value', 'valueChange');
 
@@ -994,11 +998,13 @@ export const IxNumberInput: StencilVueComponent<JSX.IxNumberInput, JSX.IxNumberI
   'step',
   'valueChange',
   'validityStateChange',
-  'ixBlur'
+  'ixBlur',
+  'ixChange'
 ], [
   'valueChange',
   'validityStateChange',
-  'ixBlur'
+  'ixBlur',
+  'ixChange'
 ],
 'value', 'valueChange');
 
@@ -1150,12 +1156,14 @@ export const IxSelect: StencilVueComponent<JSX.IxSelect, JSX.IxSelect["value"]> 
   'valueChange',
   'inputChange',
   'addItem',
-  'ixBlur'
+  'ixBlur',
+  'ixChange'
 ], [
   'valueChange',
   'inputChange',
   'addItem',
-  'ixBlur'
+  'ixBlur',
+  'ixChange'
 ],
 'value', 'valueChange');
 
@@ -1260,11 +1268,13 @@ export const IxTextarea: StencilVueComponent<JSX.IxTextarea, JSX.IxTextarea["val
   'minLength',
   'valueChange',
   'validityStateChange',
-  'ixBlur'
+  'ixBlur',
+  'ixChange'
 ], [
   'valueChange',
   'validityStateChange',
-  'ixBlur'
+  'ixBlur',
+  'ixChange'
 ],
 'value', 'valueChange');
 
@@ -1303,12 +1313,14 @@ export const IxTimeInput: StencilVueComponent<JSX.IxTimeInput> = /*@__PURE__*/ d
   'valueChange',
   'validityStateChange',
   'ixFocus',
-  'ixBlur'
+  'ixBlur',
+  'ixChange'
 ], [
   'valueChange',
   'validityStateChange',
   'ixFocus',
-  'ixBlur'
+  'ixBlur',
+  'ixChange'
 ]);
 
 


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 💡 What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The change event of input is missing.

GitHub Issue Number: #1811

## 🆕 What is the new behavior?

adds an ixChange event that forwards the change event of inputs for ix-input, ix-number-input and ix-textarea

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

~~- [ ] 🦮 Accessibility (a11y) features were implemented~~
~~- [ ] 🗺️ Internationalization (i18n) - no hard coded strings~~
~~- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully~~
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed) -> except oss clearing fails
