### PR TITLE
fix(core/tree): Fix RefreshTreeOptions missing import after build

### DIFF
--- a/.changeset/metal-ants-hope.md
+++ b/.changeset/metal-ants-hope.md
@@ -1,0 +1,5 @@
+---
+"@siemens/ix": patch
+---
+
+Export type __RefreshTreeOptions__ used by __ix-tree__.

--- a/packages/core/component-doc.json
+++ b/packages/core/component-doc.json
@@ -26732,6 +26732,11 @@
               "Promise": {
                 "location": "global",
                 "id": "global::Promise"
+              },
+              "RefreshTreeOptions": {
+                "location": "import",
+                "path": "tree.types",
+                "id": "src/components/tree/tree.types.ts::RefreshTreeOptions"
               }
             },
             "return": "Promise<void>"
@@ -28493,6 +28498,11 @@
       "declaration": "(\n  treeItem: TreeItem<any>,\n  context: TreeContext\n) => void",
       "docstring": "",
       "path": "src/components/tree/tree-model.ts"
+    },
+    "src/components/tree/tree.types.ts::RefreshTreeOptions": {
+      "declaration": "{\n  force?: boolean;\n}",
+      "docstring": "",
+      "path": "src/components/tree/tree.types.ts"
     },
     "src/components/tree/tree-model.ts::TreeItemContext": {
       "declaration": "export interface TreeItemContext {\n  isExpanded: boolean;\n  isSelected: boolean;\n}",

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -50,6 +50,7 @@ import { ShowToastResult } from "./components/toast/toast-container.types";
 import { ElementReference as ElementReference1 } from "./components.d";
 import { Element } from "@stencil/core";
 import { TreeContext, TreeItemContext, TreeModel, UpdateCallback } from "./components/tree/tree-model";
+import { RefreshTreeOptions } from "./components/tree/tree.types";
 import { TextDecoration, TypographyColors, TypographyFormat } from "./components/typography/typography.types";
 import { UploadFileState } from "./components/upload/upload-file-state";
 export { ActionCardVariant } from "./components/action-card/action-card.types";
@@ -97,6 +98,7 @@ export { ShowToastResult } from "./components/toast/toast-container.types";
 export { ElementReference as ElementReference1 } from "./components.d";
 export { Element } from "@stencil/core";
 export { TreeContext, TreeItemContext, TreeModel, UpdateCallback } from "./components/tree/tree-model";
+export { RefreshTreeOptions } from "./components/tree/tree.types";
 export { TextDecoration, TypographyColors, TypographyFormat } from "./components/typography/typography.types";
 export { UploadFileState } from "./components/upload/upload-file-state";
 export namespace Components {

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -310,7 +310,7 @@ export class Tree {
    * This will re-render the list with the current model and context.
    */
   @Method()
-  async refreshTree(options = defaultRefreshTreeOptions) {
+  async refreshTree(options: RefreshTreeOptions = defaultRefreshTreeOptions) {
     if (this.hyperlist) {
       this.hyperlist.refresh(
         this.hostElement,


### PR DESCRIPTION
## 💡 What is the current behavior?

RefreshTreeOptions is currently not imported in components.d.ts after building.

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

RefreshTreeOptions is now correctly imported and no longer causes an error.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)
