### PR TITLE
fix(core/tooltip): Fix tooltip styling

### DIFF
--- a/.changeset/late-mugs-yell.md
+++ b/.changeset/late-mugs-yell.md
@@ -1,0 +1,7 @@
+---
+'@siemens/ix': patch
+---
+
+Fix styling of tooltip container height in __ix-tooltip__.
+
+Fixes #2009.

--- a/packages/core/src/components/tooltip/tooltip.scss
+++ b/packages/core/src/components/tooltip/tooltip.scss
@@ -23,7 +23,7 @@
   display: block;
   position: relative;
   width: auto;
-  height: 100%;
+  height: fit-content;
   background: var(--theme-tootlip--background);
   color: var(--theme-color-std-text);
   padding: 0.375rem 0.75rem 0.375rem 0.875rem;


### PR DESCRIPTION
## 💡 What is the current behavior?

The ix-tooltips are not displayed correctly when using the Safari browser.

GitHub Issue Number: #2009

## 🆕 What is the new behavior?

- The styling of the tooltip container height was fixed.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support