### PR TITLE
Feat/2595 input validation checkbox

### DIFF
--- a/packages/angular/src/components.ts
+++ b/packages/angular/src/components.ts
@@ -403,7 +403,8 @@ export declare interface IxCategoryFilter extends Components.IxCategoryFilter {
 
 
 @ProxyCmp({
-  inputs: ['checked', 'disabled', 'indeterminate', 'label', 'name', 'required', 'value']
+  inputs: ['checked', 'disabled', 'indeterminate', 'label', 'name', 'required', 'value'],
+  methods: ['clear']
 })
 @Component({
   selector: 'ix-checkbox',
@@ -443,7 +444,8 @@ export declare interface IxCheckbox extends Components.IxCheckbox {
 
 
 @ProxyCmp({
-  inputs: ['direction', 'helperText', 'infoText', 'invalidText', 'label', 'showTextAsTooltip', 'validText', 'warningText']
+  inputs: ['direction', 'helperText', 'infoText', 'invalidText', 'label', 'showTextAsTooltip', 'validText', 'warningText'],
+  methods: ['clear']
 })
 @Component({
   selector: 'ix-checkbox-group',

--- a/packages/angular/standalone/src/components.ts
+++ b/packages/angular/standalone/src/components.ts
@@ -506,7 +506,8 @@ export declare interface IxCategoryFilter extends Components.IxCategoryFilter {
 
 @ProxyCmp({
   defineCustomElementFn: defineIxCheckbox,
-  inputs: ['checked', 'disabled', 'indeterminate', 'label', 'name', 'required', 'value']
+  inputs: ['checked', 'disabled', 'indeterminate', 'label', 'name', 'required', 'value'],
+  methods: ['clear']
 })
 @Component({
   selector: 'ix-checkbox',
@@ -546,7 +547,8 @@ export declare interface IxCheckbox extends Components.IxCheckbox {
 
 @ProxyCmp({
   defineCustomElementFn: defineIxCheckboxGroup,
-  inputs: ['direction', 'helperText', 'infoText', 'invalidText', 'label', 'showTextAsTooltip', 'validText', 'warningText']
+  inputs: ['direction', 'helperText', 'infoText', 'invalidText', 'label', 'showTextAsTooltip', 'validText', 'warningText'],
+  methods: ['clear']
 })
 @Component({
   selector: 'ix-checkbox-group',

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -651,6 +651,10 @@ export namespace Components {
          */
         "checked": boolean;
         /**
+          * Resets the checkbox to its initial unchecked state and clears validation.
+         */
+        "clear": () => Promise<void>;
+        /**
           * Disabled state of the checkbox component
           * @default false
          */
@@ -686,6 +690,7 @@ export namespace Components {
      * @form-ready 
      */
     interface IxCheckboxGroup {
+        "clear": () => Promise<void>;
         /**
           * Alignment of the checkboxes in the group
           * @default 'column'

--- a/packages/core/src/components/checkbox-group/checkbox-group.tsx
+++ b/packages/core/src/components/checkbox-group/checkbox-group.tsx
@@ -15,6 +15,7 @@ import {
 } from '../utils/input';
 import { IxComponentInterface } from '../utils/internal';
 import { makeRef } from '../utils/make-ref';
+import { clearCheckboxGroupValidationState } from '../checkbox/checkbox-validation';
 
 /**
  * @form-ready
@@ -142,6 +143,19 @@ export class CheckboxGroup
     return Promise.resolve(
       this.checkboxElements.some((checkbox) => checkbox.checked)
     );
+  }
+
+  @Method()
+  async clear(): Promise<void> {
+    this.touched = false;
+    this.checkboxElements.forEach((checkbox) => {
+      checkbox.clear();
+    });
+    this.clearValidationState();
+  }
+
+  private clearValidationState() {
+    clearCheckboxGroupValidationState(this.hostElement, this.checkboxElements);
   }
 
   render() {

--- a/packages/core/src/components/checkbox-group/test/checkbox-group.ct.ts
+++ b/packages/core/src/components/checkbox-group/test/checkbox-group.ct.ts
@@ -29,6 +29,31 @@ regressionTest('renders', async ({ mount, page }) => {
   await expect(radioOption3).toHaveClass(/hydrated/);
 });
 
+regressionTest(
+  'should apply invalid class to checkbox-group when required checkbox is touched',
+  async ({ mount, page }) => {
+    await mount(`
+      <form>
+        <ix-checkbox-group>
+          <ix-checkbox label="Option 1" value="option1" required></ix-checkbox>
+          <ix-checkbox label="Option 2" value="option2"></ix-checkbox>
+        </ix-checkbox-group>
+        <button type="button">Other</button>
+      </form>
+    `);
+
+    const checkboxGroup = page.locator('ix-checkbox-group');
+    const checkbox1 = page.locator('ix-checkbox').nth(0);
+    await expect(checkbox1).toHaveClass(/\bhydrated\b/);
+
+    await checkbox1.focus();
+    await page.locator('button[type="button"]').focus();
+
+    await expect(checkboxGroup).toHaveClass(/\bix-invalid--required\b/);
+    await expect(checkboxGroup).toHaveClass(/\bix-invalid\b/);
+  }
+);
+
 regressionTest('required', async ({ mount, page }) => {
   await mount(
     `

--- a/packages/core/src/components/checkbox/checkbox-validation.ts
+++ b/packages/core/src/components/checkbox/checkbox-validation.ts
@@ -1,0 +1,75 @@
+﻿/*
+ * SPDX-FileCopyrightText: 2024 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+interface CheckboxElement extends HTMLElement {
+  required: boolean;
+  checked: boolean;
+}
+
+export function isFormNoValidate(element: HTMLElement): boolean {
+  const form = element.closest('form');
+  if (!form) return false;
+  return (
+    form.hasAttribute('novalidate') ||
+    form.dataset.novalidate !== undefined ||
+    form.hasAttribute('ngnovalidate')
+  );
+}
+
+export function setupFormSubmitListener(
+  element: HTMLElement,
+  callback: () => void
+): (() => void) | undefined {
+  const form = element.closest('form');
+  if (!form) return undefined;
+
+  const handler = () => callback();
+  form.addEventListener('submit', handler);
+
+  return () => {
+    form.removeEventListener('submit', handler);
+  };
+}
+
+export function applyCheckboxValidation(
+  checkboxes: NodeListOf<CheckboxElement> | CheckboxElement[],
+  group: Element | null,
+  touched: boolean,
+  formSubmissionAttempted: boolean
+) {
+  const checkboxArr = Array.from(checkboxes);
+  const requiredCheckboxes = checkboxArr.filter((el) => el.required);
+  const targets =
+    requiredCheckboxes.length > 0 ? requiredCheckboxes : checkboxArr;
+
+  const anyChecked = targets.some((el) => el.checked);
+  const shouldShowError = !anyChecked && (touched || formSubmissionAttempted);
+
+  checkboxArr.forEach((el) => {
+    const isTarget = targets.includes(el);
+    el.classList.toggle('ix-invalid--required', isTarget && shouldShowError);
+    el.classList.toggle('ix-invalid', isTarget && shouldShowError);
+  });
+
+  if (group) {
+    group.classList.toggle('ix-invalid--required', shouldShowError);
+    group.classList.toggle('ix-invalid', shouldShowError);
+  }
+}
+
+export function clearCheckboxGroupValidationState(
+  group: HTMLElement,
+  checkboxes: CheckboxElement[] | NodeListOf<CheckboxElement>
+) {
+  const checkboxArr = Array.from(checkboxes);
+  group.classList.remove('ix-invalid--required', 'ix-invalid');
+  checkboxArr.forEach((el) => {
+    el.classList.remove('ix-invalid', 'ix-invalid--required');
+  });
+}

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -21,8 +21,18 @@ import {
   Watch,
 } from '@stencil/core';
 import { a11yBoolean } from '../utils/a11y';
-import { HookValidationLifecycle, IxFormComponent } from '../utils/input';
+import {
+  ClassMutationObserver,
+  createClassMutationObserver,
+  HookValidationLifecycle,
+  IxFormComponent,
+} from '../utils/input';
 import { makeRef } from '../utils/make-ref';
+import {
+  isFormNoValidate,
+  applyCheckboxValidation,
+  setupFormSubmitListener,
+} from './checkbox-validation';
 
 /**
  * @form-ready
@@ -30,7 +40,7 @@ import { makeRef } from '../utils/make-ref';
 @Component({
   tag: 'ix-checkbox',
   styleUrl: 'checkbox.scss',
-  shadow: true,
+  shadow: { delegatesFocus: true },
   formAssociated: true,
 })
 export class Checkbox implements IxFormComponent<string> {
@@ -91,6 +101,9 @@ export class Checkbox implements IxFormComponent<string> {
   @Event() ixBlur!: EventEmitter<void>;
 
   private touched = false;
+  private formSubmissionAttempted = false;
+  private cleanupFormListener?: () => void;
+  private classMutationObserver?: ClassMutationObserver;
 
   private readonly inputRef = makeRef<HTMLInputElement>((checkboxRef) => {
     checkboxRef.checked = this.checked;
@@ -105,11 +118,72 @@ export class Checkbox implements IxFormComponent<string> {
   onCheckedChange() {
     this.touched = true;
     this.updateFormInternalValue();
+    this.syncValidationClasses();
+  }
+
+  private syncValidationClasses() {
+    if (isFormNoValidate(this.hostElement)) {
+      this.hostElement.classList.remove('ix-invalid--required', 'ix-invalid');
+      return;
+    }
+
+    const checkboxGroup = this.hostElement.closest('ix-checkbox-group');
+    let checkboxes: HTMLIxCheckboxElement[];
+    let group: Element | null;
+
+    if (checkboxGroup) {
+      checkboxes = Array.from(
+        checkboxGroup.querySelectorAll<HTMLIxCheckboxElement>('ix-checkbox')
+      );
+      group = checkboxGroup;
+    } else {
+      checkboxes = [this.hostElement];
+      group = null;
+    }
+
+    const hasRequired = checkboxes.some((c) => c.required);
+    if (!hasRequired) {
+      this.hostElement.classList.remove('ix-invalid--required', 'ix-invalid');
+      return;
+    }
+
+    applyCheckboxValidation(
+      checkboxes,
+      group,
+      this.touched,
+      this.formSubmissionAttempted
+    );
   }
 
   @Watch('value')
   onValueChange() {
     this.valueChange.emit(this.value);
+    this.syncValidationClasses();
+  }
+
+  connectedCallback(): void {
+    const parent = this.hostElement.closest('ix-checkbox-group');
+    if (parent) {
+      this.classMutationObserver = createClassMutationObserver(parent, () => {
+        this.hostElement.classList.toggle(
+          'ix-invalid--required',
+          parent.classList.contains('ix-invalid--required')
+        );
+      });
+    }
+    this.cleanupFormListener = setupFormSubmitListener(this.hostElement, () => {
+      this.formSubmissionAttempted = true;
+      this.syncValidationClasses();
+    });
+  }
+
+  disconnectedCallback(): void {
+    if (this.classMutationObserver) {
+      this.classMutationObserver.destroy();
+    }
+    if (this.cleanupFormListener) {
+      this.cleanupFormListener();
+    }
   }
 
   componentWillLoad() {
@@ -145,6 +219,18 @@ export class Checkbox implements IxFormComponent<string> {
   @HookValidationLifecycle()
   updateClassMappings() {
     /** This function is intentionally empty */
+  }
+
+  /**
+   * Resets the checkbox to its initial unchecked state and clears validation.
+   */
+  @Method()
+  async clear(): Promise<void> {
+    this.checked = false;
+    this.touched = false;
+    this.formSubmissionAttempted = false;
+    this.updateFormInternalValue();
+    this.syncValidationClasses();
   }
 
   private renderCheckmark() {
@@ -192,7 +278,11 @@ export class Checkbox implements IxFormComponent<string> {
           indeterminate: this.indeterminate,
         }}
         onFocus={() => (this.touched = true)}
-        onBlur={() => this.ixBlur.emit()}
+        onBlur={() => {
+          this.ixBlur.emit();
+          this.touched = true;
+          this.syncValidationClasses();
+        }}
       >
         <label>
           <input

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -21,12 +21,7 @@ import {
   Watch,
 } from '@stencil/core';
 import { a11yBoolean } from '../utils/a11y';
-import {
-  ClassMutationObserver,
-  createClassMutationObserver,
-  HookValidationLifecycle,
-  IxFormComponent,
-} from '../utils/input';
+import { HookValidationLifecycle, IxFormComponent } from '../utils/input';
 import { makeRef } from '../utils/make-ref';
 import {
   isFormNoValidate,
@@ -103,7 +98,6 @@ export class Checkbox implements IxFormComponent<string> {
   private touched = false;
   private formSubmissionAttempted = false;
   private cleanupFormListener?: () => void;
-  private classMutationObserver?: ClassMutationObserver;
 
   private readonly inputRef = makeRef<HTMLInputElement>((checkboxRef) => {
     checkboxRef.checked = this.checked;
@@ -162,15 +156,7 @@ export class Checkbox implements IxFormComponent<string> {
   }
 
   connectedCallback(): void {
-    const parent = this.hostElement.closest('ix-checkbox-group');
-    if (parent) {
-      this.classMutationObserver = createClassMutationObserver(parent, () => {
-        this.hostElement.classList.toggle(
-          'ix-invalid--required',
-          parent.classList.contains('ix-invalid--required')
-        );
-      });
-    }
+    this.syncValidationClasses();
     this.cleanupFormListener = setupFormSubmitListener(this.hostElement, () => {
       this.formSubmissionAttempted = true;
       this.syncValidationClasses();
@@ -178,9 +164,6 @@ export class Checkbox implements IxFormComponent<string> {
   }
 
   disconnectedCallback(): void {
-    if (this.classMutationObserver) {
-      this.classMutationObserver.destroy();
-    }
     if (this.cleanupFormListener) {
       this.cleanupFormListener();
     }

--- a/packages/core/src/components/checkbox/tests/checkbox.ct.ts
+++ b/packages/core/src/components/checkbox/tests/checkbox.ct.ts
@@ -132,3 +132,151 @@ test.describe('accessibility', () => {
     await expect(checkbox).toHaveAttribute('aria-checked', 'true');
   });
 });
+
+test('should show invalid class when required checkbox is blurred without selection', async ({
+  mount,
+  page,
+}) => {
+  await mount(`
+    <form>
+      <ix-checkbox-group>
+        <ix-checkbox label="Option 1" value="opt1" required></ix-checkbox>
+        <ix-checkbox label="Option 2" value="opt2"></ix-checkbox>
+      </ix-checkbox-group>
+      <button type="button">Other</button>
+    </form>
+  `);
+
+  const checkbox1 = page.locator('ix-checkbox').nth(0);
+  await expect(checkbox1).toHaveClass(/\bhydrated\b/);
+
+  await checkbox1.focus();
+  await page.locator('button[type="button"]').focus();
+
+  await expect(checkbox1).toHaveClass(/\bix-invalid--required\b/);
+  await expect(checkbox1).toHaveClass(/\bix-invalid\b/);
+});
+
+test('should not show invalid class before checkbox is touched', async ({
+  mount,
+  page,
+}) => {
+  await mount(`
+    <form>
+      <ix-checkbox-group>
+        <ix-checkbox label="Option 1" value="opt1" required></ix-checkbox>
+        <ix-checkbox label="Option 2" value="opt2"></ix-checkbox>
+      </ix-checkbox-group>
+    </form>
+  `);
+
+  const checkbox1 = page.locator('ix-checkbox').nth(0);
+  await expect(checkbox1).toHaveClass(/\bhydrated\b/);
+
+  await expect(checkbox1).not.toHaveClass(/\bix-invalid--required\b/);
+  await expect(checkbox1).not.toHaveClass(/\bix-invalid\b/);
+});
+
+test('should remove invalid class after checking a checkbox', async ({
+  mount,
+  page,
+}) => {
+  await mount(`
+    <form>
+      <ix-checkbox-group>
+        <ix-checkbox label="Option 1" value="opt1" required></ix-checkbox>
+        <ix-checkbox label="Option 2" value="opt2"></ix-checkbox>
+      </ix-checkbox-group>
+      <button type="button">Other</button>
+    </form>
+  `);
+
+  const checkbox1 = page.locator('ix-checkbox').nth(0);
+  await expect(checkbox1).toHaveClass(/\bhydrated\b/);
+
+  await checkbox1.focus();
+  await page.locator('button[type="button"]').focus();
+
+  await expect(checkbox1).toHaveClass(/\bix-invalid--required\b/);
+
+  await checkbox1.click();
+
+  await expect(checkbox1).not.toHaveClass(/\bix-invalid--required\b/);
+  await expect(checkbox1).not.toHaveClass(/\bix-invalid\b/);
+});
+
+test('should not show invalid class when form has novalidate', async ({
+  mount,
+  page,
+}) => {
+  await mount(`
+    <form novalidate>
+      <ix-checkbox-group>
+        <ix-checkbox label="Option 1" value="opt1" required></ix-checkbox>
+        <ix-checkbox label="Option 2" value="opt2"></ix-checkbox>
+      </ix-checkbox-group>
+      <button type="button">Other</button>
+    </form>
+  `);
+
+  const checkbox1 = page.locator('ix-checkbox').nth(0);
+  await expect(checkbox1).toHaveClass(/\bhydrated\b/);
+
+  await checkbox1.focus();
+  await page.locator('button[type="button"]').focus();
+
+  await expect(checkbox1).not.toHaveClass(/\bix-invalid--required\b/);
+  await expect(checkbox1).not.toHaveClass(/\bix-invalid\b/);
+});
+
+test('should show invalid class on form submit when required and unchecked', async ({
+  mount,
+  page,
+}) => {
+  await mount(`
+    <form>
+      <ix-checkbox-group>
+        <ix-checkbox label="Option 1" value="opt1" required></ix-checkbox>
+        <ix-checkbox label="Option 2" value="opt2"></ix-checkbox>
+      </ix-checkbox-group>
+      <button type="submit">Submit</button>
+    </form>
+  `);
+
+  const formElement = page.locator('form');
+  preventFormSubmission(formElement);
+
+  const checkbox1 = page.locator('ix-checkbox').nth(0);
+  await expect(checkbox1).toHaveClass(/\bhydrated\b/);
+
+  await page.locator('button[type="submit"]').click();
+
+  await expect(checkbox1).toHaveClass(/\bix-invalid--required\b/);
+  await expect(checkbox1).toHaveClass(/\bix-invalid\b/);
+});
+
+test('should not show invalid class on form submit when form has novalidate', async ({
+  mount,
+  page,
+}) => {
+  await mount(`
+    <form novalidate>
+      <ix-checkbox-group>
+        <ix-checkbox label="Option 1" value="opt1" required></ix-checkbox>
+        <ix-checkbox label="Option 2" value="opt2"></ix-checkbox>
+      </ix-checkbox-group>
+      <button type="submit">Submit</button>
+    </form>
+  `);
+
+  const formElement = page.locator('form');
+  preventFormSubmission(formElement);
+
+  const checkbox1 = page.locator('ix-checkbox').nth(0);
+  await expect(checkbox1).toHaveClass(/\bhydrated\b/);
+
+  await page.locator('button[type="submit"]').click();
+
+  await expect(checkbox1).not.toHaveClass(/\bix-invalid--required\b/);
+  await expect(checkbox1).not.toHaveClass(/\bix-invalid\b/);
+});


### PR DESCRIPTION
💡 What is the current behavior?
There are some errors which prevent validations from happening as expected.

GitHub Issue Number: https://github.com/siemens/ix/issues/1799
JIRA: [IX-2595](https://agileworld.siemens.cloud/jira/browse/IX-2595)

🆕 What is the new behavior?
The acceptance criteria for this ticket has been met for checkbox component:

Required input:
Invalid input > Removing value with keyboard > Stays invalid
Invalid input > Remove touched state (e.g. clear button) > Valid again
Invalid input > Programmatically setting it to empty > Stays invalid
Valid input > Removing value with keyboard > It is invalid
Valid input > Remove touched state (e.g. autoclear button) > Valid
Valid input > Programmatically setting it to empty > It is invalid

Not required input:
Invalid input > Removing value with keyboard > Valid
Invalid input > Remove touched state (e.g. clear button) > Valid again
Invalid input > Programmatically setting it to empty > Valid
Valid input > Removing value with keyboard > Valid
Valid input > Remove touched state (e.g. clear button) > Valid
Valid input > Programmatically setting it to empty > Valid

Also form 'novalidate' cases is handled.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
