### PR TITLE
fix(core/time-input): Invalid input of time-input breaks the component

### DIFF
--- a/packages/core/src/components/date-input/date-input.tsx
+++ b/packages/core/src/components/date-input/date-input.tsx
@@ -70,6 +70,10 @@ export class DateInput implements IxInputFieldComponent<string | undefined> {
    */
   @Prop({ reflect: true, mutable: true }) value?: string = '';
 
+  @Watch('value') watchValuePropHandler(newValue: string) {
+    this.onInput(newValue);
+  }
+
   /**
    * The earliest date that can be selected by the date input/picker.
    * If not set there will be no restriction.

--- a/packages/core/src/components/date-input/tests/date-input.ct.ts
+++ b/packages/core/src/components/date-input/tests/date-input.ct.ts
@@ -186,17 +186,18 @@ regressionTest(
     await mount(`<ix-date-input value="2024/05/05"></ix-date-input>`);
 
     const dateInput = page.locator('ix-date-input');
+    const input = page.locator('input');
 
     await dateInput.evaluateHandle((el) => {
       el.setAttribute('value', 'invalid-date');
     });
 
-    await expect(dateInput).toHaveClass(/is-invalid/);
+    await expect(input).toHaveClass(/is-invalid/);
 
     await dateInput.evaluateHandle((el) => {
       el.setAttribute('value', '2024/05/05');
     });
 
-    await expect(dateInput).not.toHaveClass(/is-invalid/);
+    await expect(input).not.toHaveClass(/is-invalid/);
   }
 );

--- a/packages/core/src/components/date-input/tests/date-input.ct.ts
+++ b/packages/core/src/components/date-input/tests/date-input.ct.ts
@@ -179,3 +179,28 @@ regressionTest(
     expect(formData).toBe('2024/12/12');
   }
 );
+
+regressionTest(
+  'updating component value attribute updates validity',
+  async ({ page, mount }) => {
+    await mount(
+      `<ix-date-input id="date-input" value="2024/05/05"></ix-date-input>`
+    );
+
+    await page.evaluate(() => {
+      document
+        .getElementById('date-input')
+        ?.setAttribute('value', 'invalid-date');
+    });
+
+    await expect(page.locator('input')).toHaveClass(/is-invalid/);
+
+    await page.evaluate(() => {
+      document
+        .getElementById('date-input')
+        ?.setAttribute('value', '2024/05/05');
+    });
+
+    await expect(page.locator('input')).not.toHaveClass(/is-invalid/);
+  }
+);

--- a/packages/core/src/components/date-input/tests/date-input.ct.ts
+++ b/packages/core/src/components/date-input/tests/date-input.ct.ts
@@ -183,24 +183,20 @@ regressionTest(
 regressionTest(
   'updating component value attribute updates validity',
   async ({ page, mount }) => {
-    await mount(
-      `<ix-date-input id="date-input" value="2024/05/05"></ix-date-input>`
-    );
+    await mount(`<ix-date-input value="2024/05/05"></ix-date-input>`);
 
-    await page.evaluate(() => {
-      document
-        .getElementById('date-input')
-        ?.setAttribute('value', 'invalid-date');
+    const dateInput = page.locator('ix-date-input');
+
+    await dateInput.evaluateHandle((el) => {
+      el.setAttribute('value', 'invalid-date');
     });
 
-    await expect(page.locator('input')).toHaveClass(/is-invalid/);
+    await expect(dateInput).toHaveClass(/is-invalid/);
 
-    await page.evaluate(() => {
-      document
-        .getElementById('date-input')
-        ?.setAttribute('value', '2024/05/05');
+    await dateInput.evaluateHandle((el) => {
+      el.setAttribute('value', '2024/05/05');
     });
 
-    await expect(page.locator('input')).not.toHaveClass(/is-invalid/);
+    await expect(dateInput).not.toHaveClass(/is-invalid/);
   }
 );

--- a/packages/core/src/components/time-input/test/time-input.ct.ts
+++ b/packages/core/src/components/time-input/test/time-input.ct.ts
@@ -100,4 +100,56 @@ regressionTest.describe('time input tests', () => {
       await expect(page.locator('input')).toHaveValue('12:30:45');
     }
   );
+
+  regressionTest(
+    'closing dropdown and reopening after entering invalid time does not break component',
+    async ({ page }) => {
+      await page.locator('input').click();
+
+      await expect(
+        page.locator('ix-dropdown[data-testid="time-dropdown"]')
+      ).toHaveClass(/show/);
+
+      await expect(page.locator('ix-time-picker')).toBeVisible();
+
+      await page.locator('input').fill('invalid-time');
+
+      await expect(page.locator('input')).toHaveClass(/is-invalid/);
+      await expect(page.locator('ix-field-wrapper')).toContainText(
+        'Time is not valid'
+      );
+
+      await page
+        .locator('ix-icon-button[data-testid="open-time-picker"]')
+        .click();
+
+      await expect(
+        page.locator('ix-dropdown[data-testid="time-dropdown"]')
+      ).not.toHaveClass(/show/);
+
+      await expect(page.locator('input')).toHaveClass(/is-invalid/);
+      await expect(page.locator('ix-field-wrapper')).toContainText(
+        'Time is not valid'
+      );
+
+      await page
+        .locator('ix-icon-button[data-testid="open-time-picker"]')
+        .click();
+
+      await expect(
+        page.locator('ix-dropdown[data-testid="time-dropdown"]')
+      ).toHaveClass(/show/);
+
+      await page
+        .locator('ix-time-picker [data-element-container-id="second-30"]')
+        .click();
+
+      await page.locator('ix-time-picker ix-button').click();
+
+      await expect(page.locator('input')).not.toHaveClass(/is-invalid/);
+      await expect(page.locator('ix-field-wrapper')).not.toContainText(
+        'Time is not valid'
+      );
+    }
+  );
 });

--- a/packages/core/src/components/time-input/test/time-input.ct.ts
+++ b/packages/core/src/components/time-input/test/time-input.ct.ts
@@ -13,6 +13,7 @@ regressionTest.describe('time input tests', () => {
   regressionTest.beforeEach(async ({ mount }) => {
     await mount(
       `<ix-time-input
+        id="time-input"
         value="09:10:11"
         format="HH:mm:ss"
       >
@@ -150,6 +151,27 @@ regressionTest.describe('time input tests', () => {
       await expect(page.locator('ix-field-wrapper')).not.toContainText(
         'Time is not valid'
       );
+    }
+  );
+
+  regressionTest(
+    'updating component value attribute updates validity',
+    async ({ page }) => {
+      await page.evaluate(() => {
+        document
+          .getElementById('time-input')
+          ?.setAttribute('value', 'invalid-time');
+      });
+
+      await expect(page.locator('input')).toHaveClass(/is-invalid/);
+
+      await page.evaluate(() => {
+        document
+          .getElementById('time-input')
+          ?.setAttribute('value', '09:10:11');
+      });
+
+      await expect(page.locator('input')).not.toHaveClass(/is-invalid/);
     }
   );
 });

--- a/packages/core/src/components/time-input/test/time-input.ct.ts
+++ b/packages/core/src/components/time-input/test/time-input.ct.ts
@@ -13,7 +13,6 @@ regressionTest.describe('time input tests', () => {
   regressionTest.beforeEach(async ({ mount }) => {
     await mount(
       `<ix-time-input
-        id="time-input"
         value="09:10:11"
         format="HH:mm:ss"
       >
@@ -157,21 +156,19 @@ regressionTest.describe('time input tests', () => {
   regressionTest(
     'updating component value attribute updates validity',
     async ({ page }) => {
-      await page.evaluate(() => {
-        document
-          .getElementById('time-input')
-          ?.setAttribute('value', 'invalid-time');
+      const timeInput = page.locator('ix-time-input');
+
+      await timeInput.evaluateHandle((el) => {
+        el.setAttribute('value', 'invalid-time');
       });
 
-      await expect(page.locator('input')).toHaveClass(/is-invalid/);
+      await expect(timeInput).toHaveClass(/is-invalid/);
 
-      await page.evaluate(() => {
-        document
-          .getElementById('time-input')
-          ?.setAttribute('value', '09:10:11');
+      await timeInput.evaluateHandle((el) => {
+        el.setAttribute('value', '09:10:11');
       });
 
-      await expect(page.locator('input')).not.toHaveClass(/is-invalid/);
+      await expect(timeInput).not.toHaveClass(/is-invalid/);
     }
   );
 });

--- a/packages/core/src/components/time-input/test/time-input.ct.ts
+++ b/packages/core/src/components/time-input/test/time-input.ct.ts
@@ -104,41 +104,34 @@ regressionTest.describe('time input tests', () => {
   regressionTest(
     'closing dropdown and reopening after entering invalid time does not break component',
     async ({ page }) => {
-      await page.locator('input').click();
+      const input = page.locator('input');
+      const fieldWrapper = page.locator('ix-field-wrapper');
+      const dropdown = page.locator('ix-dropdown[data-testid="time-dropdown"]');
+      const iconButton = page.locator(
+        'ix-icon-button[data-testid="open-time-picker"]'
+      );
 
-      await expect(
-        page.locator('ix-dropdown[data-testid="time-dropdown"]')
-      ).toHaveClass(/show/);
+      await input.click();
+
+      await expect(dropdown).toHaveClass(/show/);
 
       await expect(page.locator('ix-time-picker')).toBeVisible();
 
-      await page.locator('input').fill('invalid-time');
+      await input.fill('invalid-time');
 
-      await expect(page.locator('input')).toHaveClass(/is-invalid/);
-      await expect(page.locator('ix-field-wrapper')).toContainText(
-        'Time is not valid'
-      );
+      await expect(input).toHaveClass(/is-invalid/);
+      await expect(fieldWrapper).toContainText('Time is not valid');
 
-      await page
-        .locator('ix-icon-button[data-testid="open-time-picker"]')
-        .click();
+      await iconButton.click();
 
-      await expect(
-        page.locator('ix-dropdown[data-testid="time-dropdown"]')
-      ).not.toHaveClass(/show/);
+      await expect(dropdown).not.toHaveClass(/show/);
 
-      await expect(page.locator('input')).toHaveClass(/is-invalid/);
-      await expect(page.locator('ix-field-wrapper')).toContainText(
-        'Time is not valid'
-      );
+      await expect(input).toHaveClass(/is-invalid/);
+      await expect(fieldWrapper).toContainText('Time is not valid');
 
-      await page
-        .locator('ix-icon-button[data-testid="open-time-picker"]')
-        .click();
+      await iconButton.click();
 
-      await expect(
-        page.locator('ix-dropdown[data-testid="time-dropdown"]')
-      ).toHaveClass(/show/);
+      await expect(dropdown).toHaveClass(/show/);
 
       await page
         .locator('ix-time-picker [data-element-container-id="second-30"]')
@@ -146,10 +139,8 @@ regressionTest.describe('time input tests', () => {
 
       await page.locator('ix-time-picker ix-button').click();
 
-      await expect(page.locator('input')).not.toHaveClass(/is-invalid/);
-      await expect(page.locator('ix-field-wrapper')).not.toContainText(
-        'Time is not valid'
-      );
+      await expect(input).not.toHaveClass(/is-invalid/);
+      await expect(fieldWrapper).not.toContainText('Time is not valid');
     }
   );
 
@@ -157,18 +148,19 @@ regressionTest.describe('time input tests', () => {
     'updating component value attribute updates validity',
     async ({ page }) => {
       const timeInput = page.locator('ix-time-input');
+      const input = page.locator('input');
 
       await timeInput.evaluateHandle((el) => {
         el.setAttribute('value', 'invalid-time');
       });
 
-      await expect(timeInput).toHaveClass(/is-invalid/);
+      await expect(input).toHaveClass(/is-invalid/);
 
       await timeInput.evaluateHandle((el) => {
         el.setAttribute('value', '09:10:11');
       });
 
-      await expect(timeInput).not.toHaveClass(/is-invalid/);
+      await expect(input).not.toHaveClass(/is-invalid/);
     }
   );
 });

--- a/packages/core/src/components/time-input/time-input.tsx
+++ b/packages/core/src/components/time-input/time-input.tsx
@@ -71,6 +71,10 @@ export class TimeInput implements IxInputFieldComponent<string> {
    */
   @Prop({ reflect: true, mutable: true }) value: string = '';
 
+  @Watch('value') watchValuePropHandler(newValue: string) {
+    this.onInput(newValue);
+  }
+
   /**
    * Format of time string
    * See {@link "https://moment.github.io/luxon/#/formatting?id=table-of-tokens"} for all available tokens.

--- a/packages/core/src/components/time-picker/time-picker.tsx
+++ b/packages/core/src/components/time-picker/time-picker.tsx
@@ -572,8 +572,11 @@ export class TimePicker {
 
       if (!dropdown.classList.contains('show')) {
         // keep picker in sync with input
-        this._time = DateTime.fromFormat(this.time, this.format);
-        this.setInitialFocusedValueAndUnit();
+        const timeFormat = DateTime.fromFormat(this.time, this.format);
+        if (timeFormat.isValid) {
+          this._time = DateTime.fromFormat(this.time, this.format);
+          this.setInitialFocusedValueAndUnit();
+        }
 
         continue;
       }


### PR DESCRIPTION
## 💡 What is the current behavior?

- enter invalid date
- close dropdown
- reopen dropdown and select a time --> component breaks

## 🆕 What is the new behavior?

- does not break anymore (keeps the previous valid time selected in the picker)

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)
