### PR TITLE
fix(core/select): Make disabled prop work for select items

### DIFF
--- a/.changeset/select-item-disabled-fix.md
+++ b/.changeset/select-item-disabled-fix.md
@@ -1,5 +1,5 @@
 ---
-'@siemens/ix': patch
+'@siemens/ix': minor
 ---
 
 Fix `disabled` prop on `ix-select-item` having no effect. The `disabled` state is now reflected to the host, propagated to the underlying `ix-dropdown-item` and the item is excluded from mouse and keyboard selection in `ix-select`.

--- a/.changeset/select-item-disabled-fix.md
+++ b/.changeset/select-item-disabled-fix.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix': patch
+---
+
+Fix `disabled` prop on `ix-select-item` having no effect. The `disabled` state is now reflected to the host, propagated to the underlying `ix-dropdown-item` and the item is excluded from mouse and keyboard selection in `ix-select`.

--- a/packages/angular/src/components.ts
+++ b/packages/angular/src/components.ts
@@ -2403,14 +2403,14 @@ export declare interface IxSelect extends Components.IxSelect {
 
 
 @ProxyCmp({
-  inputs: ['label', 'selected', 'value']
+  inputs: ['disabled', 'label', 'selected', 'value']
 })
 @Component({
   selector: 'ix-select-item',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['label', 'selected', { name: 'value', required: true }],
+  inputs: ['disabled', 'label', 'selected', { name: 'value', required: true }],
   outputs: ['itemClick'],
   standalone: false
 })

--- a/packages/angular/standalone/src/components.ts
+++ b/packages/angular/standalone/src/components.ts
@@ -2503,14 +2503,14 @@ export declare interface IxSelect extends Components.IxSelect {
 
 @ProxyCmp({
   defineCustomElementFn: defineIxSelectItem,
-  inputs: ['label', 'selected', 'value']
+  inputs: ['disabled', 'label', 'selected', 'value']
 })
 @Component({
   selector: 'ix-select-item',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['label', 'selected', { name: 'value', required: true }],
+  inputs: ['disabled', 'label', 'selected', { name: 'value', required: true }],
   outputs: ['itemClick'],
 })
 export class IxSelectItem {

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -3497,6 +3497,12 @@ export namespace Components {
           * @default false
          */
         "disableAriaSelectHandling": boolean;
+        /**
+          * Disable the item. A disabled item cannot be selected via mouse or keyboard and is excluded from the focusable items of the parent ix-select.
+          * @since 5.0.0
+          * @default false
+         */
+        "disabled": boolean;
         "getDropdownItemElement": () => Promise<HTMLIxDropdownItemElement>;
         /**
           * @default false
@@ -10017,6 +10023,12 @@ declare namespace LocalJSX {
          */
         "disableAriaSelectHandling"?: boolean;
         /**
+          * Disable the item. A disabled item cannot be selected via mouse or keyboard and is excluded from the focusable items of the parent ix-select.
+          * @since 5.0.0
+          * @default false
+         */
+        "disabled"?: boolean;
+        /**
           * @default false
          */
         "hover"?: boolean;
@@ -11938,6 +11950,7 @@ declare namespace LocalJSX {
         "label": string;
         "value": string;
         "selected": boolean;
+        "disabled": boolean;
         "hover": boolean;
     }
     interface IxSliderAttributes {

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -3499,7 +3499,7 @@ export namespace Components {
         "disableAriaSelectHandling": boolean;
         /**
           * Disable the item. A disabled item cannot be selected via mouse or keyboard and is excluded from the focusable items of the parent ix-select.
-          * @since 5.0.0
+          * @since 5.1.0
           * @default false
          */
         "disabled": boolean;
@@ -10024,7 +10024,7 @@ declare namespace LocalJSX {
         "disableAriaSelectHandling"?: boolean;
         /**
           * Disable the item. A disabled item cannot be selected via mouse or keyboard and is excluded from the focusable items of the parent ix-select.
-          * @since 5.0.0
+          * @since 5.1.0
           * @default false
          */
         "disabled"?: boolean;

--- a/packages/core/src/components/select-item/select-item.scss
+++ b/packages/core/src/components/select-item/select-item.scss
@@ -28,3 +28,8 @@
 :host(.display-none) {
   display: none;
 }
+
+:host([disabled]) {
+  pointer-events: none;
+  cursor: default;
+}

--- a/packages/core/src/components/select-item/select-item.tsx
+++ b/packages/core/src/components/select-item/select-item.tsx
@@ -66,7 +66,7 @@ export class SelectItem
    * Disable the item. A disabled item cannot be selected via mouse or keyboard
    * and is excluded from the focusable items of the parent ix-select.
    *
-   * @since 5.0.0
+   * @since 5.1.0
    */
   @Prop({ reflect: true }) disabled = false;
 

--- a/packages/core/src/components/select-item/select-item.tsx
+++ b/packages/core/src/components/select-item/select-item.tsx
@@ -63,6 +63,14 @@ export class SelectItem
   @Prop() selected = false;
 
   /**
+   * Disable the item. A disabled item cannot be selected via mouse or keyboard
+   * and is excluded from the focusable items of the parent ix-select.
+   *
+   * @since 5.0.0
+   */
+  @Prop({ reflect: true }) disabled = false;
+
+  /**
    * @internal
    */
   @Prop() hover = false;
@@ -142,6 +150,7 @@ export class SelectItem
             [IX_FOCUS_VISIBLE_ACTIVE]: this.ixFocusVisible,
           }}
           checked={this.selected}
+          disabled={this.disabled}
           label={this.label ? this.label : this.value}
           ref={this.dropdownItemRef}
         ></ix-dropdown-item>

--- a/packages/core/src/components/select-item/test/select-item.spec.tsx
+++ b/packages/core/src/components/select-item/test/select-item.spec.tsx
@@ -41,4 +41,44 @@ describe('select-item', () => {
 
     expect(eventSpy).toHaveReceivedEvent();
   });
+
+  it('should reflect disabled attribute to the host', async () => {
+    const { root, waitForChanges } = await render(
+      <ix-select-item value="test" label="Test" disabled></ix-select-item>
+    );
+
+    await waitForChanges();
+
+    expect(root.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('should forward disabled to the inner ix-dropdown-item', async () => {
+    const { root, waitForChanges } = await render(
+      <ix-select-item value="test" label="Test" disabled></ix-select-item>
+    );
+
+    await waitForChanges();
+
+    const item = root as HTMLIxSelectItemElement;
+    const dropdownItem = item.shadowRoot!.querySelector('ix-dropdown-item')!;
+
+    expect(dropdownItem.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('should not emit itemClick when disabled', async () => {
+    const { root, spyOnEvent, waitForChanges } = await render(
+      <ix-select-item value="test" label="Test" disabled></ix-select-item>
+    );
+
+    const eventSpy = spyOnEvent('itemClick');
+    const item = root as HTMLIxSelectItemElement;
+    const dropdownItem = item.shadowRoot!.querySelector(
+      'ix-dropdown-item'
+    ) as HTMLElement;
+    dropdownItem.click();
+
+    await waitForChanges();
+
+    expect(eventSpy).not.toHaveReceivedEvent();
+  });
 });

--- a/packages/core/src/components/select/test/select.ct.ts
+++ b/packages/core/src/components/select/test/select.ct.ts
@@ -78,6 +78,55 @@ test('does not open the dropdown when disabled', async ({ mount, page }) => {
   await expect(dropdown).not.toHaveClass(/show/);
 });
 
+test('does not select an item when ix-select-item is disabled', async ({
+  mount,
+  page,
+}) => {
+  await mount(`
+    <ix-select>
+      <ix-select-item value="11" label="Item 1"></ix-select-item>
+      <ix-select-item value="22" label="Item 2" disabled></ix-select-item>
+    </ix-select>
+  `);
+
+  const select = page.locator('ix-select');
+  await expect(select).toHaveClass(/hydrated/);
+
+  await page.locator('[data-select-dropdown]').click();
+
+  const disabledItem = page.locator('ix-select-item[disabled]');
+  await expect(disabledItem).toHaveAttribute('aria-disabled', 'true');
+
+  await disabledItem.click({ force: true });
+
+  const ctrl = selectController(select);
+  await expect(ctrl.getInputLocator()).toHaveValue('');
+  await expect(disabledItem).not.toHaveAttribute('selected', /.*/);
+});
+
+test('disabled ix-select-item is excluded from keyboard navigation', async ({
+  mount,
+  page,
+}) => {
+  await mount(`
+    <ix-select>
+      <ix-select-item value="11" label="Item 1"></ix-select-item>
+      <ix-select-item value="22" label="Item 2" disabled></ix-select-item>
+      <ix-select-item value="33" label="Item 3"></ix-select-item>
+    </ix-select>
+  `);
+
+  const select = page.locator('ix-select');
+  const ctrl = selectController(select);
+
+  await ctrl.focusInput();
+  await ctrl.arrowDown(true);
+  await ctrl.arrowDown();
+  await ctrl.pressEnter();
+
+  await expect(ctrl.getInputLocator()).toHaveValue('Item 3');
+});
+
 test('does not open the dropdown when readonly', async ({ mount, page }) => {
   await mount(`
     <ix-select readonly>

--- a/packages/core/src/components/select/test/select.ct.ts
+++ b/packages/core/src/components/select/test/select.ct.ts
@@ -81,6 +81,7 @@ test('does not open the dropdown when disabled', async ({ mount, page }) => {
 test('does not select an item when ix-select-item is disabled', async ({
   mount,
   page,
+  makeAxeBuilder,
 }) => {
   await mount(`
     <ix-select>
@@ -95,7 +96,10 @@ test('does not select an item when ix-select-item is disabled', async ({
   await page.locator('[data-select-dropdown]').click();
 
   const disabledItem = page.locator('ix-select-item[disabled]');
-  await expect(disabledItem).toHaveAttribute('aria-disabled', 'true');
+  await expect(disabledItem).toBeVisible();
+
+  const accessibilityScanResults = await makeAxeBuilder().analyze();
+  expect(accessibilityScanResults.violations).toEqual([]);
 
   await disabledItem.click({ force: true });
 

--- a/packages/react/src/components/components.server.ts
+++ b/packages/react/src/components/components.server.ts
@@ -1677,6 +1677,7 @@ export const IxSelectItem: StencilReactComponent<IxSelectItemElement, IxSelectIt
         label: 'label',
         value: 'value',
         selected: 'selected',
+        disabled: 'disabled',
         hover: 'hover'
     },
     hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,

--- a/packages/vue/src/components/ix-select-item.ts
+++ b/packages/vue/src/components/ix-select-item.ts
@@ -12,6 +12,7 @@ export const IxSelectItem: StencilVueComponent<JSX.IxSelectItem> = /*@__PURE__*/
   'label',
   'value',
   'selected',
+  'disabled',
   'hover',
   'itemClick'
 ], [


### PR DESCRIPTION
## 💡 What is the current behavior?

"disabled" prop is ignored when set to select item. 

JIRA ref: IX-4149
Docs repo PR: https://github.com/siemens/ix-docs/pull/241

## 🆕 What is the new behavior?

"disabled" prop now works properly, setting it up disabled the selected item.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [x] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
