### PR TITLE
fix(core/split-button): Remove placement prop for split button

### DIFF
--- a/.changeset/beige-icons-poke.md
+++ b/.changeset/beige-icons-poke.md
@@ -1,0 +1,8 @@
+---
+'@siemens/ix-angular': major
+'@siemens/ix-react': major
+'@siemens/ix': major
+'@siemens/ix-vue': major
+---
+
+**Breaking (v5):** Remove the **`placement`** property (and **`placement`** attribute) from **`ix-split-button`**. It was not wired to the internal dropdown, so it had no effect; removing it only drops a misleading no-op from the public API. See **`BREAKING_CHANGES/v5.md`**.

--- a/BREAKING_CHANGES/v5.md
+++ b/BREAKING_CHANGES/v5.md
@@ -247,6 +247,35 @@ Escape and the `<dialog>` **cancel** path always call **`dismissModal()`**. To b
 
 **Note:** `beforeDismiss` runs for **every** `dismissModal` attempt, not only Escape. If you only need to block some dismiss sources, pass a **reason** (when supported) or split flows between **`closeModal`** vs **`dismissModal`**.
 
+## `ix-split-button`: `placement` removed
+
+The `placement` property on `ix-split-button` was not applied to the internal menu. It is removed as a public API to avoid a misleading no-op.
+
+| v4 API or behavior      | V5 replacement |
+| ----------------------- | -------------- |
+| `placement` / `placement` | Remove         |
+
+### `ix-split-button` before
+
+```html
+<ix-split-button label="Save" placement="bottom-start">
+  <ix-dropdown-item label="Item 1"></ix-dropdown-item>
+</ix-split-button>
+```
+
+### `ix-split-button` after
+
+```html
+<ix-split-button label="Save">
+  <ix-dropdown-item label="Item 1"></ix-dropdown-item>
+</ix-split-button>
+```
+
+### `ix-split-button` migration rules
+
+1. Remove every `placement` (and `placement` attribute) from `ix-split-button`.
+2. No layout change is expected: the v4 value was not used when positioning the dropdown.
+
 ## Validation checklist
 
 1. There are no remaining `theme-<theme>-<schema>` classes in application code.
@@ -256,3 +285,4 @@ Escape and the `<dialog>` **cancel** path always call **`dismissModal()`**. To b
 5. Every `ix-application` usage passes a plain theme name, not a combined theme-and-schema value.
 6. Button-related hosts use native `aria-label` instead of `aria-label-button`, `a11y-label`, or `aria-label-icon-button`.
 7. There are no remaining `disableEscapeClose` / `disable-escape-close` usages; use `beforeDismiss` instead.
+8. There are no remaining `placement` props on `ix-split-button` (`placement` attribute).

--- a/packages/angular/src/components.ts
+++ b/packages/angular/src/components.ts
@@ -2551,14 +2551,14 @@ export declare interface IxSpinner extends Components.IxSpinner {}
 
 
 @ProxyCmp({
-  inputs: ['ariaLabelButton', 'ariaLabelSplitIconButton', 'closeBehavior', 'disableButton', 'disableDropdownButton', 'disabled', 'enableTopLayer', 'icon', 'label', 'placement', 'splitIcon', 'variant']
+  inputs: ['ariaLabelButton', 'ariaLabelSplitIconButton', 'closeBehavior', 'disableButton', 'disableDropdownButton', 'disabled', 'enableTopLayer', 'icon', 'label', 'splitIcon', 'variant']
 })
 @Component({
   selector: 'ix-split-button',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabelButton', 'ariaLabelSplitIconButton', 'closeBehavior', 'disableButton', 'disableDropdownButton', 'disabled', 'enableTopLayer', 'icon', 'label', 'placement', 'splitIcon', 'variant'],
+  inputs: ['ariaLabelButton', 'ariaLabelSplitIconButton', 'closeBehavior', 'disableButton', 'disableDropdownButton', 'disabled', 'enableTopLayer', 'icon', 'label', 'splitIcon', 'variant'],
   outputs: ['buttonClick'],
   standalone: false
 })

