### PR TITLE
fix(core/modal): Modal showing outside viewport when trigger button at bottom of the page

### DIFF
--- a/.changeset/little-bananas-fail.md
+++ b/.changeset/little-bananas-fail.md
@@ -1,0 +1,9 @@
+---
+"@siemens/ix": patch
+"@siemens/ix-angular": patch
+"@siemens/ix-react": patch
+"@siemens/ix-vue": patch
+---
+
+Fixed a bug where the **ix-modal** was shown outside the viewport if the user has scrolled down on the page.
+Closes #2083

--- a/packages/core/src/components/modal/modal.scss
+++ b/packages/core/src/components/modal/modal.scss
@@ -37,7 +37,7 @@
   .modal {
     display: flex;
     flex-direction: column;
-    position: relative;
+    position: fixed;
     border: none;
     border-radius: var(--theme-default-border-radius);
     background: var(--theme-modal--background);


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

If the user has scrolled down the web page to trigger the modal, the modal dialog may be rendered outside the visible area of the viewport, making it inaccessible without manual scrolling.

GitHub Issue Number: #2083 

## 🆕 What is the new behavior?

If the user has scrolled down the web page to trigger the modal, the modal dialog will be rendered in visible area of the viewport.

-
-

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [X] 🧐 Static code analysis passes (`pnpm lint`)
- [X] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
