### PR TITLE
Ix menu about has all tabs contents on first load

### DIFF
--- a/packages/core/src/components/menu-about/test/menu-about.ct.ts
+++ b/packages/core/src/components/menu-about/test/menu-about.ct.ts
@@ -28,6 +28,29 @@ regressionTest('renders', async ({ mount, page }) => {
   await expect(aboutAndLegal).toHaveClass(/hydrated/);
 });
 
+regressionTest(
+  'should show only the first tab content on initial render',
+  async ({ mount, page }) => {
+    await mount(`
+      <ix-menu>
+        <ix-menu-about>
+          <ix-menu-about-item label="Tab 1">Content 1</ix-menu-about-item>
+          <ix-menu-about-item label="Tab 2">Content 2</ix-menu-about-item>
+        </ix-menu-about>
+      </ix-menu>
+    `);
+
+    const element = page.locator('#aboutAndLegal');
+    await element.click();
+
+    const aboutItems = page.locator('ix-menu-about-item');
+    await expect(aboutItems.first()).toHaveClass(/hydrated/);
+
+    await expect(aboutItems.first()).toHaveCSS('display', 'block');
+    await expect(aboutItems.last()).toHaveCSS('display', 'none');
+  }
+);
+
 regressionTest('active-tab-label', async ({ mount, page }) => {
   await mount(`
     <ix-application>
@@ -46,8 +69,12 @@ regressionTest('active-tab-label', async ({ mount, page }) => {
   const tabItems = page.locator('ix-tab-item');
   await expect(tabItems.first()).toHaveClass(/hydrated/);
 
-  await expect(tabItems.first()).not.toHaveClass(/\bselected\b/);
-  await expect(tabItems.last()).toHaveClass(/\bselected\b/);
+  await expect(tabItems.first()).not.toHaveAttribute('selected', 'true');
+  await expect(tabItems.last()).toHaveAttribute('selected', 'true');
+
+  const aboutItems = page.locator('ix-menu-about-item');
+  await expect(aboutItems.first()).toHaveCSS('display', 'none');
+  await expect(aboutItems.last()).toHaveCSS('display', 'block');
 });
 
 regressionTest('should not change tab', async ({ mount, page }) => {

--- a/packages/core/src/components/menu-about/test/menu-about.ct.ts
+++ b/packages/core/src/components/menu-about/test/menu-about.ct.ts
@@ -71,10 +71,6 @@ regressionTest('active-tab-label', async ({ mount, page }) => {
 
   await expect(tabItems.first()).not.toHaveAttribute('selected', 'true');
   await expect(tabItems.last()).toHaveAttribute('selected', 'true');
-
-  const aboutItems = page.locator('ix-menu-about-item');
-  await expect(aboutItems.first()).toHaveCSS('display', 'none');
-  await expect(aboutItems.last()).toHaveCSS('display', 'block');
 });
 
 regressionTest('should not change tab', async ({ mount, page }) => {

--- a/packages/core/src/components/utils/menu-tabs/menu-tabs-utils.ts
+++ b/packages/core/src/components/utils/menu-tabs/menu-tabs-utils.ts
@@ -7,6 +7,67 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { MenuAbout } from '../../menu-about/menu-about';
+import { MenuSettings } from '../../menu-settings/menu-settings';
+
+function getItems(
+  context: MenuSettings | MenuAbout
+): HTMLIxMenuSettingsItemElement[] | HTMLIxMenuAboutItemElement[] {
+  return Array.from(
+    context.el.querySelectorAll(
+      context instanceof MenuSettings
+        ? 'ix-menu-settings-item'
+        : 'ix-menu-about-item'
+    )
+  );
+}
+
+export function setTab(context: MenuSettings | MenuAbout, label: string) {
+  if (context.activeTabLabel === label) {
+    return;
+  }
+  const { defaultPrevented } = context.tabChange.emit(label);
+
+  if (defaultPrevented) {
+    return;
+  }
+  context.activeTabLabel = label;
+}
+
+export function syncTabDisplay(
+  context: MenuSettings | MenuAbout,
+  label: string
+) {
+  context.items.forEach((i) => {
+    i.style.display = 'none';
+    if (i.label === label) {
+      i.style.display = 'block';
+    }
+  });
+}
+
+export function initialize(context: MenuSettings | MenuAbout) {
+  context.items = getItems(context);
+
+  if (context.items.length) {
+    const selectedLabel = context.activeTabLabel || context.items[0].label;
+    if (selectedLabel) {
+      setTab(context, selectedLabel);
+      syncTabDisplay(context, selectedLabel);
+    }
+  }
+
+  context.items.forEach((item) => {
+    item.addEventListener('labelChange', (e: CustomEvent) => {
+      context.items = getItems(context);
+
+      if (e.detail.oldLabel === context.activeTabLabel) {
+        context.activeTabLabel = e.detail.newLabel;
+      }
+    });
+  });
+}
+
 export interface CustomLabelChangeEvent {
   name: string;
   oldLabel: string;

--- a/packages/vue-test-app/src/preview-examples/about-and-legal.vue
+++ b/packages/vue-test-app/src/preview-examples/about-and-legal.vue
@@ -26,7 +26,7 @@ const setActiveTabKey = (event: CustomEvent<string | undefined>) => {
 };
 
 onMounted(() => {
-  input.value?.toggleAbout(true);
+  (input.value as any).$el?.toggleAbout(true);
 });
 </script>
 


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?
core: 
About & Legal has all tabs contents on initial render. After switching tabs, it works as it should.
preview example: 
The About & Legal panel didn't open automatically in the Vue-test-app preview example.



GitHub Issue Number: 2482
Jira ticket: IX-4153, IX-4199
## 🆕 What is the new behavior?

1. Each tab displays only its own content on initial render and after tab switches.
2. The About & Legal panel open automatically in the preview.



## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [X] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [X] 🧐 Static code analysis passes (`pnpm lint`)
- [X] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
