### PR TITLE
fix(input-group) icon and the placeholder text overlap within the input field

### DIFF
--- a/packages/core/src/components/drawer/drawer.scss
+++ b/packages/core/src/components/drawer/drawer.scss
@@ -13,8 +13,10 @@
 :host {
   @include ix-component;
 
+  position: fixed;
   top: 0;
   right: 0;
+  z-index: 100;
   @include box-shadow(3);
 
   display: block;
@@ -53,7 +55,6 @@
     order: 2;
     height: 100%;
     width: 100%;
-    overflow-y: auto;
   }
 }
 

--- a/packages/core/src/components/input-group/input-group.scss
+++ b/packages/core/src/components/input-group/input-group.scss
@@ -30,6 +30,8 @@
     height: 2rem;
     margin-left: 0.5rem;
     color: var(--theme-color-soft-text);
+    top: 50%;
+    transform: translateY(-50%); 
   }
 
   .group-end {

--- a/packages/core/src/components/input-group/input-group.tsx
+++ b/packages/core/src/components/input-group/input-group.tsx
@@ -133,7 +133,7 @@ export class InputGroup {
         this.inputElement.style.backgroundPosition = `left ${left}px center`;
         this.inputPaddingLeft += 26;
       }
-    });
+    }, 100);
   }
 
   private endSlotChanged() {

--- a/packages/react-test-app/src/preview-examples/drawer.tsx
+++ b/packages/react-test-app/src/preview-examples/drawer.tsx
@@ -7,22 +7,47 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { IxButton, IxDrawer } from '@siemens/ix-react';
+import { IxButton, IxDrawer, IxInputGroup, IxIcon } from '@siemens/ix-react';
 import { useState } from 'react';
+import { iconSuccess } from '@siemens/ix-icons/icons';
 
 export default () => {
   const [show, setShow] = useState(false);
 
   return (
     <>
-      <IxDrawer
-        closeOnClickOutside={true}
-        show={show}
-        onDrawerClose={() => setShow(false)}
-      >
-        <span>Some content of drawer</span>
-      </IxDrawer>
-      <IxButton onClick={() => setShow(!show)}>Toggle drawer</IxButton>
+    <IxDrawer
+      closeOnClickOutside={true}
+      show={show}
+      onDrawerClose={() => setShow(false)}
+    >
+      <IxInputGroup>
+        <IxIcon
+          slot="input-start"
+          name={iconSuccess}
+          color={'color-success'}
+          size="16"
+        />
+        <input
+          readOnly
+          type="text"
+          value="input text"
+          placeholder="Enter text"
+        />
+      </IxInputGroup>
+    </IxDrawer>
+    <IxButton onClick={() => setShow(!show)}>
+      Toggle drawer
+    </IxButton>
+    <IxInputGroup>
+      <IxIcon
+        slot="input-start"
+        name={iconSuccess}
+        color={'color-success'}
+        size="16"
+      />
+      <input readOnly type="text" value="input text" />
+    </IxInputGroup>
     </>
   );
 };


### PR DESCRIPTION

## 💡 What is the current behavior?

 icon and the placeholder text overlap within the input field

GitHub Issue Number: #1551

## 🆕 What is the new behavior?

The input field display correctly, with the placeholder text positioned beside the icon without any overlap inside the input-group

-
-

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [x] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
