### PR TITLE
feat(core/toast): Missing documentation

### DIFF
--- a/.changeset/rich-walls-shave.md
+++ b/.changeset/rich-walls-shave.md
@@ -1,5 +1,0 @@
----
-"documentation": patch
----
-
-Angular function descriptions are now displayed in the documentation.

--- a/.changeset/rich-walls-shave.md
+++ b/.changeset/rich-walls-shave.md
@@ -1,0 +1,5 @@
+---
+"documentation": patch
+---
+
+Angular function descriptions are now displayed in the documentation.

--- a/packages/angular/src/providers/toast/toast.service.ts
+++ b/packages/angular/src/providers/toast/toast.service.ts
@@ -22,14 +22,23 @@ export class ToastService extends BaseToastService {
     super();
   }
 
+  /**
+   * Gets the current toast position
+   */
   public getPosition(): ToastPosition {
     return super.getPosition();
   }
 
+  /**
+   * Sets the current toast position
+   */
   public setPosition(position: ToastPosition): void {
     super.setPosition(position);
   }
 
+  /**
+   * Shows the toast
+   */
   public show(config: ToastConfig): Promise<ShowToastResult> {
     return super.show(config);
   }

--- a/packages/core/component-doc.json
+++ b/packages/core/component-doc.json
@@ -29165,7 +29165,7 @@
       "path": "src/components/toast/toast-container.types.ts"
     },
     "src/components/toast/toast-utils.ts::ToastConfig": {
-      "declaration": "export interface ToastConfig {\n  title?: string;\n  message?: string | HTMLElement;\n  action?: HTMLElement;\n  type?: ToastType;\n  autoClose?: boolean;\n  autoCloseDelay?: number;\n  icon?: string;\n  iconColor?: string;\n}",
+      "declaration": "export interface ToastConfig {\n  /**\n   * Title of the toast\n   */\n  title?: string;\n  message?: string | HTMLElement;\n  action?: HTMLElement;\n  type?: ToastType;\n  autoClose?: boolean;\n  autoCloseDelay?: number;\n  icon?: string;\n  iconColor?: string;\n}",
       "docstring": "",
       "path": "src/components/toast/toast-utils.ts"
     },

--- a/packages/core/component-doc.json
+++ b/packages/core/component-doc.json
@@ -29165,7 +29165,7 @@
       "path": "src/components/toast/toast-container.types.ts"
     },
     "src/components/toast/toast-utils.ts::ToastConfig": {
-      "declaration": "export interface ToastConfig {\n  /**\n   * Title of the toast\n   */\n  title?: string;\n  message?: string | HTMLElement;\n  action?: HTMLElement;\n  type?: ToastType;\n  autoClose?: boolean;\n  autoCloseDelay?: number;\n  icon?: string;\n  iconColor?: string;\n}",
+      "declaration": "export interface ToastConfig {\n  /**\n   * Title of the toast\n   */\n  title?: string;\n  /**\n   * Message of the toast\n   */\n  message?: string | HTMLElement;\n  /**\n   * Action element that is displayed below the toast message/title\n   */\n  action?: HTMLElement;\n  /**\n   * Type of the toast\n   */\n  type?: ToastType;\n  /**\n   * Controls whether the toast closes automatically after a delay\n   */\n  autoClose?: boolean;\n  /**\n   * Sets the delay for autoClose in milliseconds\n   */\n  autoCloseDelay?: number;\n  /**\n   * Icon that is displayed with the toast\n   */\n  icon?: string;\n  /**\n   * Color of the icon\n   */\n  iconColor?: string;\n}",
       "docstring": "",
       "path": "src/components/toast/toast-utils.ts"
     },

--- a/packages/core/src/components/toast/toast-utils.ts
+++ b/packages/core/src/components/toast/toast-utils.ts
@@ -28,11 +28,20 @@ export interface ToastConfig {
    */
   type?: ToastType;
   /**
-   *
+   * Controls whether the toast closes automatically after a delay
    */
   autoClose?: boolean;
+  /**
+   * Sets the delay for autoClose in milliseconds
+   */
   autoCloseDelay?: number;
+  /**
+   * Icon that is displayed with the toast
+   */
   icon?: string;
+  /**
+   * Color of the icon
+   */
   iconColor?: string;
 }
 

--- a/packages/core/src/components/toast/toast-utils.ts
+++ b/packages/core/src/components/toast/toast-utils.ts
@@ -11,6 +11,9 @@ export type ToastType = 'info' | 'success' | 'error' | 'warning';
 export type ToastPosition = 'bottom-right' | 'top-right';
 
 export interface ToastConfig {
+  /**
+   * Title of the toast
+   */
   title?: string;
   message?: string | HTMLElement;
   action?: HTMLElement;

--- a/packages/core/src/components/toast/toast-utils.ts
+++ b/packages/core/src/components/toast/toast-utils.ts
@@ -15,9 +15,21 @@ export interface ToastConfig {
    * Title of the toast
    */
   title?: string;
+  /**
+   * Message of the toast
+   */
   message?: string | HTMLElement;
+  /**
+   * Action element that is displayed below the toast message/title
+   */
   action?: HTMLElement;
+  /**
+   * Type of the toast
+   */
   type?: ToastType;
+  /**
+   *
+   */
   autoClose?: boolean;
   autoCloseDelay?: number;
   icon?: string;

--- a/packages/documentation/scripts/typedoc-generator.ts
+++ b/packages/documentation/scripts/typedoc-generator.ts
@@ -105,14 +105,22 @@ function extractCommentTags(
 }
 
 function getCommentSummary(property: any): string {
-  if (!property?.comment?.summary) {
-    return '';
+  if (property?.comment?.summary) {
+    return property.comment.summary
+      .filter((summary: any) => summary.kind === 'text')
+      .map((summary: any) => summary.text)
+      .join('');
   }
 
-  return property.comment.summary
-    .filter((summary: any) => summary.kind === 'text')
-    .map((summary: any) => summary.text)
-    .join('');
+  // For methods, check the signature comment
+  if (property.signatures && property.signatures[0]?.comment?.summary) {
+    return property.signatures[0].comment.summary
+      .filter((summary: any) => summary.kind === 'text')
+      .map((summary: any) => summary.text)
+      .join('');
+  }
+
+  return '';
 }
 
 function processProperties(child: any): TypeDocProperty[] {

--- a/packages/documentation/scripts/typedoc-generator.ts
+++ b/packages/documentation/scripts/typedoc-generator.ts
@@ -105,16 +105,11 @@ function extractCommentTags(
 }
 
 function getCommentSummary(property: any): string {
-  if (property?.comment?.summary) {
-    return property.comment.summary
-      .filter((summary: any) => summary.kind === 'text')
-      .map((summary: any) => summary.text)
-      .join('');
-  }
+  const summary =
+    property?.comment?.summary ?? property?.signatures?.[0]?.comment?.summary;
 
-  // For methods, check the signature comment
-  if (property.signatures && property.signatures[0]?.comment?.summary) {
-    return property.signatures[0].comment.summary
+  if (summary) {
+    return summary
       .filter((summary: any) => summary.kind === 'text')
       .map((summary: any) => summary.text)
       .join('');


### PR DESCRIPTION
IX-2903

## 💡 What is the current behavior?

Currently descriptions for functions in angular services are not added to the documentation

## 🆕 What is the new behavior?

- Now adds comments above functions in angular services as description to the documentation
- Add missing comments for toast

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)

