### PR TITLE
fix(core/theme-switcher): Fix MutationObserver for document body

### DIFF
--- a/.changeset/healthy-knives-repeat.md
+++ b/.changeset/healthy-knives-repeat.md
@@ -1,0 +1,5 @@
+---
+"@siemens/ix": patch
+---
+
+Fix **theme-switcher** to detect and toggle theme changes on both document.body and document.documentElement.

--- a/packages/core/src/components/utils/test/theme-switcher.spec.ts
+++ b/packages/core/src/components/utils/test/theme-switcher.spec.ts
@@ -53,15 +53,6 @@ describe('ThemeSwitcher', () => {
       expect(document.body.getAttribute('data-ix-color-schema')).toBe('light');
     });
 
-    it('should toggle theme CSS class on html element', () => {
-      themeSwitcher.setTheme(themeClass, false, document.documentElement);
-      themeSwitcher.toggleMode();
-
-      expect(
-        document.documentElement.classList.contains('theme-classic-light')
-      ).toBe(true);
-    });
-
     it('should toggle theme on html element', () => {
       themeSwitcher.setTheme(theme, false, document.documentElement);
       themeSwitcher.setVariant('dark');

--- a/packages/core/src/components/utils/test/theme-switcher.spec.ts
+++ b/packages/core/src/components/utils/test/theme-switcher.spec.ts
@@ -35,6 +35,43 @@ describe('ThemeSwitcher', () => {
         theme
       );
     });
+
+    it('should toggle theme CSS class', () => {
+      themeSwitcher.setTheme(themeClass);
+      themeSwitcher.toggleMode();
+      expect(document.body.classList.contains('theme-classic-light')).toBe(
+        true
+      );
+    });
+
+    it('should toggle theme attribute', () => {
+      themeSwitcher.setTheme(theme);
+      themeSwitcher.setVariant('dark');
+      themeSwitcher.toggleMode();
+
+      expect(document.body.getAttribute('data-ix-theme')).toBe(theme);
+      expect(document.body.getAttribute('data-ix-color-schema')).toBe('light');
+    });
+
+    it('should toggle theme CSS class on html element', () => {
+      themeSwitcher.setTheme(themeClass, false);
+      themeSwitcher.toggleMode();
+
+      expect(document.body.classList.contains('theme-classic-light')).toBe(
+        true
+      );
+    });
+
+    it('should toggle theme on html element', () => {
+      themeSwitcher.setTheme(theme, false, document.documentElement);
+      themeSwitcher.setVariant('dark');
+      themeSwitcher.toggleMode();
+
+      expect(document.documentElement.getAttribute('data-ix-theme')).toBe(
+        theme
+      );
+      expect(document.body.getAttribute('data-ix-color-schema')).toBe('light');
+    });
   });
 
   describe('schema', () => {

--- a/packages/core/src/components/utils/test/theme-switcher.spec.ts
+++ b/packages/core/src/components/utils/test/theme-switcher.spec.ts
@@ -54,12 +54,12 @@ describe('ThemeSwitcher', () => {
     });
 
     it('should toggle theme CSS class on html element', () => {
-      themeSwitcher.setTheme(themeClass, false);
+      themeSwitcher.setTheme(themeClass, false, document.documentElement);
       themeSwitcher.toggleMode();
 
-      expect(document.body.classList.contains('theme-classic-light')).toBe(
-        true
-      );
+      expect(
+        document.documentElement.classList.contains('theme-classic-light')
+      ).toBe(true);
     });
 
     it('should toggle theme on html element', () => {

--- a/packages/core/src/components/utils/theme-switcher.ts
+++ b/packages/core/src/components/utils/theme-switcher.ts
@@ -96,23 +96,24 @@ class ThemeSwitcher {
       return;
     }
 
-    const oldThemes: string[] = [];
-    Array.from(document.body.classList)
-      .filter((className) => className && this.isThemeClass(className))
-      .forEach((className) => {
-        oldThemes.push(className);
-      });
+    const elementsWithThemes = elements
+      .map((element) => ({
+        element,
+        themes: Array.from(element.classList).filter(
+          (className) => className && this.isThemeClass(className)
+        ),
+      }))
+      .filter((item) => item.themes.length > 0);
 
-    if (oldThemes.length === 0) {
+    if (elementsWithThemes.length === 0) {
       document.body.classList.add(this.getOppositeMode(this.defaultTheme));
       return;
     }
 
-    oldThemes.forEach((themeName) => {
-      document.body.classList.replace(
-        themeName,
-        this.getOppositeMode(themeName)
-      );
+    elementsWithThemes.forEach(({ element, themes }) => {
+      themes.forEach((themeName) => {
+        element.classList.replace(themeName, this.getOppositeMode(themeName));
+      });
     });
   }
 

--- a/packages/core/src/components/utils/theme-switcher.ts
+++ b/packages/core/src/components/utils/theme-switcher.ts
@@ -21,7 +21,8 @@ class ThemeSwitcher {
   readonly suffixDark = '-dark';
   readonly defaultTheme = 'theme-classic-dark';
 
-  mutationObserver?: MutationObserver;
+  mutationObserverDocumentElement?: MutationObserver;
+  mutationObserverBody?: MutationObserver;
   mutationObserverData?: MutationObserver;
   _themeChanged = new TypedEvent<string>();
   _schemaChanged = new TypedEvent<string>();
@@ -175,7 +176,21 @@ class ThemeSwitcher {
     return '';
   }
 
-  private handleMutations(mutations: MutationRecord[]) {
+  private splitMutations(mutations: MutationRecord[]) {
+    const classMutations = mutations.filter(
+      (mutation) => mutation.attributeName === 'class'
+    );
+
+    const dataMutations = mutations.filter(
+      (mutation) =>
+        mutation.attributeName === dataIxTheme ||
+        mutation.attributeName === dataIxColorSchema
+    );
+
+    return { classMutations, dataMutations };
+  }
+
+  private handleClassMutations(mutations: MutationRecord[]) {
     return mutations.forEach((mutation) => {
       const { target } = mutation;
       (target as HTMLElement).classList.forEach((className) => {
@@ -186,6 +201,23 @@ class ThemeSwitcher {
           this._themeChanged.emit(className);
         }
       });
+    });
+  }
+
+  private handleDataMutations(mutations: MutationRecord[]) {
+    return mutations.forEach((mutation) => {
+      const { target } = mutation;
+      const theme = (target as Element).attributes.getNamedItem(dataIxTheme);
+      if (theme?.value && mutation.oldValue !== theme.value) {
+        this._themeChanged.emit(theme.value);
+      }
+
+      const colorSchema = (target as Element).attributes.getNamedItem(
+        dataIxColorSchema
+      );
+      if (colorSchema?.value && mutation.oldValue !== colorSchema.value) {
+        this._schemaChanged.emit(colorSchema.value);
+      }
     });
   }
 
@@ -201,36 +233,28 @@ class ThemeSwitcher {
       return;
     }
 
-    this.mutationObserver = new MutationObserver((mutations) => {
-      this.handleMutations(mutations);
-    });
-
-    this.mutationObserver.observe(document.documentElement, {
-      attributeFilter: ['class'],
+    const mutationObserverConfig = {
+      attributeFilter: ['class', dataIxTheme, dataIxColorSchema],
       attributeOldValue: true,
-    });
+    };
 
-    this.mutationObserverData = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        const { target } = mutation;
-        const theme = (target as Element).attributes.getNamedItem(dataIxTheme);
-        if (theme?.value && mutation.oldValue !== theme.value) {
-          this._themeChanged.emit(theme.value);
-        }
+    const handleMutations = (mutations: MutationRecord[]) => {
+      const { classMutations, dataMutations } = this.splitMutations(mutations);
 
-        const colorSchema = (target as Element).attributes.getNamedItem(
-          dataIxColorSchema
-        );
-        if (colorSchema?.value && mutation.oldValue !== colorSchema.value) {
-          this._schemaChanged.emit(colorSchema.value);
-        }
-      });
-    });
+      this.handleClassMutations(classMutations);
+      this.handleDataMutations(dataMutations);
+    };
 
-    this.mutationObserverData.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: [dataIxTheme, dataIxColorSchema],
-    });
+    this.mutationObserverDocumentElement = new MutationObserver(
+      handleMutations
+    );
+    this.mutationObserverDocumentElement.observe(
+      document.documentElement,
+      mutationObserverConfig
+    );
+
+    this.mutationObserverBody = new MutationObserver(handleMutations);
+    this.mutationObserverBody.observe(document.body, mutationObserverConfig);
   }
 
   public constructor() {

--- a/packages/core/src/components/utils/theme-switcher.ts
+++ b/packages/core/src/components/utils/theme-switcher.ts
@@ -107,6 +107,9 @@ class ThemeSwitcher {
 
     if (elementsWithThemes.length === 0) {
       document.body.classList.add(this.getOppositeMode(this.defaultTheme));
+      document.documentElement.classList.add(
+        this.getOppositeMode(this.defaultTheme)
+      );
       return;
     }
 

--- a/packages/core/src/components/utils/theme-switcher.ts
+++ b/packages/core/src/components/utils/theme-switcher.ts
@@ -86,7 +86,6 @@ class ThemeSwitcher {
     const elementWithSchema = elements.find((el) =>
       this.getDataColorSchema(el)
     );
-
     if (elementWithSchema) {
       const currentSchema = this.getDataColorSchema(elementWithSchema)!;
       elementWithSchema.setAttribute(
@@ -96,27 +95,23 @@ class ThemeSwitcher {
       return;
     }
 
-    const elementsWithThemes = elements
-      .map((element) => ({
-        element,
-        themes: Array.from(element.classList).filter(
-          (className) => className && this.isThemeClass(className)
-        ),
-      }))
-      .filter((item) => item.themes.length > 0);
+    const oldThemes: string[] = [];
+    Array.from(document.body.classList)
+      .filter((className) => className && this.isThemeClass(className))
+      .forEach((className) => {
+        oldThemes.push(className);
+      });
 
-    if (elementsWithThemes.length === 0) {
+    if (oldThemes.length === 0) {
       document.body.classList.add(this.getOppositeMode(this.defaultTheme));
-      document.documentElement.classList.add(
-        this.getOppositeMode(this.defaultTheme)
-      );
       return;
     }
 
-    elementsWithThemes.forEach(({ element, themes }) => {
-      themes.forEach((themeName) => {
-        element.classList.replace(themeName, this.getOppositeMode(themeName));
-      });
+    oldThemes.forEach((themeName) => {
+      document.body.classList.replace(
+        themeName,
+        this.getOppositeMode(themeName)
+      );
     });
   }
 


### PR DESCRIPTION
## 💡 What is the current behavior?

The MutationObserver in the theme-switcher currently only checks for changes on the documentElement.

## 🆕 What is the new behavior?

The MutationObserver now checks for both document body and documentElement

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)

