### PR TITLE
Added fix for properties textarea-rows and textarea-width issues

### DIFF
--- a/packages/core/scss/mixins/_input.scss
+++ b/packages/core/scss/mixins/_input.scss
@@ -119,7 +119,6 @@
 @mixin element-textarea {
   & {
     min-height: 2rem;
-    height: 3.25rem;
     padding: calc(0.375rem - var(--theme-input--border-thickness))
       calc(0.5rem - var(--theme-input--border-thickness));
   }

--- a/packages/core/src/components/input/textarea.scss
+++ b/packages/core/src/components/input/textarea.scss
@@ -54,3 +54,21 @@
     border-color: var(--theme-input--border-color--invalid--active) !important;
   }
 }
+
+:host {
+  textarea:not([rows]) {
+    height: 3.25rem; 
+  }
+  display: block;
+  width: var(--textarea-width, 100%);
+
+}
+
+.input-wrapper{
+  width: 100%;
+}
+
+textarea {
+  width: 100%;
+}
+

--- a/packages/core/src/components/input/textarea.tsx
+++ b/packages/core/src/components/input/textarea.tsx
@@ -175,9 +175,12 @@ export class Textarea implements IxInputFieldComponent<string> {
   componentWillLoad() {
     this.updateFormInternalValue(this.value);
     if (this.textareaWidth) {
-    this.hostElement.style.setProperty('--textarea-width', this.textareaWidth);
-    this.hostElement.setAttribute('textarea-width', '');
-  }
+      this.hostElement.style.setProperty(
+        '--textarea-width',
+        this.textareaWidth
+      );
+      this.hostElement.setAttribute('textarea-width', '');
+    }
   }
 
   updateFormInternalValue(value: string) {

--- a/packages/core/src/components/input/textarea.tsx
+++ b/packages/core/src/components/input/textarea.tsx
@@ -174,6 +174,10 @@ export class Textarea implements IxInputFieldComponent<string> {
 
   componentWillLoad() {
     this.updateFormInternalValue(this.value);
+    if (this.textareaWidth) {
+    this.hostElement.style.setProperty('--textarea-width', this.textareaWidth);
+    this.hostElement.setAttribute('textarea-width', '');
+  }
   }
 
   updateFormInternalValue(value: string) {


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

textareaRows property has no noticable effect on the component.
textareaWidth property relative values (e.g. 50%) will not work as expected

GitHub Issue Number: #1975  only textarea

## 🆕 What is the new behavior?
- Textarea Rows and textarea width has effect
-

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [X] 🧐 Static code analysis passes (`pnpm lint`)
- [X] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
