### PR TITLE
splitbutton independent disable functionality

### DIFF
--- a/packages/core/src/components/split-button/split-button.tsx
+++ b/packages/core/src/components/split-button/split-button.tsx
@@ -83,6 +83,8 @@ export class SplitButton {
    * Disabled
    */
   @Prop() disabled = false;
+  @Prop() disabledButton = false;
+  @Prop() disabledIcon = false;
 
   /**
    * Placement of the dropdown
@@ -99,6 +101,14 @@ export class SplitButton {
   private triggerElement?: HTMLElement;
   private dropdownElement?: HTMLIxDropdownElement;
 
+  private get isDisabledButton() {
+    return this.disabled || this.disabledButton;
+  }
+
+  private get isDisabledIcon() {
+    return this.disabled || this.disabledIcon;
+  }
+
   private linkTriggerRef() {
     if (this.triggerElement && this.dropdownElement) {
       this.dropdownElement.trigger = this.triggerElement;
@@ -114,10 +124,17 @@ export class SplitButton {
       variant: this.variant,
       outline: this.outline,
       ghost: this.ghost,
-      disabled: this.disabled,
+      disabled: this.disabled || this.isDisabledButton,
       class: {
         'left-button-border': !this.outline,
       },
+    };
+    const disabledButtonAttributes = {
+      variant: this.variant,
+      outline: this.outline,
+      ghost: this.ghost,
+      disabled: this.disabled || this.isDisabledIcon,
+      class: { anchor: true },
     };
     return (
       <Host>
@@ -139,7 +156,7 @@ export class SplitButton {
             ></ix-icon-button>
           )}
           <ix-icon-button
-            {...buttonAttributes}
+            {...disabledButtonAttributes}
             ref={(r) => (this.triggerElement = r)}
             class={'anchor'}
             icon={this.splitIcon ?? iconContextMenu}


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

Split button can only be set to disabled as a whole.

GitHub Issue Number: #<ISSUE NUMBER>

## 🆕 What is the new behavior?

Split button can be disabled individually

-
-

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [X] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [X] 🧐 Static code analysis passes (`pnpm lint`)
- [X] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
