### PR TITLE
fix(docs/blind): update blind component preview examples with correct variant

### DIFF
--- a/packages/angular-standalone-test-app/src/preview-examples/blind-variants.html
+++ b/packages/angular-standalone-test-app/src/preview-examples/blind-variants.html
@@ -7,8 +7,8 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 -->
 
-<ix-blind icon="bulb" label="Insight" sublabel="sublabel">
-  <div>Insight content</div>
+<ix-blind icon="bulb" label="Example" sublabel="sublabel">
+  <div>Filled content</div>
 </ix-blind>
 <ix-blind variant="outline" icon="bulb" label="Outline" sublabel="sublabel">
   <div>Outline content</div>

--- a/packages/angular-test-app/src/preview-examples/blind-variants.html
+++ b/packages/angular-test-app/src/preview-examples/blind-variants.html
@@ -7,8 +7,8 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 -->
 
-<ix-blind icon="bulb" label="Insight" sublabel="sublabel">
-  <div>Insight content</div>
+<ix-blind icon="bulb" label="Example" sublabel="sublabel">
+  <div>Filled content</div>
 </ix-blind>
 <ix-blind variant="outline" icon="bulb" label="Outline" sublabel="sublabel">
   <div>Outline content</div>

--- a/packages/html-test-app/src/preview-examples/blind-variants.html
+++ b/packages/html-test-app/src/preview-examples/blind-variants.html
@@ -23,8 +23,8 @@ LICENSE file in the root directory of this source tree.
     </script>
   </head>
   <body>
-    <ix-blind icon="bulb" label="Insight" sublabel="sublabel">
-      <div>Insight content</div>
+    <ix-blind icon="bulb" label="Example" sublabel="sublabel">
+      <div>Filled content</div>
     </ix-blind>
     <ix-blind variant="outline" icon="bulb" label="Outline" sublabel="sublabel">
       <div>Outline content</div>

--- a/packages/react-test-app/src/preview-examples/blind-variants.tsx
+++ b/packages/react-test-app/src/preview-examples/blind-variants.tsx
@@ -15,8 +15,8 @@ import { IxBlind } from '@siemens/ix-react';
 export default () => {
   return (
     <>
-      <IxBlind icon={iconBulb} label="Insight" sublabel="sublabel">
-        <div>Insight content</div>
+      <IxBlind icon={iconBulb} label="Example" sublabel="sublabel">
+        <div>Filled content</div>
       </IxBlind>
       <IxBlind
         variant="outline"

--- a/packages/vue-test-app/src/preview-examples/blind-variants.vue
+++ b/packages/vue-test-app/src/preview-examples/blind-variants.vue
@@ -15,8 +15,8 @@ import { IxBlind } from '@siemens/ix-vue';
 <style scoped src="./blind-variants.css"></style>
 
 <template>
-  <IxBlind :icon="iconBulb" label="Insight" sublabel="sublabel">
-    <div>Insight content</div>
+  <IxBlind :icon="iconBulb" label="Example" sublabel="sublabel">
+    <div>Filled content</div>
   </IxBlind>
   <IxBlind
     variant="outline"


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

Go to code tab of the blind component, see "Insight" as first element in the example

GitHub Issue Number: 

## 🆕 What is the new behavior?

Example in the blind component does not mention an "Insight" variant and preview examples updated according to figma

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
