### PR TITLE
fix(dropdown): adapt description for top-layer default

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -1570,7 +1570,7 @@ export namespace Components {
         "discoverSubmenu": () => Promise<void>;
         /**
           * Enable Popover API rendering for top-layer positioning.
-          * @default false in v4.x, will default to true in v5.0.0
+          * @default false in v5.x, will default to true in v6.0.0
           * @since 4.3.0
          */
         "enableTopLayer": boolean;
@@ -8056,7 +8056,7 @@ declare namespace LocalJSX {
         "discoverAllSubmenus"?: boolean;
         /**
           * Enable Popover API rendering for top-layer positioning.
-          * @default false in v4.x, will default to true in v5.0.0
+          * @default false in v5.x, will default to true in v6.0.0
           * @since 4.3.0
          */
         "enableTopLayer"?: boolean;

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -143,7 +143,7 @@ export class Dropdown
   /**
    * Enable Popover API rendering for top-layer positioning.
    *
-   * @default false in v4.x, will default to true in v5.0.0
+   * @default false in v5.x, will default to true in v6.0.0
    * @since 4.3.0
    */
   @Prop() enableTopLayer: boolean = false;


### PR DESCRIPTION
## 💡 What is the current behavior?

top-layer positioning currently announces a new default for v5.0.0


## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

top-layer positioning new default announced for v6.0.0

We moved the default change to v6.0.0 because we want to roll out the top-layer behavior consistently across affected components, and doing that safely would take longer than the v5.0.0 release window allows.