### PR TITLE
fix(select): correct listbox screen reader selection and option role IX-4263

### DIFF
--- a/.changeset/ix-4263-select-screen-reader.md
+++ b/.changeset/ix-4263-select-screen-reader.md
@@ -1,0 +1,9 @@
+---
+'@siemens/ix': patch
+---
+
+**ix-select:** Screen reader output for the dropdown list now follows listbox semantics: the focus proxy exposes **aria-selected** from real selection state (and the add row from **checked**), no longer sets **aria-checked** on proxy options, and uses **value** as a fallback accessible name when **label** is absent.
+
+**ix-select-item:** Stops mapping keyboard focus visibility to **aria-selected** on the host so unselected options are not announced as selected.
+
+**ix-dropdown-item:** Adds **`itemRole`** (default **`menuitem`**) for the host **role**; select rows use **`option`**, matching listbox usage.

--- a/.changeset/ix-4263-select-screen-reader.md
+++ b/.changeset/ix-4263-select-screen-reader.md
@@ -9,3 +9,5 @@
 **ix-select-item:** With **`disableAriaSelectHandling`** enabled on the host, keyboard focus visibility is no longer mirrored to **aria-selected** on **`ix-select-item`**, so assistive technologies do not treat every focused row as selected. **`disableAriaSelectHandling`** is documented with **`@since 5.0.0`**.
 
 **ix-dropdown-item:** New **`itemRole`** prop (**`menuitem`** | **`option`**, default **`menuitem`**) sets the host **`role`**; **`ix-select-item`** passes **`option`** for listbox usage. Documented with **`@since 5.0.0`**. Generated React, Angular, and Vue bindings include **`itemRole`** / **`item-role`**.
+
+**ix-select (multiple mode):** Passes **`ariaLabelCloseIconButton`** on each **`ix-filter-chip`** (via **`i18n-remove-selected-item`**, default prefix **`Remove`**) so the close control is announced with the item label (e.g. “Remove Item 1”).

--- a/.changeset/ix-4263-select-screen-reader.md
+++ b/.changeset/ix-4263-select-screen-reader.md
@@ -1,9 +1,11 @@
 ---
-'@siemens/ix': patch
+'@siemens/ix': major
 ---
 
-**ix-select:** Screen reader output for the dropdown list now follows listbox semantics: the focus proxy exposes **aria-selected** from real selection state (and the add row from **checked**), no longer sets **aria-checked** on proxy options, and uses **value** as a fallback accessible name when **label** is absent.
+**Select listbox accessibility**
 
-**ix-select-item:** Stops mapping keyboard focus visibility to **aria-selected** on the host so unselected options are not announced as selected.
+**ix-select:** Screen reader output for the dropdown list follows listbox semantics: the focus proxy sets **aria-selected** from real selection state (and the add row from **checked**), no longer sets **aria-checked** on proxy options, and uses **value** as a fallback accessible name when **label** is absent.
 
-**ix-dropdown-item:** Adds **`itemRole`** (default **`menuitem`**) for the host **role**; select rows use **`option`**, matching listbox usage.
+**ix-select-item:** With **`disableAriaSelectHandling`** enabled on the host, keyboard focus visibility is no longer mirrored to **aria-selected** on **`ix-select-item`**, so assistive technologies do not treat every focused row as selected. **`disableAriaSelectHandling`** is documented with **`@since 5.0.0`**.
+
+**ix-dropdown-item:** New **`itemRole`** prop (**`menuitem`** | **`option`**, default **`menuitem`**) sets the host **`role`**; **`ix-select-item`** passes **`option`** for listbox usage. Documented with **`@since 5.0.0`**. Generated React, Angular, and Vue bindings include **`itemRole`** / **`item-role`**.

--- a/.changeset/ix-4263-select-screen-reader.md
+++ b/.changeset/ix-4263-select-screen-reader.md
@@ -6,8 +6,8 @@
 
 **ix-select:** Screen reader output for the dropdown list follows listbox semantics: the focus proxy sets **aria-selected** from real selection state (and the add row from **checked**), no longer sets **aria-checked** on proxy options, and uses **value** as a fallback accessible name when **label** is absent.
 
-**ix-select-item:** With **`disableAriaSelectHandling`** enabled on the host, keyboard focus visibility is no longer mirrored to **aria-selected** on **`ix-select-item`**, so assistive technologies do not treat every focused row as selected. **`disableAriaSelectHandling`** is documented with **`@since 5.0.0`**.
+**ix-select-item:** With **`disableAriaSelectHandling`** enabled on the host, keyboard focus visibility is no longer mirrored to **aria-selected** on **`ix-select-item`**, so assistive technologies do not treat every focused row as selected.
 
 **ix-dropdown-item:** New **`itemRole`** prop (**`menuitem`** | **`option`**, default **`menuitem`**) sets the host **`role`**; **`ix-select-item`** passes **`option`** for listbox usage. Documented with **`@since 5.0.0`**. Generated React, Angular, and Vue bindings include **`itemRole`** / **`item-role`**.
 
-**ix-select (multiple mode):** Passes **`ariaLabelCloseIconButton`** on each **`ix-filter-chip`** (via **`i18n-remove-selected-item`**, default prefix **`Remove`**) so the close control is announced with the item label (e.g. “Remove Item 1”).
+**ix-select (multiple mode):** Passes **`ariaLabelCloseIconButton`** on each **`ix-filter-chip`** (via **`i18n-remove-selected-item`**, default prefix **`Remove`**) so the close control is announced with the item label (e.g. “Remove Item 1”). Documented with **`@since 5.0.0`**.

