### PR TITLE
fix(core): prevent undefined access of ref elements

### DIFF
--- a/.changeset/steady-tab-order.md
+++ b/.changeset/steady-tab-order.md
@@ -2,6 +2,6 @@
 '@siemens/ix': patch
 ---
 
-Prevent `undefined` access of internal element during render phase. Effected components: `ix-date-input`, `ix-dropdown-button`, `ix-menu-category` and `ix-time-input`.
+Prevent `undefined` access of internal element during render phase. Affected components: `ix-date-input`, `ix-dropdown-button`, `ix-menu-category` and `ix-time-input`.
 
 Fixes #2568

--- a/.changeset/steady-tab-order.md
+++ b/.changeset/steady-tab-order.md
@@ -1,0 +1,7 @@
+---
+'@siemens/ix': patch
+---
+
+Prevent `undefined` access of internal element during render phase. Effected components: `ix-date-input`, `ix-dropdown-button`, `ix-menu-category` and `ix-time-input`.
+
+Fixes #2568

--- a/packages/core/src/components/date-input/date-input.tsx
+++ b/packages/core/src/components/date-input/date-input.tsx
@@ -56,6 +56,7 @@ import {
   InputPickerMixinContract,
 } from '../utils/internal/mixins/input/input-picker.mixin';
 import { hasKeyboardMode } from '../utils/internal/mixins/setup.mixin';
+import { forceTabIndex } from '../utils/a11y';
 
 /**
  * @form-ready
@@ -465,7 +466,7 @@ export class DateInput
         >
           <ix-icon-button
             tabindex={-1}
-            ref={(ref) => (ref!.tabIndex = -1)}
+            ref={(ref) => forceTabIndex(ref, -1)}
             aria-label={this.ariaLabelCalendarButton}
             data-testid="open-calendar"
             class={{ 'calendar-hidden': this.disabled || this.readonly }}

--- a/packages/core/src/components/dropdown-button/dropdown-button.tsx
+++ b/packages/core/src/components/dropdown-button/dropdown-button.tsx
@@ -24,7 +24,12 @@ import {
   Method,
 } from '@stencil/core';
 import { AlignedPlacement } from '../dropdown/placement';
-import { A11yAttributes, a11yBoolean, a11yHostAttributes } from '../utils/a11y';
+import {
+  A11yAttributes,
+  a11yBoolean,
+  a11yHostAttributes,
+  forceTabIndex,
+} from '../utils/a11y';
 import { makeRef } from '../utils/make-ref';
 import type { DropdownButtonVariant } from './dropdown-button.types';
 import { DefaultMixins } from '../utils/internal/component';
@@ -244,7 +249,7 @@ export class DropdownButton
               {...commonProperties}
               class={'internal-button'}
               alignment="start"
-              ref={(ref) => (ref!.tabIndex = -1)}
+              ref={(ref) => forceTabIndex(ref, -1)}
               ariaLabelButton={
                 this.ariaLabelDropdownButton ??
                 (this.dropdownShow ? 'Close dropdown' : 'Open dropdown')
@@ -278,7 +283,7 @@ export class DropdownButton
               <ix-icon-button
                 {...commonProperties}
                 icon={this.icon}
-                ref={(ref) => (ref!.tabIndex = -1)}
+                ref={(ref) => forceTabIndex(ref, -1)}
                 aria-label={
                   this.ariaLabelDropdownButton ??
                   (this.dropdownShow ? 'Close dropdown' : 'Open dropdown')

--- a/packages/core/src/components/menu-category/menu-category.tsx
+++ b/packages/core/src/components/menu-category/menu-category.tsx
@@ -371,7 +371,7 @@ export class MenuCategory
           </span>
         </ix-menu-item>
         <div
-          ref={(ref) => (this.menuItemsContainer = ref!)}
+          ref={(ref) => (this.menuItemsContainer = ref)}
           class={{
             'menu-items': true,
             'menu-items--expanded': this.showItems,

--- a/packages/core/src/components/time-input/time-input.tsx
+++ b/packages/core/src/components/time-input/time-input.tsx
@@ -62,6 +62,7 @@ import {
 import { MakeRef, makeRef } from '../utils/make-ref';
 import { requestAnimationFrameNoNgZone } from '../utils/requestAnimationFrame';
 import type { TimeInputValidityState } from './time-input.types';
+import { forceTabIndex } from '../utils/a11y';
 
 /**
  * @since 3.2.0
@@ -580,7 +581,7 @@ export class TimeInput
         >
           <ix-icon-button
             tabindex={-1}
-            ref={(ref) => (ref!.tabIndex = -1)}
+            ref={(ref) => forceTabIndex(ref, -1)}
             data-testid="open-time-picker"
             class={{ 'time-icon-hidden': this.disabled || this.readonly }}
             variant="subtle-tertiary"

--- a/packages/core/src/components/utils/a11y.ts
+++ b/packages/core/src/components/utils/a11y.ts
@@ -187,3 +187,16 @@ type PartialRecord<K extends A11yAttributeName, T> = {
   [P in K]?: T;
 };
 export type A11yAttributes = PartialRecord<A11yAttributeName, string>;
+
+/**
+ * Usually called by ref={(ref) => forceTabIndex(ref, -1)} to workaround an issue
+ * where the tabIndex is not applied to the element after re-render.
+ */
+export const forceTabIndex = (
+  element: HTMLElement | undefined,
+  tabIndex: number
+) => {
+  if (element) {
+    element.tabIndex = tabIndex;
+  }
+};


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #2568

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Make ref check before accessing tabIndex

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