--- a/packages/angular/standalone/src/components.ts
+++ b/packages/angular/standalone/src/components.ts
@@ -2654,14 +2654,14 @@ export declare interface IxSpinner extends Components.IxSpinner {}
 
 @ProxyCmp({
   defineCustomElementFn: defineIxSplitButton,
-  inputs: ['ariaLabelButton', 'ariaLabelSplitIconButton', 'closeBehavior', 'disableButton', 'disableDropdownButton', 'disabled', 'enableTopLayer', 'icon', 'label', 'placement', 'splitIcon', 'variant']
+  inputs: ['ariaLabelButton', 'ariaLabelSplitIconButton', 'closeBehavior', 'disableButton', 'disableDropdownButton', 'disabled', 'enableTopLayer', 'icon', 'label', 'splitIcon', 'variant']
 })
 @Component({
   selector: 'ix-split-button',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabelButton', 'ariaLabelSplitIconButton', 'closeBehavior', 'disableButton', 'disableDropdownButton', 'disabled', 'enableTopLayer', 'icon', 'label', 'placement', 'splitIcon', 'variant'],
+  inputs: ['ariaLabelButton', 'ariaLabelSplitIconButton', 'closeBehavior', 'disableButton', 'disableDropdownButton', 'disabled', 'enableTopLayer', 'icon', 'label', 'splitIcon', 'variant'],
   outputs: ['buttonClick'],
 })
 export class IxSplitButton {

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -3660,11 +3660,6 @@ export namespace Components {
          */
         "label"?: string;
         /**
-          * Placement of the dropdown
-          * @default 'bottom-start'
-         */
-        "placement": AlignedPlacement;
-        /**
           * Icon of the button on the right
          */
         "splitIcon"?: string;
@@ -10183,11 +10178,6 @@ declare namespace LocalJSX {
          */
         "onButtonClick"?: (event: IxSplitButtonCustomEvent<MouseEvent>) => void;
         /**
-          * Placement of the dropdown
-          * @default 'bottom-start'
-         */
-        "placement"?: AlignedPlacement;
-        /**
           * Icon of the button on the right
          */
         "splitIcon"?: string;
@@ -11909,7 +11899,6 @@ declare namespace LocalJSX {
         "disabled": boolean;
         "disableButton": boolean;
         "disableDropdownButton": boolean;
-        "placement": AlignedPlacement;
         "enableTopLayer": boolean;
     }
     interface IxTabItemAttributes {

--- a/packages/core/src/components/split-button/split-button.tsx
+++ b/packages/core/src/components/split-button/split-button.tsx
@@ -20,7 +20,6 @@ import {
   Build,
 } from '@stencil/core';
 import { CloseBehavior } from '../dropdown/dropdown-controller';
-import { AlignedPlacement } from '../dropdown/placement';
 import {
   FocusProxy,
   PROXY_LIST_ID_SUFFIX,
@@ -102,11 +101,6 @@ export class SplitButton
    * @since 4.1.0
    */
   @Prop() disableDropdownButton = false;
-
-  /**
-   * Placement of the dropdown
-   */
-  @Prop() placement: AlignedPlacement = 'bottom-start';
 
   /**
    * Enable Popover API rendering for dropdown.

--- a/packages/react/src/components.server.ts
+++ b/packages/react/src/components.server.ts
@@ -1756,7 +1756,6 @@ export const IxSplitButton: StencilReactComponent<IxSplitButtonElement, IxSplitB
         disabled: 'disabled',
         disableButton: 'disable-button',
         disableDropdownButton: 'disable-dropdown-button',
-        placement: 'placement',
         enableTopLayer: 'enable-top-layer'
     },
     hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,

--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -1341,7 +1341,6 @@ export const IxSplitButton: StencilVueComponent<JSX.IxSplitButton> = /*@__PURE__
   'disabled',
   'disableButton',
   'disableDropdownButton',
-  'placement',
   'enableTopLayer',
   'buttonClick'
 ], [


### PR DESCRIPTION
JIRA issue: IX-4193
Docs PR: https://github.com/siemens/ix-docs/pull/227

## 💡 What is the current behavior?

Unused placement prop is defined for split-button component 

## 🆕 What is the new behavior?

Placement prop completely removed from the split-button component

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [x] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
