### PR TITLE
fix(core/menu)- Replaced div with span to fix layout issue in menu item component while using NVDA

### DIFF
--- a/packages/core/src/components/menu-category/menu-category.tsx
+++ b/packages/core/src/components/menu-category/menu-category.tsx
@@ -263,8 +263,8 @@ export class MenuCategory implements IxMenuItemBase {
           tooltipText={this.tooltipText}
           isCategory
         >
-          <div class="category">
-            <div class="category-text">{this.label}</div>
+          <span class="category">
+            <span class="category-text">{this.label}</span>
             <ix-icon
               name={iconChevronDownSmall}
               class={{
@@ -273,7 +273,7 @@ export class MenuCategory implements IxMenuItemBase {
               }}
               aria-hidden="true"
             ></ix-icon>
-          </div>
+          </span>
         </ix-menu-item>
         <div
           ref={(ref) => (this.menuItemsContainer = ref!)}

--- a/packages/core/src/components/menu-item/menu-item.scss
+++ b/packages/core/src/components/menu-item/menu-item.scss
@@ -66,13 +66,17 @@ $menuItemPadding: 0.875rem;
       font-size: 0.75rem;
       font-weight: bold;
       line-height: 1;
-      font-family: Siemens Sans, Arial, sans-serif;
+      font-family:
+        Siemens Sans,
+        Arial,
+        sans-serif;
       color: var(--theme-color-primary--contrast);
       padding: vars.$tiny-space;
     }
   }
 
   .tab-text {
+    display: block;
     color: var(--theme-nav-item-primary--color);
     margin: 0 1rem 0 1.25rem;
     user-select: none;

--- a/packages/core/src/components/menu-item/menu-item.tsx
+++ b/packages/core/src/components/menu-item/menu-item.tsx
@@ -204,10 +204,10 @@ export class MenuItem implements IxMenuItemBase {
           <div class="pill">{this.notifications}</div>
         </div>
       ) : null,
-      <div id={this.internalItemId} class="tab-text text-default">
+      <span id={this.internalItemId} class="tab-text text-default">
         {this.label}
         <slot></slot>
-      </div>,
+      </span>,
     ];
 
     return (


### PR DESCRIPTION
## 💡 What is the current behavior?

While using the NVDA screen reader, enter keydown does not expand the category menu button.

GitHub Issue Number: #<ISSUE NUMBER>
Jira Issue Number: IX-3847

Submenu now expands on enter keydown while NVDA is running.

Earlier when menu-category was being slotted inside the menu item, the html element semantic structure was compromised. div tags were placed inside the span tag which caused the issue.

Fix involved reverting the divs for menu category to span. This allows the enter keydown while using NVDA to work as expected.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)


