### PR TITLE
feat(core/ix-time-input|ix-date-input): Extract basic logic into shared util functions

### DIFF
--- a/packages/core/src/components/date-input/date-input.tsx
+++ b/packages/core/src/components/date-input/date-input.tsx
@@ -22,7 +22,6 @@ import {
   h,
 } from '@stencil/core';
 import { DateTime } from 'luxon';
-import { dropdownController } from '../dropdown/dropdown-controller';
 import { SlotEnd, SlotStart } from '../input/input.fc';
 import {
   DisposableChangesAndVisibilityObservers,
@@ -38,6 +37,12 @@ import {
 } from '../utils/input';
 import { makeRef } from '../utils/make-ref';
 import type { DateInputValidityState } from './date-input.types';
+import {
+  closeDropdown,
+  createValidityState,
+  handleIconClick,
+  openDropdown,
+} from '../utils/input/picker-input.util';
 
 /**
  * @form-ready
@@ -316,46 +321,20 @@ export class DateInput implements IxInputFieldComponent<string | undefined> {
   }
 
   onCalenderClick(event: Event) {
-    if (!this.show) {
-      event.stopPropagation();
-      event.preventDefault();
-      this.openDropdown();
-    }
-
-    if (this.inputElementRef.current) {
-      this.inputElementRef.current.focus();
-    }
+    handleIconClick(
+      event,
+      this.show,
+      () => this.openDropdown(),
+      this.inputElementRef
+    );
   }
 
   async openDropdown() {
-    const dropdownElement = await this.dropdownElementRef.waitForCurrent();
-    const id = dropdownElement.getAttribute('data-ix-dropdown');
-
-    dropdownController.dismissAll();
-    if (!id) {
-      return;
-    }
-
-    const dropdown = dropdownController.getDropdownById(id);
-    if (!dropdown) {
-      return;
-    }
-    dropdownController.present(dropdown);
+    return openDropdown(this.dropdownElementRef);
   }
 
   async closeDropdown() {
-    const dropdownElement = await this.dropdownElementRef.waitForCurrent();
-    const id = dropdownElement.getAttribute('data-ix-dropdown');
-
-    if (!id) {
-      return;
-    }
-
-    const dropdown = dropdownController.getDropdownById(id);
-    if (!dropdown) {
-      return;
-    }
-    dropdownController.dismiss(dropdown);
+    return closeDropdown(this.dropdownElementRef);
   }
 
   private checkClassList() {
@@ -445,19 +424,9 @@ export class DateInput implements IxInputFieldComponent<string | undefined> {
   /** @internal */
   @Method()
   getValidityState(): Promise<ValidityState> {
-    return Promise.resolve({
-      badInput: false,
-      customError: false,
-      patternMismatch: this.isInputInvalid,
-      rangeOverflow: false,
-      rangeUnderflow: false,
-      stepMismatch: false,
-      tooLong: false,
-      tooShort: false,
-      typeMismatch: false,
-      valid: !this.isInputInvalid,
-      valueMissing: !!this.required && !this.value,
-    });
+    return Promise.resolve(
+      createValidityState(this.isInputInvalid, !!this.required, this.value)
+    );
   }
 
   /**

--- a/packages/core/src/components/time-input/time-input.tsx
+++ b/packages/core/src/components/time-input/time-input.tsx
@@ -22,7 +22,6 @@ import {
   h,
 } from '@stencil/core';
 import { DateTime } from 'luxon';
-import { dropdownController } from '../dropdown/dropdown-controller';
 import { SlotEnd, SlotStart } from '../input/input.fc';
 import {
   DisposableChangesAndVisibilityObservers,
@@ -39,6 +38,12 @@ import {
 import { makeRef } from '../utils/make-ref';
 import { IxTimePickerCustomEvent } from '../../components';
 import type { TimeInputValidityState } from './time-input.types';
+import {
+  closeDropdown,
+  createValidityState,
+  handleIconClick,
+  openDropdown,
+} from '../utils/input/picker-input.util';
 
 /**
  * @since 3.2.0
@@ -324,49 +329,23 @@ export class TimeInput implements IxInputFieldComponent<string> {
   }
 
   onTimeIconClick(event: Event) {
-    if (!this.show) {
-      event.stopPropagation();
-      event.preventDefault();
-      this.openDropdown();
-    }
-
-    if (this.inputElementRef.current) {
-      this.inputElementRef.current.focus();
-    }
+    handleIconClick(
+      event,
+      this.show,
+      () => this.openDropdown(),
+      this.inputElementRef
+    );
   }
 
   async openDropdown() {
     // keep picker in sync with input
     this.time = this.value;
 
-    const dropdownElement = await this.dropdownElementRef.waitForCurrent();
-    const id = dropdownElement.getAttribute('data-ix-dropdown');
-
-    dropdownController.dismissAll();
-    if (!id) {
-      return;
-    }
-
-    const dropdown = dropdownController.getDropdownById(id);
-    if (!dropdown) {
-      return;
-    }
-    dropdownController.present(dropdown);
+    return openDropdown(this.dropdownElementRef);
   }
 
   async closeDropdown() {
-    const dropdownElement = await this.dropdownElementRef.waitForCurrent();
-    const id = dropdownElement.getAttribute('data-ix-dropdown');
-
-    if (!id) {
-      return;
-    }
-
-    const dropdown = dropdownController.getDropdownById(id);
-    if (!dropdown) {
-      return;
-    }
-    dropdownController.dismiss(dropdown);
+    return closeDropdown(this.dropdownElementRef);
   }
 
   private checkClassList() {
@@ -456,19 +435,9 @@ export class TimeInput implements IxInputFieldComponent<string> {
   /** @internal */
   @Method()
   getValidityState(): Promise<ValidityState> {
-    return Promise.resolve({
-      badInput: false,
-      customError: false,
-      patternMismatch: this.isInputInvalid,
-      rangeOverflow: false,
-      rangeUnderflow: false,
-      stepMismatch: false,
-      tooLong: false,
-      tooShort: false,
-      typeMismatch: false,
-      valid: !this.isInputInvalid,
-      valueMissing: !!this.required && !this.value,
-    });
+    return Promise.resolve(
+      createValidityState(this.isInputInvalid, !!this.required, this.value)
+    );
   }
 
   /**

--- a/packages/core/src/components/utils/input/picker-input.util.ts
+++ b/packages/core/src/components/utils/input/picker-input.util.ts
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { dropdownController } from '../../dropdown/dropdown-controller';
+
+export async function openDropdown(dropdownElementRef: any) {
+  const dropdownElement = await dropdownElementRef.waitForCurrent();
+  const id = dropdownElement.getAttribute('data-ix-dropdown');
+
+  dropdownController.dismissAll();
+  if (!id) {
+    return;
+  }
+
+  const dropdown = dropdownController.getDropdownById(id);
+  if (!dropdown) {
+    return;
+  }
+  dropdownController.present(dropdown);
+}
+
+export async function closeDropdown(dropdownElementRef: any) {
+  const dropdownElement = await dropdownElementRef.waitForCurrent();
+  const id = dropdownElement.getAttribute('data-ix-dropdown');
+
+  if (!id) {
+    return;
+  }
+
+  const dropdown = dropdownController.getDropdownById(id);
+  if (!dropdown) {
+    return;
+  }
+  dropdownController.dismiss(dropdown);
+}
+
+export function handleIconClick(
+  event: Event,
+  show: boolean,
+  openDropdownFn: () => void,
+  inputElementRef: any
+) {
+  if (!show) {
+    event.stopPropagation();
+    event.preventDefault();
+    openDropdownFn();
+  }
+
+  if (inputElementRef.current) {
+    inputElementRef.current.focus();
+  }
+}
+
+export function createValidityState(
+  isInputInvalid: boolean,
+  required: boolean,
+  value: string | undefined
+): ValidityState {
+  return {
+    badInput: false,
+    customError: false,
+    patternMismatch: isInputInvalid,
+    rangeOverflow: false,
+    rangeUnderflow: false,
+    stepMismatch: false,
+    tooLong: false,
+    tooShort: false,
+    typeMismatch: false,
+    valid: !isInputInvalid,
+    valueMissing: !!required && !value,
+  };
+}


### PR DESCRIPTION
## 💡 What is the current behavior?

Currently we have some duplication in ix-time-input and ix-date-input due to shared logic.

## 🆕 What is the new behavior?

I have extracted the most basic functionality into util functions which both components now use. Proper removal of all duplication will be done as soon as stencil has finished implementing proper inheritance of components.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
