### PR TITLE
fix(ix-radio) emits click event once's when the label gets clicked

### DIFF
--- a/packages/core/src/components/radio/radio.tsx
+++ b/packages/core/src/components/radio/radio.tsx
@@ -192,10 +192,13 @@ export class Radio implements IxFormComponent<string> {
             />
             <button
               disabled={this.disabled}
-              class={{
-                checked: this.checked,
+              class={{ checked: this.checked }}
+              onClick={(event) => {
+                event.stopPropagation();
+                if (!this.disabled && this.inputRef.current) {
+                  this.inputRef.current.click();
+                }
               }}
-              onClick={() => this.setCheckedState(!this.checked)}
             >
               <div
                 class="checkmark"

--- a/packages/core/src/components/radio/test/radio.ct.ts
+++ b/packages/core/src/components/radio/test/radio.ct.ts
@@ -120,3 +120,49 @@ test('Clicking label (including padding) checks the radio', async ({
   await label.waitFor({ state: 'visible' });
   await expect(radio).toHaveAttribute('aria-checked', 'true');
 });
+
+test('Clicking the custom circle triggers only one checkedChange event', async ({
+  mount,
+  page,
+}) => {
+  await mount(`<ix-radio label="Test"></ix-radio>`);
+  const radio = page.locator('ix-radio');
+  const button = radio.locator('button');
+
+  const checkedChangePromise = radio.evaluate((element: HTMLElement) => {
+    return new Promise<number>((resolve) => {
+      let count = 0;
+      element.addEventListener('checkedChange', () => {
+        count++;
+        setTimeout(() => resolve(count), 100);
+      });
+    });
+  });
+
+  await button.click();
+  const eventCount = await checkedChangePromise;
+  expect(eventCount).toBe(1);
+});
+
+test('Clicking the label triggers only one checkedChange event', async ({
+  mount,
+  page,
+}) => {
+  await mount(`<ix-radio label="Test"></ix-radio>`);
+  const radio = page.locator('ix-radio');
+  const label = radio.locator('label');
+
+  const checkedChangePromise = radio.evaluate((element: HTMLElement) => {
+    return new Promise<number>((resolve) => {
+      let count = 0;
+      element.addEventListener('checkedChange', () => {
+        count++;
+        setTimeout(() => resolve(count), 100);
+      });
+    });
+  });
+
+  await label.click();
+  const eventCount = await checkedChangePromise;
+  expect(eventCount).toBe(1);
+});


### PR DESCRIPTION


## 💡 What is the current behavior?

ix-radio emits click event twice when the label gets clicked

GitHub Issue Number: #2085

## 🆕 What is the new behavior?

ix-radio emits click event once's when the label gets clicked

-
-

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

