### PR TITLE
feat(modal)- Return closable instance

### DIFF
--- a/packages/angular/common/src/providers/modal/modal.service.ts
+++ b/packages/angular/common/src/providers/modal/modal.service.ts
@@ -36,6 +36,21 @@ export class ModalService {
     private injector: Injector
   ) {}
 
+  public close<TReason = any>(
+    instance: { htmlElement: any },
+    reason?: TReason
+  ): void {
+    if (
+      instance &&
+      instance.htmlElement &&
+      typeof instance.htmlElement.closeModal === 'function'
+    ) {
+      instance.htmlElement.closeModal(reason);
+    } else {
+      throw new Error('Invalid modal instance: cannot close');
+    }
+  }
+
   public async open<TData = any, TReason = any>(config: ModalConfig<TData>) {
     const context: ModalContext<TData> = {
       close: null,

--- a/packages/angular/src/providers/modal/modal.service.ts
+++ b/packages/angular/src/providers/modal/modal.service.ts
@@ -36,22 +36,16 @@ export class ModalService extends BaseModalService {
     super(appRef, componentFactoryResolver, injector);
   }
 
-
   public open<TData = any, TReason = any>(
     config: ModalConfig<TData>
   ): Promise<ModalInstance<TReason>> {
     return super.open(config);
   }
 
-
-  /**
-   * Closes the given modal instance, optionally passing a result/reason.
-   */
-  public close<TReason = any>(instance: ModalInstance<TReason>, reason?: TReason): void {
-    if (instance && instance.htmlElement && typeof instance.htmlElement.closeModal === 'function') {
-      instance.htmlElement.closeModal(reason);
-    } else {
-      throw new Error('Invalid modal instance: cannot close');
-    }
+  public close<TReason = any>(
+    instance: ModalInstance<TReason>,
+    reason?: TReason
+  ): void {
+    super.close(instance, reason);
   }
 }

--- a/packages/angular/src/providers/modal/modal.service.ts
+++ b/packages/angular/src/providers/modal/modal.service.ts
@@ -36,9 +36,22 @@ export class ModalService extends BaseModalService {
     super(appRef, componentFactoryResolver, injector);
   }
 
+
   public open<TData = any, TReason = any>(
     config: ModalConfig<TData>
   ): Promise<ModalInstance<TReason>> {
     return super.open(config);
+  }
+
+
+  /**
+   * Closes the given modal instance, optionally passing a result/reason.
+   */
+  public close<TReason = any>(instance: ModalInstance<TReason>, reason?: TReason): void {
+    if (instance && instance.htmlElement && typeof instance.htmlElement.closeModal === 'function') {
+      instance.htmlElement.closeModal(reason);
+    } else {
+      throw new Error('Invalid modal instance: cannot close');
+    }
   }
 }

--- a/packages/angular/standalone/src/providers/modal.ts
+++ b/packages/angular/standalone/src/providers/modal.ts
@@ -37,4 +37,11 @@ export class ModalService extends BaseModalService {
     defineCustomElement();
     return super.open(config);
   }
+
+  public close<TReason = any>(
+    instance: ModalInstance<TReason>,
+    reason?: TReason
+  ): void {
+    super.close(instance, reason);
+  }
 }

--- a/packages/react/src/modal/index.ts
+++ b/packages/react/src/modal/index.ts
@@ -22,3 +22,15 @@ export async function showModal(
 ) {
   return _showModal(config);
 }
+
+/**
+ * Dismisses a modal instance returned by showModal.
+ * @param modalInstance The modal instance returned by showModal
+ * @param dismissResult Optional result to pass to the dismiss event
+ */
+export function dismissModal(
+  modalInstance: { htmlElement: any },
+  dismissResult?: any
+) {
+  modalInstance?.htmlElement?.dismissModal?.(dismissResult);
+}

--- a/packages/react/src/modal/index.ts
+++ b/packages/react/src/modal/index.ts
@@ -23,14 +23,6 @@ export async function showModal(
   return _showModal(config);
 }
 
-/**
- * Dismisses a modal instance returned by showModal.
- * @param modalInstance The modal instance returned by showModal
- * @param dismissResult Optional result to pass to the dismiss event
- */
-export function dismissModal(
-  modalInstance: { htmlElement: any },
-  dismissResult?: any
-) {
-  modalInstance?.htmlElement?.dismissModal?.(dismissResult);
+export function close(modalInstance: { htmlElement: any }, closeResult?: any) {
+  modalInstance?.htmlElement?.close?.(closeResult);
 }

--- a/packages/vue/src/modal/index.ts
+++ b/packages/vue/src/modal/index.ts
@@ -19,14 +19,6 @@ export async function showModal(
   return _showModal(config);
 }
 
-/**
- * Dismisses a modal instance returned by showModal.
- * @param modalInstance The modal instance returned by showModal
- * @param dismissResult Optional result to pass to the dismiss event
- */
-export function dismissModal(
-  modalInstance: { htmlElement: any },
-  dismissResult?: any
-) {
-  modalInstance?.htmlElement?.dismissModal?.(dismissResult);
+export function close(modalInstance: { htmlElement: any }, closeResult?: any) {
+  modalInstance?.htmlElement?.closeModal?.(closeResult);
 }

--- a/packages/vue/src/modal/index.ts
+++ b/packages/vue/src/modal/index.ts
@@ -18,3 +18,15 @@ export async function showModal(
 ) {
   return _showModal(config);
 }
+
+/**
+ * Dismisses a modal instance returned by showModal.
+ * @param modalInstance The modal instance returned by showModal
+ * @param dismissResult Optional result to pass to the dismiss event
+ */
+export function dismissModal(
+  modalInstance: { htmlElement: any },
+  dismissResult?: any
+) {
+  modalInstance?.htmlElement?.dismissModal?.(dismissResult);
+}


### PR DESCRIPTION
## 💡 What is the current behavior?
Currently there is not close function for modal when used in angular, react and vue

GitHub Issue Number: #<ISSUE NUMBER>
JIRA- IX-1318

## 🆕 What is the new behavior?

Modal now has a close function which can be accessed from outside to close modal based on custom logic.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
