### PR TITLE
fix(core/toast): Add screen reader announcement support for toast component

### DIFF
--- a/.changeset/long-words-mix.md
+++ b/.changeset/long-words-mix.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix': patch
+---
+
+Toast component now supports screen reader announcements

--- a/packages/core/src/components/toast/tests/toast.ct.ts
+++ b/packages/core/src/components/toast/tests/toast.ct.ts
@@ -31,7 +31,7 @@ regressionTest('renders', async ({ mount, page }) => {
 });
 
 regressionTest(
-  'announces message through aria-live region',
+  'sets live-region attributes for screen reader announcements',
   async ({ mount, page }) => {
     await mount('');
 
@@ -44,49 +44,11 @@ regressionTest(
 
     const toast = page.locator('ix-toast');
     await expect(toast).toHaveClass(/hydrated/);
-    await expect(toast).not.toHaveAttribute('role', 'status');
-    await expect(toast).not.toHaveAttribute('aria-live', 'polite');
-    await expect(toast).not.toHaveAttribute('aria-atomic', 'true');
-
-    const liveAnnouncer = page.locator('#toast-container-announcer');
-    await expect(liveAnnouncer).toHaveAttribute('role', 'status');
-    await expect(liveAnnouncer).toHaveAttribute('aria-live', 'polite');
-    await expect(liveAnnouncer).toHaveAttribute('aria-atomic', 'true');
-    await expect(liveAnnouncer).toContainText('Info. Toast announcement');
-  }
-);
-
-regressionTest(
-  're-announces repeated toast messages',
-  async ({ mount, page }) => {
-    await mount('');
-
-    await page.evaluate(() => {
-      window.toast({
-        title: 'Repeat',
-        message: 'Same message',
-      });
-    });
-
-    const liveAnnouncer = page.locator('#toast-container-announcer');
-    await expect(liveAnnouncer).toContainText('Repeat. Same message');
-
-    const firstAnnouncerHandle = await liveAnnouncer.elementHandle();
-    expect(firstAnnouncerHandle).toBeTruthy();
-
-    await page.evaluate(() => {
-      window.toast({
-        title: 'Repeat',
-        message: 'Same message',
-      });
-    });
-
-    await expect(liveAnnouncer).toContainText('Repeat. Same message');
-
-    const firstAnnouncerWasReplaced = await firstAnnouncerHandle!.evaluate(
-      (element) => !element.isConnected
-    );
-    expect(firstAnnouncerWasReplaced).toBe(true);
+    await expect(toast).toHaveAttribute('role', 'alert');
+    await expect(toast).toHaveAttribute('aria-live', 'polite');
+    await expect(toast).toHaveAttribute('aria-atomic', 'true');
+    await expect(toast).toContainText('Info');
+    await expect(toast).toContainText('Toast announcement');
   }
 );
 

--- a/packages/core/src/components/toast/tests/toast.ct.ts
+++ b/packages/core/src/components/toast/tests/toast.ct.ts
@@ -31,6 +31,66 @@ regressionTest('renders', async ({ mount, page }) => {
 });
 
 regressionTest(
+  'announces message through aria-live region',
+  async ({ mount, page }) => {
+    await mount('');
+
+    await page.evaluate(() => {
+      window.toast({
+        title: 'Info',
+        message: 'Toast announcement',
+      });
+    });
+
+    const toast = page.locator('ix-toast');
+    await expect(toast).toHaveClass(/hydrated/);
+    await expect(toast).not.toHaveAttribute('role', 'status');
+    await expect(toast).not.toHaveAttribute('aria-live', 'polite');
+    await expect(toast).not.toHaveAttribute('aria-atomic', 'true');
+
+    const liveAnnouncer = page.locator('#toast-container-announcer');
+    await expect(liveAnnouncer).toHaveAttribute('role', 'status');
+    await expect(liveAnnouncer).toHaveAttribute('aria-live', 'polite');
+    await expect(liveAnnouncer).toHaveAttribute('aria-atomic', 'true');
+    await expect(liveAnnouncer).toContainText('Info. Toast announcement');
+  }
+);
+
+regressionTest(
+  're-announces repeated toast messages',
+  async ({ mount, page }) => {
+    await mount('');
+
+    await page.evaluate(() => {
+      window.toast({
+        title: 'Repeat',
+        message: 'Same message',
+      });
+    });
+
+    const liveAnnouncer = page.locator('#toast-container-announcer');
+    await expect(liveAnnouncer).toContainText('Repeat. Same message');
+
+    const firstAnnouncerHandle = await liveAnnouncer.elementHandle();
+    expect(firstAnnouncerHandle).toBeTruthy();
+
+    await page.evaluate(() => {
+      window.toast({
+        title: 'Repeat',
+        message: 'Same message',
+      });
+    });
+
+    await expect(liveAnnouncer).toContainText('Repeat. Same message');
+
+    const firstAnnouncerWasReplaced = await firstAnnouncerHandle!.evaluate(
+      (element) => !element.isConnected
+    );
+    expect(firstAnnouncerWasReplaced).toBe(true);
+  }
+);
+
+regressionTest(
   'should be visible through overlays',
   async ({ mount, page }) => {
     await mount(`

--- a/packages/core/src/components/toast/toast-container.tsx
+++ b/packages/core/src/components/toast/toast-container.tsx
@@ -32,63 +32,6 @@ export class ToastContainer {
 
   private readonly PREFIX_POSITION_CLASS = 'toast-container--';
 
-  private get announcerId() {
-    return `${this.containerId}-announcer`;
-  }
-
-  private getScreenReaderAnnouncement(config: ToastConfig): string | undefined {
-    const messageText =
-      typeof config.message === 'string'
-        ? config.message
-        : (config.message?.textContent ?? '');
-
-    const announcement = [config.title ?? '', messageText]
-      .map((part) => part.trim())
-      .filter((part) => part.length > 0)
-      .join('. ');
-
-    return announcement.length > 0 ? announcement : undefined;
-  }
-
-  private createAnnouncer() {
-    const announcer = document.createElement('div');
-    announcer.id = this.announcerId;
-    announcer.setAttribute('role', 'status');
-    announcer.setAttribute('aria-live', 'polite');
-    announcer.setAttribute('aria-atomic', 'true');
-
-    // Keep announcer in light DOM so VoiceOver reliably picks updates.
-    announcer.style.position = 'fixed';
-    announcer.style.width = '1px';
-    announcer.style.height = '1px';
-    announcer.style.padding = '0';
-    announcer.style.margin = '-1px';
-    announcer.style.overflow = 'hidden';
-    announcer.style.clip = 'rect(0, 0, 0, 0)';
-    announcer.style.whiteSpace = 'nowrap';
-    announcer.style.border = '0';
-
-    document.body.appendChild(announcer);
-    return announcer;
-  }
-
-  private announceForScreenReader(message?: string) {
-    if (!message) {
-      return;
-    }
-
-    const existingAnnouncer = document.getElementById(this.announcerId);
-    if (existingAnnouncer) {
-      existingAnnouncer.remove();
-    }
-
-    const announcer = this.createAnnouncer();
-
-    window.setTimeout(() => {
-      announcer.textContent = message;
-    }, 50);
-  }
-
   get hostContainer() {
     return new Promise<HTMLElement>((resolve) => {
       const interval = setInterval(() => {
@@ -148,8 +91,6 @@ export class ToastContainer {
     toast.iconColor = config.iconColor;
     toast.hideIcon = config.hideIcon ?? false;
 
-    const screenReaderAnnouncement = this.getScreenReaderAnnouncement(config);
-
     toast.addEventListener(
       'closeToast',
       (event: CustomEvent<any | undefined>) => {
@@ -172,7 +113,6 @@ export class ToastContainer {
     }
 
     (await this.hostContainer).appendChild(toast);
-    this.announceForScreenReader(screenReaderAnnouncement);
 
     return {
       onClose,

--- a/packages/core/src/components/toast/toast-container.tsx
+++ b/packages/core/src/components/toast/toast-container.tsx
@@ -32,6 +32,73 @@ export class ToastContainer {
 
   private readonly PREFIX_POSITION_CLASS = 'toast-container--';
 
+  private get announcerId() {
+    return `${this.containerId}-announcer`;
+  }
+
+  private getScreenReaderAnnouncement(config: ToastConfig): string | undefined {
+    const messageText =
+      typeof config.message === 'string'
+        ? config.message
+        : (config.message?.textContent ?? '');
+
+    const announcement = [config.title ?? '', messageText]
+      .map((part) => part.trim())
+      .filter((part) => part.length > 0)
+      .join('. ');
+
+    return announcement.length > 0 ? announcement : undefined;
+  }
+
+  private createAnnouncer() {
+    const announcer = document.createElement('div');
+    announcer.id = this.announcerId;
+    announcer.setAttribute('role', 'status');
+    announcer.setAttribute('aria-live', 'polite');
+    announcer.setAttribute('aria-atomic', 'true');
+
+    // Keep announcer in light DOM so VoiceOver reliably picks updates.
+    announcer.style.position = 'fixed';
+    announcer.style.width = '1px';
+    announcer.style.height = '1px';
+    announcer.style.padding = '0';
+    announcer.style.margin = '-1px';
+    announcer.style.overflow = 'hidden';
+    announcer.style.clip = 'rect(0, 0, 0, 0)';
+    announcer.style.whiteSpace = 'nowrap';
+    announcer.style.border = '0';
+
+    document.body.appendChild(announcer);
+    return announcer;
+  }
+
+  private ensureScreenReaderAnnouncer() {
+    const existingAnnouncer = document.getElementById(this.announcerId);
+    if (existingAnnouncer) {
+      return existingAnnouncer;
+    }
+
+    return this.createAnnouncer();
+  }
+
+  private announceForScreenReader(message?: string) {
+    if (!message) {
+      return;
+    }
+
+    const existingAnnouncer = document.getElementById(this.announcerId);
+    if (existingAnnouncer) {
+      existingAnnouncer.remove();
+    }
+
+    const announcer = this.createAnnouncer();
+    announcer.textContent = '';
+
+    window.setTimeout(() => {
+      announcer.textContent = message;
+    }, 50);
+  }
+
   get hostContainer() {
     return new Promise<HTMLElement>((resolve) => {
       const interval = setInterval(() => {
@@ -54,6 +121,8 @@ export class ToastContainer {
       );
       document.body.appendChild(toastContainer);
     }
+
+    this.ensureScreenReaderAnnouncer();
   }
 
   @Watch('position')
@@ -90,6 +159,9 @@ export class ToastContainer {
     toast.icon = config.icon;
     toast.iconColor = config.iconColor;
     toast.hideIcon = config.hideIcon ?? false;
+
+    const screenReaderAnnouncement = this.getScreenReaderAnnouncement(config);
+
     toast.addEventListener(
       'closeToast',
       (event: CustomEvent<any | undefined>) => {
@@ -112,6 +184,7 @@ export class ToastContainer {
     }
 
     (await this.hostContainer).appendChild(toast);
+    this.announceForScreenReader(screenReaderAnnouncement);
 
     return {
       onClose,

--- a/packages/core/src/components/toast/toast-container.tsx
+++ b/packages/core/src/components/toast/toast-container.tsx
@@ -72,15 +72,6 @@ export class ToastContainer {
     return announcer;
   }
 
-  private ensureScreenReaderAnnouncer() {
-    const existingAnnouncer = document.getElementById(this.announcerId);
-    if (existingAnnouncer) {
-      return existingAnnouncer;
-    }
-
-    return this.createAnnouncer();
-  }
-
   private announceForScreenReader(message?: string) {
     if (!message) {
       return;
@@ -92,7 +83,6 @@ export class ToastContainer {
     }
 
     const announcer = this.createAnnouncer();
-    announcer.textContent = '';
 
     window.setTimeout(() => {
       announcer.textContent = message;
@@ -121,8 +111,6 @@ export class ToastContainer {
       );
       document.body.appendChild(toastContainer);
     }
-
-    this.ensureScreenReaderAnnouncer();
   }
 
   @Watch('position')

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -192,7 +192,12 @@ export class Toast {
     progressBarClass.push('toast-progress-bar--animated');
 
     return (
-      <Host class="animate__animated animate__fadeIn">
+      <Host
+        role="alert"
+        aria-live="polite"
+        aria-atomic="true"
+        class="animate__animated animate__fadeIn"
+      >
         <div
           class="toast-body"
           onPointerLeave={() => {


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

Toast messages are not picked up by screen readers.

Jira: IX-4009

## 🆕 What is the new behavior?

Whenever a toast message appears on the screen, screen reader is gonna announce that message.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
