### PR TITLE
fix(modal): Updated imports in standalone modal preview examples

### DIFF
--- a/packages/angular-standalone-test-app/src/preview-examples/modal-by-instance.ts
+++ b/packages/angular-standalone-test-app/src/preview-examples/modal-by-instance.ts
@@ -8,14 +8,13 @@
  */
 
 import { Component } from '@angular/core';
-import { IxButton } from '@siemens/ix-angular/standalone';
-
-import { ModalService } from '@siemens/ix-angular';
+import { IxButton, ModalService } from '@siemens/ix-angular/standalone';
 import ModalByInstanceExample from './modal-by-instance-content';
 
 @Component({
   selector: 'app-example',
   imports: [IxButton],
+  providers: [ModalService],
   template: '<ix-button (click)="openModal()">Show modal</ix-button>',
 })
 export default class ModalByInstance {

--- a/packages/angular-standalone-test-app/src/preview-examples/modal-by-template.ts
+++ b/packages/angular-standalone-test-app/src/preview-examples/modal-by-template.ts
@@ -14,13 +14,13 @@ import {
   IxModalHeader,
   IxModalContent,
   IxModalFooter,
+  ModalService,
 } from '@siemens/ix-angular/standalone';
-
-import { ModalService } from '@siemens/ix-angular';
 
 @Component({
   selector: 'app-example',
   imports: [IxButton, IxModal, IxModalHeader, IxModalContent, IxModalFooter],
+  providers: [ModalService],
   template: `
     <ix-button (click)="openModal()">Show modal</ix-button>
 

--- a/packages/angular-standalone-test-app/src/preview-examples/modal-close.ts
+++ b/packages/angular-standalone-test-app/src/preview-examples/modal-close.ts
@@ -8,9 +8,7 @@
  */
 
 import { Component, inject } from '@angular/core';
-import { IxButton } from '@siemens/ix-angular/standalone';
-
-import { ModalService } from '@siemens/ix-angular/standalone';
+import { IxButton, ModalService } from '@siemens/ix-angular/standalone';
 import ModalByInstanceExample from './modal-by-instance-content';
 
 @Component({

--- a/packages/angular-standalone-test-app/src/preview-examples/modal-form-ix-button-submit.ts
+++ b/packages/angular-standalone-test-app/src/preview-examples/modal-form-ix-button-submit.ts
@@ -31,6 +31,7 @@ import { FormsModule, NgForm } from '@angular/forms';
     IxModalFooter,
     IxInput,
   ],
+  providers: [ModalService],
 })
 export default class ModalFormIxButtonSubmit {
   @ViewChild('customModal', { read: TemplateRef })

--- a/packages/angular-standalone-test-app/src/preview-examples/modal-sizes.ts
+++ b/packages/angular-standalone-test-app/src/preview-examples/modal-sizes.ts
@@ -8,13 +8,14 @@
  */
 
 import { Component, TemplateRef, ViewChild } from '@angular/core';
-import { IxButton } from '@siemens/ix-angular/standalone';
+import { IxButton, ModalService } from '@siemens/ix-angular/standalone';
 
-import { IxModalSize, ModalService } from '@siemens/ix-angular';
+import { IxModalSize } from '@siemens/ix-angular';
 
 @Component({
   selector: 'app-example',
   imports: [IxButton],
+  providers: [ModalService],
   styleUrls: ['./modal-sizes.css'],
   templateUrl: './modal-sizes.html',
 })


### PR DESCRIPTION
## 💡 What is the current behavior?

- ModalService imported from @siemens/ix-angular fails with "no provider found" error 

GitHub Issue Number: #2060 
Jira Issue Number: 3296

## 🆕 What is the new behavior?

- ModalService imported from @siemens/ix-angular/standalone works correctly with proper provider setup

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support