--- a/packages/angular/src/components.ts
+++ b/packages/angular/src/components.ts
@@ -2415,7 +2415,7 @@ export declare interface IxRow extends Components.IxRow {}
 
 
 @ProxyCmp({
-  inputs: ['allowClear', 'ariaLabelAddItem', 'ariaLabelChevronDownIconButton', 'ariaLabelClearIconButton', 'collapseMultipleSelection', 'disabled', 'dropdownMaxWidth', 'dropdownWidth', 'editable', 'enableTopLayer', 'helperText', 'hideListHeader', 'i18nAllSelected', 'i18nNoMatches', 'i18nPlaceholder', 'i18nPlaceholderEditable', 'i18nSelectListHeader', 'infoText', 'invalidText', 'label', 'mode', 'name', 'readonly', 'required', 'showTextAsTooltip', 'validText', 'value', 'warningText'],
+  inputs: ['allowClear', 'ariaLabelAddItem', 'ariaLabelChevronDownIconButton', 'ariaLabelClearIconButton', 'collapseMultipleSelection', 'disabled', 'dropdownMaxWidth', 'dropdownWidth', 'editable', 'enableTopLayer', 'helperText', 'hideListHeader', 'i18nAllSelected', 'i18nNoMatches', 'i18nPlaceholder', 'i18nPlaceholderEditable', 'i18nRemoveSelectedItem', 'i18nSelectListHeader', 'infoText', 'invalidText', 'label', 'mode', 'name', 'readonly', 'required', 'showTextAsTooltip', 'validText', 'value', 'warningText'],
   methods: ['getNativeInputElement', 'focusInput']
 })
 @Component({
@@ -2423,7 +2423,7 @@ export declare interface IxRow extends Components.IxRow {}
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['allowClear', 'ariaLabelAddItem', 'ariaLabelChevronDownIconButton', 'ariaLabelClearIconButton', 'collapseMultipleSelection', 'disabled', 'dropdownMaxWidth', 'dropdownWidth', 'editable', 'enableTopLayer', 'helperText', 'hideListHeader', 'i18nAllSelected', 'i18nNoMatches', 'i18nPlaceholder', 'i18nPlaceholderEditable', 'i18nSelectListHeader', 'infoText', 'invalidText', 'label', 'mode', 'name', 'readonly', 'required', 'showTextAsTooltip', 'validText', 'value', 'warningText'],
+  inputs: ['allowClear', 'ariaLabelAddItem', 'ariaLabelChevronDownIconButton', 'ariaLabelClearIconButton', 'collapseMultipleSelection', 'disabled', 'dropdownMaxWidth', 'dropdownWidth', 'editable', 'enableTopLayer', 'helperText', 'hideListHeader', 'i18nAllSelected', 'i18nNoMatches', 'i18nPlaceholder', 'i18nPlaceholderEditable', 'i18nRemoveSelectedItem', 'i18nSelectListHeader', 'infoText', 'invalidText', 'label', 'mode', 'name', 'readonly', 'required', 'showTextAsTooltip', 'validText', 'value', 'warningText'],
   outputs: ['valueChange', 'inputChange', 'addItem', 'ixBlur'],
   standalone: false
 })

