### PR TITLE
fix(vue-test-app): fix about-and-legal preview example

### DIFF
--- a/packages/vue-test-app/src/preview-examples/about-and-legal.vue
+++ b/packages/vue-test-app/src/preview-examples/about-and-legal.vue
@@ -26,7 +26,7 @@ const setActiveTabKey = (event: CustomEvent<string | undefined>) => {
 };
 
 onMounted(() => {
-  input.value?.toggleAbout(true);
+  (input.value as any).$el?.toggleAbout(true);
 });
 </script>
 
@@ -36,7 +36,7 @@ onMounted(() => {
       <div className="placeholder-logo" slot="logo"></div>
     </IxApplicationHeader>
     <IxMenu ref="menu">
-      <IxMenuAbout>
+      <IxMenuAbout suppressLegacyTabs>
         <IxTabs :activeTabKey="activeTabKey" @tabChange="setActiveTabKey">
           <IxTabItem tabKey="tab-1">Tab 1</IxTabItem>
           <IxTabItem tabKey="tab-2">Tab 2</IxTabItem>

--- a/packages/vue-test-app/src/preview-examples/about-and-legal.vue
+++ b/packages/vue-test-app/src/preview-examples/about-and-legal.vue
@@ -18,7 +18,7 @@ import {
 } from '@siemens/ix-vue';
 import { onMounted, ref, useTemplateRef } from 'vue';
 
-const input = useTemplateRef<HTMLIxMenuElement>('menu');
+const input = useTemplateRef<InstanceType<typeof IxMenu>>('menu');
 const activeTabKey = ref('tab-1');
 
 const setActiveTabKey = (event: CustomEvent<string | undefined>) => {
@@ -26,7 +26,7 @@ const setActiveTabKey = (event: CustomEvent<string | undefined>) => {
 };
 
 onMounted(() => {
-  (input.value as any).$el?.toggleAbout(true);
+  input.value?.$el?.toggleAbout(true);
 });
 </script>
 
@@ -36,7 +36,7 @@ onMounted(() => {
       <div className="placeholder-logo" slot="logo"></div>
     </IxApplicationHeader>
     <IxMenu ref="menu">
-      <IxMenuAbout suppressLegacyTabs>
+      <IxMenuAbout>
         <IxTabs :activeTabKey="activeTabKey" @tabChange="setActiveTabKey">
           <IxTabItem tabKey="tab-1">Tab 1</IxTabItem>
           <IxTabItem tabKey="tab-2">Tab 2</IxTabItem>

--- a/packages/vue-test-app/src/preview-examples/about-and-legal.vue
+++ b/packages/vue-test-app/src/preview-examples/about-and-legal.vue
@@ -36,7 +36,7 @@ onMounted(() => {
       <div className="placeholder-logo" slot="logo"></div>
     </IxApplicationHeader>
     <IxMenu ref="menu">
-      <IxMenuAbout>
+      <IxMenuAbout suppressLegacyTabs>
         <IxTabs :activeTabKey="activeTabKey" @tabChange="setActiveTabKey">
           <IxTabItem tabKey="tab-1">Tab 1</IxTabItem>
           <IxTabItem tabKey="tab-2">Tab 2</IxTabItem>


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

1. The About & Legal panel didn't open automatically in the Vue-test-app preview example.
2. The horizontal line in the Vue test app's about and legal components is an unexpected display, unlike other framework examples.

Jira ticket: IX-4199

## 🆕 What is the new behavior?

The About & Legal panel opened automatically in the Vue-test-app preview example.
The horizontal line in the Vue test app's about and legal components is an expected display, similar to other framework examples.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [X] 🧐 Static code analysis passes (`pnpm lint`)
- [X] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
