### PR TITLE
fix(core/field-wrapper):empty tooltip will not render when hover overed field

### DIFF
--- a/packages/core/src/components/field-wrapper/helper-text-util.tsx
+++ b/packages/core/src/components/field-wrapper/helper-text-util.tsx
@@ -16,19 +16,31 @@ import {
 
 export function hasAnyText({
   invalidText,
+  isInvalid,
   warningText,
+  isWarning,
   infoText,
+  isInfo,
   validText,
+  isValid,
   helperText,
 }: {
   invalidText?: string;
+  isInvalid?: boolean;
   warningText?: string;
+  isWarning?: boolean;
   infoText?: string;
+  isInfo?: boolean;
   validText?: string;
+  isValid?: boolean;
   helperText?: string;
 }) {
-  return [invalidText, warningText, infoText, validText, helperText].some(
-    (text) => text?.trim()
+  return (
+    (isInvalid && invalidText?.trim()) ||
+    (isWarning && warningText?.trim()) ||
+    (isInfo && infoText?.trim()) ||
+    (isValid && validText?.trim()) ||
+    helperText?.trim()
   );
 }
 


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

If [showTextAsTooltip] = true, an empty tooltip is always shown when a user hovers over the field. Only invalid text is specified.

GitHub Issue Number: #2147

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- When showTooltipAsText is set to true and when the field is not valid empty tooltip will not render

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