--- a/packages/angular/src/components.ts
+++ b/packages/angular/src/components.ts
@@ -979,14 +979,14 @@ export declare interface IxDropdownHeader extends Components.IxDropdownHeader {}
 
 
 @ProxyCmp({
-  inputs: ['ariaLabelButton', 'ariaLabelIcon', 'checked', 'disabled', 'hover', 'icon', 'label']
+  inputs: ['ariaLabelButton', 'ariaLabelIcon', 'checked', 'disabled', 'hover', 'icon', 'itemRole', 'label']
 })
 @Component({
   selector: 'ix-dropdown-item',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabelButton', 'ariaLabelIcon', 'checked', 'disabled', 'hover', 'icon', 'label'],
+  inputs: ['ariaLabelButton', 'ariaLabelIcon', 'checked', 'disabled', 'hover', 'icon', 'itemRole', 'label'],
   standalone: false
 })
 export class IxDropdownItem {

--- a/packages/angular/standalone/src/components.ts
+++ b/packages/angular/standalone/src/components.ts
@@ -2518,7 +2518,7 @@ export declare interface IxRow extends Components.IxRow {}
 
 @ProxyCmp({
   defineCustomElementFn: defineIxSelect,
-  inputs: ['allowClear', 'ariaLabelAddItem', 'ariaLabelChevronDownIconButton', 'ariaLabelClearIconButton', 'collapseMultipleSelection', 'disabled', 'dropdownMaxWidth', 'dropdownWidth', 'editable', 'enableTopLayer', 'helperText', 'hideListHeader', 'i18nAllSelected', 'i18nNoMatches', 'i18nPlaceholder', 'i18nPlaceholderEditable', 'i18nSelectListHeader', 'infoText', 'invalidText', 'label', 'mode', 'name', 'readonly', 'required', 'showTextAsTooltip', 'validText', 'value', 'warningText'],
+  inputs: ['allowClear', 'ariaLabelAddItem', 'ariaLabelChevronDownIconButton', 'ariaLabelClearIconButton', 'collapseMultipleSelection', 'disabled', 'dropdownMaxWidth', 'dropdownWidth', 'editable', 'enableTopLayer', 'helperText', 'hideListHeader', 'i18nAllSelected', 'i18nNoMatches', 'i18nPlaceholder', 'i18nPlaceholderEditable', 'i18nRemoveSelectedItem', 'i18nSelectListHeader', 'infoText', 'invalidText', 'label', 'mode', 'name', 'readonly', 'required', 'showTextAsTooltip', 'validText', 'value', 'warningText'],
   methods: ['getNativeInputElement', 'focusInput']
 })
 @Component({
@@ -2526,7 +2526,7 @@ export declare interface IxRow extends Components.IxRow {}
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['allowClear', 'ariaLabelAddItem', 'ariaLabelChevronDownIconButton', 'ariaLabelClearIconButton', 'collapseMultipleSelection', 'disabled', 'dropdownMaxWidth', 'dropdownWidth', 'editable', 'enableTopLayer', 'helperText', 'hideListHeader', 'i18nAllSelected', 'i18nNoMatches', 'i18nPlaceholder', 'i18nPlaceholderEditable', 'i18nSelectListHeader', 'infoText', 'invalidText', 'label', 'mode', 'name', 'readonly', 'required', 'showTextAsTooltip', 'validText', 'value', 'warningText'],
+  inputs: ['allowClear', 'ariaLabelAddItem', 'ariaLabelChevronDownIconButton', 'ariaLabelClearIconButton', 'collapseMultipleSelection', 'disabled', 'dropdownMaxWidth', 'dropdownWidth', 'editable', 'enableTopLayer', 'helperText', 'hideListHeader', 'i18nAllSelected', 'i18nNoMatches', 'i18nPlaceholder', 'i18nPlaceholderEditable', 'i18nRemoveSelectedItem', 'i18nSelectListHeader', 'infoText', 'invalidText', 'label', 'mode', 'name', 'readonly', 'required', 'showTextAsTooltip', 'validText', 'value', 'warningText'],
   outputs: ['valueChange', 'inputChange', 'addItem', 'ixBlur'],
 })
 export class IxSelect {

--- a/packages/angular/standalone/src/components.ts
+++ b/packages/angular/standalone/src/components.ts
@@ -1082,14 +1082,14 @@ export declare interface IxDropdownHeader extends Components.IxDropdownHeader {}
 
 @ProxyCmp({
   defineCustomElementFn: defineIxDropdownItem,
-  inputs: ['ariaLabelButton', 'ariaLabelIcon', 'checked', 'disabled', 'hover', 'icon', 'label']
+  inputs: ['ariaLabelButton', 'ariaLabelIcon', 'checked', 'disabled', 'hover', 'icon', 'itemRole', 'label']
 })
 @Component({
   selector: 'ix-dropdown-item',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabelButton', 'ariaLabelIcon', 'checked', 'disabled', 'hover', 'icon', 'label'],
+  inputs: ['ariaLabelButton', 'ariaLabelIcon', 'checked', 'disabled', 'hover', 'icon', 'itemRole', 'label'],
 })
 export class IxDropdownItem {
   protected el: HTMLIxDropdownItemElement;

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -1748,6 +1748,7 @@ export namespace Components {
          */
         "checked": boolean;
         /**
+          * When `true`, do not map keyboard focus visibility to `aria-selected` on the host. Use when selection state must not mirror roving focus (e.g. `ix-select-item`).
           * @default false
          */
         "disableAriaSelectHandling": boolean;
@@ -1775,6 +1776,11 @@ export namespace Components {
           * @default false
          */
         "isSubMenu": boolean;
+        /**
+          * Role of the host surface (`menuitem` or `option`). Use `option` when the item represents a listbox option (e.g. inside select).
+          * @default 'menuitem'
+         */
+        "itemRole": string;
         /**
           * @default false
          */
@@ -3560,6 +3566,7 @@ export namespace Components {
     }
     interface IxSelectItem {
         /**
+          * When `true`, do not map keyboard focus visibility to `aria-selected` on the host. Use when selection state must not mirror roving focus (e.g. `ix-select-item`).
           * @default false
          */
         "disableAriaSelectHandling": boolean;
@@ -8281,6 +8288,7 @@ declare namespace LocalJSX {
          */
         "checked"?: boolean;
         /**
+          * When `true`, do not map keyboard focus visibility to `aria-selected` on the host. Use when selection state must not mirror roving focus (e.g. `ix-select-item`).
           * @default false
          */
         "disableAriaSelectHandling"?: boolean;
@@ -8306,6 +8314,11 @@ declare namespace LocalJSX {
           * @default false
          */
         "isSubMenu"?: boolean;
+        /**
+          * Role of the host surface (`menuitem` or `option`). Use `option` when the item represents a listbox option (e.g. inside select).
+          * @default 'menuitem'
+         */
+        "itemRole"?: string;
         /**
           * @default false
          */
@@ -10233,6 +10246,7 @@ declare namespace LocalJSX {
     }
     interface IxSelectItem {
         /**
+          * When `true`, do not map keyboard focus visibility to `aria-selected` on the host. Use when selection state must not mirror roving focus (e.g. `ix-select-item`).
           * @default false
          */
         "disableAriaSelectHandling"?: boolean;
@@ -11757,6 +11771,7 @@ declare namespace LocalJSX {
         "hover": boolean;
         "disabled": boolean;
         "checked": boolean;
+        "itemRole": string;
         "isSubMenu": boolean;
         "suppressChecked": boolean;
         "hasVisualFocus": boolean;

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -35,7 +35,7 @@ import { CloseBehavior } from "./components/dropdown/dropdown-controller";
 import { AlignedPlacement, Side } from "./components/dropdown/placement";
 import { FocusTrapOptions } from "./components/utils/focus/focus-trap";
 import { DropdownButtonVariant } from "./components/dropdown-button/dropdown-button.types";
-import { IxDropdownItemRole } from "./components/dropdown-item/dropdown-item";
+import { IxDropdownItemRole } from "./components/dropdown-item/dropdown-item.types";
 import { EmptyStateLayout } from "./components/empty-state/empty-state.types";
 import { MakeRef } from "./components/utils/make-ref";
 import { FlipTileVariant } from "./components/flip-tile/flip-tile.types";
@@ -90,7 +90,7 @@ export { CloseBehavior } from "./components/dropdown/dropdown-controller";
 export { AlignedPlacement, Side } from "./components/dropdown/placement";
 export { FocusTrapOptions } from "./components/utils/focus/focus-trap";
 export { DropdownButtonVariant } from "./components/dropdown-button/dropdown-button.types";
-export { IxDropdownItemRole } from "./components/dropdown-item/dropdown-item";
+export { IxDropdownItemRole } from "./components/dropdown-item/dropdown-item.types";
 export { EmptyStateLayout } from "./components/empty-state/empty-state.types";
 export { MakeRef } from "./components/utils/make-ref";
 export { FlipTileVariant } from "./components/flip-tile/flip-tile.types";
@@ -1746,7 +1746,6 @@ export namespace Components {
         "checked": boolean;
         /**
           * When `true`, do not map keyboard focus visibility to `aria-selected` on the host. Use when selection state must not mirror roving focus (e.g. `ix-select-item`).
-          * @since 5.0.0
           * @default false
          */
         "disableAriaSelectHandling": boolean;
@@ -3507,6 +3506,7 @@ export namespace Components {
         "i18nPlaceholderEditable": string;
         /**
           * Prefix for the accessible name of the close control on a selected chip in multiple mode. The chip label or value is appended (e.g. "Remove Item 1").
+          * @since 5.0.0
           * @default 'Remove'
          */
         "i18nRemoveSelectedItem": string;
@@ -3571,7 +3571,6 @@ export namespace Components {
     interface IxSelectItem {
         /**
           * When `true`, do not map keyboard focus visibility to `aria-selected` on the host. Use when selection state must not mirror roving focus (e.g. `ix-select-item`).
-          * @since 5.0.0
           * @default false
          */
         "disableAriaSelectHandling": boolean;
@@ -8287,7 +8286,6 @@ declare namespace LocalJSX {
         "checked"?: boolean;
         /**
           * When `true`, do not map keyboard focus visibility to `aria-selected` on the host. Use when selection state must not mirror roving focus (e.g. `ix-select-item`).
-          * @since 5.0.0
           * @default false
          */
         "disableAriaSelectHandling"?: boolean;
@@ -10176,6 +10174,7 @@ declare namespace LocalJSX {
         "i18nPlaceholderEditable"?: string;
         /**
           * Prefix for the accessible name of the close control on a selected chip in multiple mode. The chip label or value is appended (e.g. "Remove Item 1").
+          * @since 5.0.0
           * @default 'Remove'
          */
         "i18nRemoveSelectedItem"?: string;
@@ -10252,7 +10251,6 @@ declare namespace LocalJSX {
     interface IxSelectItem {
         /**
           * When `true`, do not map keyboard focus visibility to `aria-selected` on the host. Use when selection state must not mirror roving focus (e.g. `ix-select-item`).
-          * @since 5.0.0
           * @default false
          */
         "disableAriaSelectHandling"?: boolean;

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -3506,6 +3506,11 @@ export namespace Components {
          */
         "i18nPlaceholderEditable": string;
         /**
+          * Prefix for the accessible name of the close control on a selected chip in multiple mode. The chip label or value is appended (e.g. "Remove Item 1").
+          * @default 'Remove'
+         */
+        "i18nRemoveSelectedItem": string;
+        /**
           * Select list header
           * @default 'Select an option'
          */
@@ -10170,6 +10175,11 @@ declare namespace LocalJSX {
          */
         "i18nPlaceholderEditable"?: string;
         /**
+          * Prefix for the accessible name of the close control on a selected chip in multiple mode. The chip label or value is appended (e.g. "Remove Item 1").
+          * @default 'Remove'
+         */
+        "i18nRemoveSelectedItem"?: string;
+        /**
           * Select list header
           * @default 'Select an option'
          */
@@ -12192,6 +12202,7 @@ declare namespace LocalJSX {
         "i18nSelectListHeader": string;
         "i18nNoMatches": string;
         "i18nAllSelected": string;
+        "i18nRemoveSelectedItem": string;
         "hideListHeader": boolean;
         "dropdownWidth": string;
         "dropdownMaxWidth": string;

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -35,6 +35,7 @@ import { CloseBehavior } from "./components/dropdown/dropdown-controller";
 import { AlignedPlacement, Side } from "./components/dropdown/placement";
 import { FocusTrapOptions } from "./components/utils/focus/focus-trap";
 import { DropdownButtonVariant } from "./components/dropdown-button/dropdown-button.types";
+import { IxDropdownItemRole } from "./components/dropdown-item/dropdown-item";
 import { EmptyStateLayout } from "./components/empty-state/empty-state.types";
 import { MakeRef } from "./components/utils/make-ref";
 import { FlipTileVariant } from "./components/flip-tile/flip-tile.types";
@@ -89,6 +90,7 @@ export { CloseBehavior } from "./components/dropdown/dropdown-controller";
 export { AlignedPlacement, Side } from "./components/dropdown/placement";
 export { FocusTrapOptions } from "./components/utils/focus/focus-trap";
 export { DropdownButtonVariant } from "./components/dropdown-button/dropdown-button.types";
+export { IxDropdownItemRole } from "./components/dropdown-item/dropdown-item";
 export { EmptyStateLayout } from "./components/empty-state/empty-state.types";
 export { MakeRef } from "./components/utils/make-ref";
 export { FlipTileVariant } from "./components/flip-tile/flip-tile.types";
@@ -1744,6 +1746,7 @@ export namespace Components {
         "checked": boolean;
         /**
           * When `true`, do not map keyboard focus visibility to `aria-selected` on the host. Use when selection state must not mirror roving focus (e.g. `ix-select-item`).
+          * @since 5.0.0
           * @default false
          */
         "disableAriaSelectHandling": boolean;
@@ -1772,10 +1775,11 @@ export namespace Components {
          */
         "isSubMenu": boolean;
         /**
-          * Role of the host surface (`menuitem` or `option`). Use `option` when the item represents a listbox option (e.g. inside select).
+          * Role of the host surface. Use `option` when the item represents a listbox option (e.g. inside select); use `menuitem` in menus.
+          * @since 5.0.0
           * @default 'menuitem'
          */
-        "itemRole": string;
+        "itemRole": IxDropdownItemRole;
         /**
           * @default false
          */
@@ -3562,6 +3566,7 @@ export namespace Components {
     interface IxSelectItem {
         /**
           * When `true`, do not map keyboard focus visibility to `aria-selected` on the host. Use when selection state must not mirror roving focus (e.g. `ix-select-item`).
+          * @since 5.0.0
           * @default false
          */
         "disableAriaSelectHandling": boolean;
@@ -8277,6 +8282,7 @@ declare namespace LocalJSX {
         "checked"?: boolean;
         /**
           * When `true`, do not map keyboard focus visibility to `aria-selected` on the host. Use when selection state must not mirror roving focus (e.g. `ix-select-item`).
+          * @since 5.0.0
           * @default false
          */
         "disableAriaSelectHandling"?: boolean;
@@ -8303,10 +8309,11 @@ declare namespace LocalJSX {
          */
         "isSubMenu"?: boolean;
         /**
-          * Role of the host surface (`menuitem` or `option`). Use `option` when the item represents a listbox option (e.g. inside select).
+          * Role of the host surface. Use `option` when the item represents a listbox option (e.g. inside select); use `menuitem` in menus.
+          * @since 5.0.0
           * @default 'menuitem'
          */
-        "itemRole"?: string;
+        "itemRole"?: IxDropdownItemRole;
         /**
           * @default false
          */
@@ -10235,6 +10242,7 @@ declare namespace LocalJSX {
     interface IxSelectItem {
         /**
           * When `true`, do not map keyboard focus visibility to `aria-selected` on the host. Use when selection state must not mirror roving focus (e.g. `ix-select-item`).
+          * @since 5.0.0
           * @default false
          */
         "disableAriaSelectHandling"?: boolean;
@@ -11752,7 +11760,7 @@ declare namespace LocalJSX {
         "hover": boolean;
         "disabled": boolean;
         "checked": boolean;
-        "itemRole": string;
+        "itemRole": IxDropdownItemRole;
         "isSubMenu": boolean;
         "suppressChecked": boolean;
         "hasVisualFocus": boolean;

--- a/packages/core/src/components/dropdown-item/dropdown-item.tsx
+++ b/packages/core/src/components/dropdown-item/dropdown-item.tsx
@@ -32,6 +32,8 @@ import {
 } from '../utils/internal/mixins/id.mixin';
 import { FocusVisibleMixin } from '../utils/internal/mixins/focus-visible.mixin';
 
+export type IxDropdownItemRole = 'menuitem' | 'option';
+
 @Component({
   tag: 'ix-dropdown-item',
   styleUrl: 'dropdown-item.scss',
@@ -84,10 +86,12 @@ export class DropdownItem
   @Prop({ reflect: true }) checked = false;
 
   /**
-   * Role of the host surface (`menuitem` or `option`).
-   * Use `option` when the item represents a listbox option (e.g. inside select).
+   * Role of the host surface.
+   * Use `option` when the item represents a listbox option (e.g. inside select); use `menuitem` in menus.
+   *
+   * @since 5.0.0
    */
-  @Prop() itemRole: string = 'menuitem';
+  @Prop() itemRole: IxDropdownItemRole = 'menuitem';
 
   /** @internal */
   @Prop() isSubMenu = false;

--- a/packages/core/src/components/dropdown-item/dropdown-item.tsx
+++ b/packages/core/src/components/dropdown-item/dropdown-item.tsx
@@ -31,8 +31,7 @@ import {
   ComponentIdMixinContract,
 } from '../utils/internal/mixins/id.mixin';
 import { FocusVisibleMixin } from '../utils/internal/mixins/focus-visible.mixin';
-
-export type IxDropdownItemRole = 'menuitem' | 'option';
+import type { IxDropdownItemRole } from './dropdown-item.types';
 
 @Component({
   tag: 'ix-dropdown-item',

--- a/packages/core/src/components/dropdown-item/dropdown-item.tsx
+++ b/packages/core/src/components/dropdown-item/dropdown-item.tsx
@@ -83,6 +83,12 @@ export class DropdownItem
    */
   @Prop({ reflect: true }) checked = false;
 
+  /**
+   * Role of the host surface (`menuitem` or `option`).
+   * Use `option` when the item represents a listbox option (e.g. inside select).
+   */
+  @Prop() itemRole: string = 'menuitem';
+
   /** @internal */
   @Prop() isSubMenu = false;
 
@@ -130,7 +136,7 @@ export class DropdownItem
     return (
       <Host
         id={id}
-        role={'menuitem'}
+        role={this.itemRole}
         aria-disabled={a11yBoolean(this.disabled)}
         aria-label={this.hostElement.ariaLabel ?? this.ariaLabelButton}
         class={{

--- a/packages/core/src/components/dropdown-item/dropdown-item.types.ts
+++ b/packages/core/src/components/dropdown-item/dropdown-item.types.ts
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export type IxDropdownItemRole = 'menuitem' | 'option';

--- a/packages/core/src/components/select-item/select-item.tsx
+++ b/packages/core/src/components/select-item/select-item.tsx
@@ -15,24 +15,24 @@ import {
   h,
   Host,
   Method,
+  Mixin,
   Prop,
   Watch,
-  Mixin,
 } from '@stencil/core';
 import { DropdownItemWrapper } from '../dropdown/dropdown-controller';
+import { A11yAttributes, a11yHostAttributes } from '../utils/a11y';
 import {
   IX_FOCUS_VISIBLE,
   IX_FOCUS_VISIBLE_ACTIVE,
 } from '../utils/focus/focus-utilities';
+import { DefaultMixins } from '../utils/internal/component';
 import { FocusVisibleMixin } from '../utils/internal/mixins/focus-visible.mixin';
+import { ComponentIdMixin } from '../utils/internal/mixins/id.mixin';
 import { makeRef } from '../utils/make-ref';
 import {
   IxSelectItemLabelChangeEvent,
   IxSelectItemValueChangeEvent,
 } from './events';
-import { DefaultMixins } from '../utils/internal/component';
-import { ComponentIdMixin } from '../utils/internal/mixins/id.mixin';
-import { A11yAttributes, a11yHostAttributes } from '../utils/a11y';
 
 @Component({
   tag: 'ix-select-item',
@@ -127,6 +127,7 @@ export class SelectItem
       <Host
         {...ariaAttributes}
         id={this.getHostElementId()}
+        disableAriaSelectHandling={true}
         class={{
           [IX_FOCUS_VISIBLE]: true,
         }}
@@ -135,7 +136,7 @@ export class SelectItem
       >
         <ix-dropdown-item
           aria-hidden="true"
-          role="option"
+          itemRole="option"
           class={{
             'select-item-checked': this.selected,
             [IX_FOCUS_VISIBLE_ACTIVE]: this.ixFocusVisible,

--- a/packages/core/src/components/select/select.tsx
+++ b/packages/core/src/components/select/select.tsx
@@ -209,6 +209,13 @@ export class Select
   @Prop({ attribute: 'i18n-all-selected' }) i18nAllSelected = 'All';
 
   /**
+   * Prefix for the accessible name of the close control on a selected chip in multiple mode.
+   * The chip label or value is appended (e.g. "Remove Item 1").
+   */
+  @Prop({ attribute: 'i18n-remove-selected-item' }) i18nRemoveSelectedItem =
+    'Remove';
+
+  /**
    * Hide list header
    */
   @Prop() hideListHeader = false;
@@ -706,11 +713,19 @@ export class Select
     );
   }
 
+  private getRemoveChipAriaLabel(item: HTMLIxSelectItemElement): string {
+    const name = (item.label ?? item.value)?.toString().trim();
+    if (!name) {
+      return this.i18nRemoveSelectedItem;
+    }
+    return `${this.i18nRemoveSelectedItem} ${name}`;
+  }
+
   private renderAllChip() {
     return (
       <ix-filter-chip
         disabled={this.disabled || this.readonly}
-        ariaLabelCloseIconButton={this.i18nAllSelected}
+        ariaLabelCloseIconButton={`${this.i18nRemoveSelectedItem} ${this.i18nAllSelected}`}
         onCloseClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
@@ -727,6 +742,7 @@ export class Select
       <ix-filter-chip
         disabled={this.disabled || this.readonly}
         key={item.value}
+        ariaLabelCloseIconButton={this.getRemoveChipAriaLabel(item)}
         onCloseClick={() => {
           this.itemClick(item.value);
           this.inputElement?.focus();

--- a/packages/core/src/components/select/select.tsx
+++ b/packages/core/src/components/select/select.tsx
@@ -211,6 +211,8 @@ export class Select
   /**
    * Prefix for the accessible name of the close control on a selected chip in multiple mode.
    * The chip label or value is appended (e.g. "Remove Item 1").
+   *
+   * @since 5.0.0
    */
   @Prop({ attribute: 'i18n-remove-selected-item' }) i18nRemoveSelectedItem =
     'Remove';
@@ -841,19 +843,19 @@ export class Select
       ariaActiveDescendantHelper!,
       this.focusableItems,
       (item, proxyElement) => {
-        proxyElement.role = 'option';
-        proxyElement.innerText = item.label ?? '';
-        proxyElement.ariaLabel =
+        const isSelectItem = item.tagName === 'IX-SELECT-ITEM';
+        const ariaLabel =
           item.getAttribute('aria-label') ||
           item.label ||
-          (item.tagName === 'IX-SELECT-ITEM'
-            ? (item as HTMLIxSelectItemElement).value
-            : '') ||
+          (isSelectItem ? (item as HTMLIxSelectItemElement).value : '') ||
           '';
-        const selected =
-          item.tagName === 'IX-SELECT-ITEM'
-            ? (item as HTMLIxSelectItemElement).selected
-            : (item as HTMLIxDropdownItemElement).checked;
+        const selected = isSelectItem
+          ? (item as HTMLIxSelectItemElement).selected
+          : (item as HTMLIxDropdownItemElement).checked;
+
+        proxyElement.role = 'option';
+        proxyElement.innerText = item.label ?? '';
+        proxyElement.ariaLabel = ariaLabel;
         proxyElement.ariaSelected = a11yBoolean(!!selected);
         // Forward clicks from the proxy element to the actual dropdown item
         proxyElement.addEventListener('click', (event) => {

--- a/packages/core/src/components/select/select.tsx
+++ b/packages/core/src/components/select/select.tsx
@@ -31,6 +31,12 @@ import {
 import { IxSelectItemLabelChangeEvent } from '../select-item/events';
 import { a11yBoolean } from '../utils/a11y';
 import {
+  FocusProxy,
+  PROXY_LIST_ID_SUFFIX,
+  PROXY_LISTITEM_ID_SUFFIX,
+  updateFocusProxyList,
+} from '../utils/focus/focus-proxy';
+import {
   IX_FOCUS_VISIBLE_ACTIVE,
   queryElements,
 } from '../utils/focus/focus-utilities';
@@ -39,23 +45,17 @@ import {
   IxInputFieldComponent,
   ValidationResults,
 } from '../utils/input';
-import { makeRef } from '../utils/make-ref';
-import { requestAnimationFrameNoNgZone } from '../utils/requestAnimationFrame';
 import { DefaultMixins } from '../utils/internal/component';
 import {
-  AriaActiveDescendantMixinContract,
   AriaActiveDescendantMixin,
+  AriaActiveDescendantMixinContract,
 } from '../utils/internal/mixins/accessibility/aria-activedescendant.mixin';
 import {
   ComponentIdMixin,
   ComponentIdMixinContract,
 } from '../utils/internal/mixins/id.mixin';
-import {
-  FocusProxy,
-  PROXY_LIST_ID_SUFFIX,
-  PROXY_LISTITEM_ID_SUFFIX,
-  updateFocusProxyList,
-} from '../utils/focus/focus-proxy';
+import { makeRef } from '../utils/make-ref';
+import { requestAnimationFrameNoNgZone } from '../utils/requestAnimationFrame';
 
 let selectId = 0;
 
@@ -828,10 +828,17 @@ export class Select
         proxyElement.role = 'option';
         proxyElement.innerText = item.label ?? '';
         proxyElement.ariaLabel =
-          item.getAttribute('aria-label') || item.label || '';
-        proxyElement.ariaSelected =
-          item.getAttribute('aria-selected') || 'false';
-        proxyElement.ariaChecked = item.getAttribute('aria-checked') || 'false';
+          item.getAttribute('aria-label') ||
+          item.label ||
+          (item.tagName === 'IX-SELECT-ITEM'
+            ? (item as HTMLIxSelectItemElement).value
+            : '') ||
+          '';
+        const selected =
+          item.tagName === 'IX-SELECT-ITEM'
+            ? (item as HTMLIxSelectItemElement).selected
+            : (item as HTMLIxDropdownItemElement).checked;
+        proxyElement.ariaSelected = a11yBoolean(!!selected);
         // Forward clicks from the proxy element to the actual dropdown item
         proxyElement.addEventListener('click', (event) => {
           event.stopPropagation();

--- a/packages/core/src/components/select/test/select.ct.ts
+++ b/packages/core/src/components/select/test/select.ct.ts
@@ -1214,3 +1214,55 @@ test('input does not clear when items added during search', async ({
     page.getByRole('option', { name: 'Test Result from API' })
   ).toBeVisible();
 });
+
+test('listbox proxy: aria-selected reflects value, not keyboard focus alone', async ({
+  mount,
+  page,
+}) => {
+  await mount(`
+    <ix-select>
+      <ix-select-item value="1" label="Item 1"></ix-select-item>
+      <ix-select-item value="2" label="Item 2"></ix-select-item>
+    </ix-select>
+  `);
+
+  const ctrl = selectController(page.locator('ix-select'));
+  await ctrl.focusInput();
+  await ctrl.arrowDown();
+  await ctrl.arrowDown();
+
+  await expect(page.getByRole('option', { name: 'Item 1' })).toHaveAttribute(
+    'aria-selected',
+    'false'
+  );
+  await expect(page.getByRole('option', { name: 'Item 2' })).toHaveAttribute(
+    'aria-selected',
+    'false'
+  );
+});
+
+test('listbox proxy: selected value stays aria-selected when another row has focus', async ({
+  mount,
+  page,
+}) => {
+  await mount(`
+    <ix-select value="1">
+      <ix-select-item value="1" label="Item 1"></ix-select-item>
+      <ix-select-item value="2" label="Item 2"></ix-select-item>
+    </ix-select>
+  `);
+
+  const ctrl = selectController(page.locator('ix-select'));
+  await ctrl.focusInput();
+  await ctrl.arrowDown();
+  await ctrl.arrowDown();
+
+  await expect(page.getByRole('option', { name: 'Item 1' })).toHaveAttribute(
+    'aria-selected',
+    'true'
+  );
+  await expect(page.getByRole('option', { name: 'Item 2' })).toHaveAttribute(
+    'aria-selected',
+    'false'
+  );
+});

--- a/packages/core/src/components/select/test/select.ct.ts
+++ b/packages/core/src/components/select/test/select.ct.ts
@@ -1241,6 +1241,33 @@ test('listbox proxy: aria-selected reflects value, not keyboard focus alone', as
   );
 });
 
+test('multiple mode: chip close button accessible name includes item label', async ({
+  mount,
+  page,
+}) => {
+  await mount(`
+    <ix-select mode="multiple">
+      <ix-select-item value="1" label="Item 1"></ix-select-item>
+      <ix-select-item value="2" label="Item 2"></ix-select-item>
+    </ix-select>
+  `);
+
+  const select = page.locator('ix-select');
+  await select.evaluate((el: HTMLIxSelectElement) => {
+    el.value = ['1', '2'];
+  });
+
+  const chips = select.locator('ix-filter-chip');
+  await expect(chips).toHaveCount(2);
+
+  await expect(
+    chips.filter({ hasText: 'Item 1' }).locator('ix-icon-button')
+  ).toHaveAttribute('aria-label', 'Remove Item 1');
+  await expect(
+    chips.filter({ hasText: 'Item 2' }).locator('ix-icon-button')
+  ).toHaveAttribute('aria-label', 'Remove Item 2');
+});
+
 test('listbox proxy: selected value stays aria-selected when another row has focus', async ({
   mount,
   page,

--- a/packages/core/src/components/select/test/select.ct.ts
+++ b/packages/core/src/components/select/test/select.ct.ts
@@ -1261,10 +1261,10 @@ test('multiple mode: chip close button accessible name includes item label', asy
   await expect(chips).toHaveCount(2);
 
   await expect(
-    chips.filter({ hasText: 'Item 1' }).locator('ix-icon-button')
+    chips.filter({ hasText: 'Item 1' }).locator('ix-icon-button button')
   ).toHaveAttribute('aria-label', 'Remove Item 1');
   await expect(
-    chips.filter({ hasText: 'Item 2' }).locator('ix-icon-button')
+    chips.filter({ hasText: 'Item 2' }).locator('ix-icon-button button')
   ).toHaveAttribute('aria-label', 'Remove Item 2');
 });
 

--- a/packages/core/src/components/utils/internal/mixins/focus-visible.mixin.ts
+++ b/packages/core/src/components/utils/internal/mixins/focus-visible.mixin.ts
@@ -32,6 +32,7 @@ export const FocusVisibleMixin = <B extends MixedInCtor<StencilLifecycle>>(
      * Use when selection state must not mirror roving focus (e.g. `ix-select-item`).
      *
      * @internal
+     * @since 5.0.0
      */
     @Prop() disableAriaSelectHandling: boolean = false;
 

--- a/packages/core/src/components/utils/internal/mixins/focus-visible.mixin.ts
+++ b/packages/core/src/components/utils/internal/mixins/focus-visible.mixin.ts
@@ -32,7 +32,6 @@ export const FocusVisibleMixin = <B extends MixedInCtor<StencilLifecycle>>(
      * Use when selection state must not mirror roving focus (e.g. `ix-select-item`).
      *
      * @internal
-     * @since 5.0.0
      */
     @Prop() disableAriaSelectHandling: boolean = false;
 

--- a/packages/core/src/components/utils/internal/mixins/focus-visible.mixin.ts
+++ b/packages/core/src/components/utils/internal/mixins/focus-visible.mixin.ts
@@ -28,6 +28,9 @@ export const FocusVisibleMixin = <B extends MixedInCtor<StencilLifecycle>>(
     @Prop({ reflect: true }) ixFocusVisible = false;
 
     /**
+     * When `true`, do not map keyboard focus visibility to `aria-selected` on the host.
+     * Use when selection state must not mirror roving focus (e.g. `ix-select-item`).
+     *
      * @internal
      */
     @Prop() disableAriaSelectHandling: boolean = false;
@@ -45,6 +48,11 @@ export const FocusVisibleMixin = <B extends MixedInCtor<StencilLifecycle>>(
     @Watch('ixFocusVisible')
     $internal_checkAriaSelected(focusVisible: boolean) {
       if (!this.hostElement) {
+        return;
+      }
+
+      if (this.disableAriaSelectHandling) {
+        this.hostElement.removeAttribute('aria-selected');
         return;
       }
 

--- a/packages/core/src/public-api.ts
+++ b/packages/core/src/public-api.ts
@@ -18,6 +18,7 @@ export * from './components/tree-item/default-tree-item';
 export * from './components/tree/tree-model';
 export * from './components/tree/tree.types';
 export * from './components/breadcrumb/breadcrumb.types';
+export type { IxDropdownItemRole } from './components/dropdown-item/dropdown-item.types';
 export * from './components/upload/upload-file-state';
 export * from './components/utils/delegate';
 export { ElementReference } from './components/utils/element-reference';

--- a/packages/react/src/components.server.ts
+++ b/packages/react/src/components.server.ts
@@ -1692,6 +1692,7 @@ export const IxSelect: StencilReactComponent<IxSelectElement, IxSelectEvents, Co
         i18nSelectListHeader: 'i18n-select-list-header',
         i18nNoMatches: 'i18n-no-matches',
         i18nAllSelected: 'i18n-all-selected',
+        i18nRemoveSelectedItem: 'i18n-remove-selected-item',
         hideListHeader: 'hide-list-header',
         dropdownWidth: 'dropdown-width',
         dropdownMaxWidth: 'dropdown-max-width',

--- a/packages/react/src/components.server.ts
+++ b/packages/react/src/components.server.ts
@@ -796,6 +796,7 @@ export const IxDropdownItem: StencilReactComponent<IxDropdownItemElement, IxDrop
         hover: 'hover',
         disabled: 'disabled',
         checked: 'checked',
+        itemRole: 'item-role',
         isSubMenu: 'is-sub-menu',
         suppressChecked: 'suppress-checked',
         hasVisualFocus: 'has-visual-focus'

--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -647,6 +647,7 @@ export const IxDropdownItem: StencilVueComponent<JSX.IxDropdownItem> = /*@__PURE
   'hover',
   'disabled',
   'checked',
+  'itemRole',
   'isSubMenu',
   'suppressChecked',
   'hasVisualFocus',

--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -1282,6 +1282,7 @@ export const IxSelect: StencilVueComponent<JSX.IxSelect, JSX.IxSelect["value"]> 
   'i18nSelectListHeader',
   'i18nNoMatches',
   'i18nAllSelected',
+  'i18nRemoveSelectedItem',
   'hideListHeader',
   'dropdownWidth',
   'dropdownMaxWidth',

--- a/testing/visual-testing/tests/menu-settings/menu-settings.e2e.ts
+++ b/testing/visual-testing/tests/menu-settings/menu-settings.e2e.ts
@@ -7,19 +7,26 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { expect } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import { regressionTest } from '@utils/test';
 
 regressionTest.describe('menu-settings', () => {
+  const openSettings = async (page: Page) => {
+    const settingsMenuItem = page.locator('ix-menu-item#settings');
+    await settingsMenuItem.click();
+    await expect(page.locator('ix-menu-settings')).toHaveClass(/show/);
+    return settingsMenuItem;
+  };
+
   regressionTest('basic', async ({ page }) => {
     await page.goto('menu-settings/basic');
-    const settings = page.locator('ix-menu-item#settings');
-    await settings.click();
-    await page.waitForTimeout(500);
+    const settingsMenuItem = await openSettings(page);
 
     // Click is needed otherwise tab item is still hovered.
     await page.getByRole('heading', { name: 'Settings' }).click();
-    await expect(settings.locator('ix-tooltip')).not.toHaveClass(/visible/);
+    await expect(settingsMenuItem.locator('ix-tooltip')).not.toHaveClass(
+      /visible/
+    );
 
     await expect(page).toHaveScreenshot({
       animations: 'disabled',
@@ -28,12 +35,14 @@ regressionTest.describe('menu-settings', () => {
 
   regressionTest('label', async ({ page }) => {
     await page.goto('menu-settings/basic');
-    const settings = page.locator('ix-menu-item#settings');
-    await settings.click();
-    await page.waitForTimeout(500);
+    const settingsMenuItem = await openSettings(page);
 
-    await page.getByText('First Content').click();
-    await expect(settings.locator('ix-tooltip')).not.toHaveClass(/visible/);
+    const firstContentButton = page.locator('#changeLabelButton');
+    await expect(firstContentButton).toBeVisible();
+    await firstContentButton.click();
+    await expect(settingsMenuItem.locator('ix-tooltip')).not.toHaveClass(
+      /visible/
+    );
 
     await expect(page).toHaveScreenshot({
       animations: 'disabled',
@@ -42,14 +51,19 @@ regressionTest.describe('menu-settings', () => {
 
   regressionTest('switch', async ({ page }) => {
     await page.goto('menu-settings/basic');
-    const settings = page.locator('ix-menu-item#settings');
-    await settings.click();
-    await page.waitForTimeout(500);
+    const settingsMenuItem = await openSettings(page);
 
-    await page.getByText('First Content').click();
-    await page.getByText('Changed Label').click();
+    const firstContentButton = page.locator('#changeLabelButton');
+    await expect(firstContentButton).toBeVisible();
+    await firstContentButton.click();
 
-    await expect(settings.locator('ix-tooltip')).not.toHaveClass(/visible/);
+    const changedLabelTab = page.getByRole('tab', { name: 'Changed Label' });
+    await expect(changedLabelTab).toBeVisible();
+    await changedLabelTab.click();
+
+    await expect(settingsMenuItem.locator('ix-tooltip')).not.toHaveClass(
+      /visible/
+    );
 
     await expect(page).toHaveScreenshot({
       animations: 'disabled',


### PR DESCRIPTION
## 💡 What is the current behavior?

- **`ix-select`** exposes list semantics to assistive technologies via a **focus proxy** (`role="listbox"` / `role="option"`) and **`aria-activedescendant`** on the combobox input. **`FocusVisibleMixin`** was writing **`aria-selected="true"`** on **`ix-select-item`** whenever the row had keyboard focus visibility, and the proxy copied that attribute. Screen readers therefore announced **every focused option as “selected”**, even when it was not part of **`value`** (Firefox / Safari). 

## 🆕 What is the new behavior?

- **`FocusVisibleMixin`** respects **`disableAriaSelectHandling`**: when **`true`**, the host **`aria-selected`** attribute is **removed** instead of mirroring **`ixFocusVisible`**. **`ix-select-item`** sets **`disableAriaSelectHandling={true}`** on its host so roving focus no longer implies selection.
- **`ix-select`** proxy options set **`aria-selected`** from **real state** (**`item.selected`** on **`ix-select-item`**, **`checked`** on the editable add row). **`aria-checked`** is no longer set on proxy options. Proxy **`aria-label`** falls back to **`value`** when **`label`** is missing (after author **`aria-label`** / **`label`**).
- **`ix-dropdown-item`** adds **`itemRole`** (default **`menuitem`**); **`ix-select-item`** passes **`itemRole="option"`** so the row surface matches listbox usage. Stencil output regenerates **Angular / React / Vue** bindings and **`components.d.ts`**.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings — *N/A*
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully — *N/A*
- [ ] 📕 Add or update a Storybook story — *N/A unless you extend select a11y stories*
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs) — *API text follows updated JSDoc on `itemRole` / mixin after usual docs sync if required*
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`) — *+2 CT cases in `select.ct.ts`; run `pnpm test` or at least `packages/core` spec + CT*
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing)) — *N/A (no intentional pixel change)*
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

- Re-verify with **VoiceOver** (Chrome / Safari) and keyboard: open **`ix-select`**, arrow through options with **no** or **partial** selection; confirm labels, position, and **“selected”** only on values in **`value`**.
- **`itemRole`** is additive with default **`menuitem`**; existing **`ix-dropdown-item`** usages keep prior behavior unless they set **`item-role`**.
