### PR TITLE
docs(aggrid): prevent unsused screen real estate

### DIFF
--- a/packages/angular-standalone-test-app/src/preview-examples/aggrid.ts
+++ b/packages/angular-standalone-test-app/src/preview-examples/aggrid.ts
@@ -70,6 +70,9 @@ export default class AGGrid implements OnInit {
           },
         },
       ],
+      autoSizeStrategy: {
+        type: 'fitGridWidth',
+      },
       rowData: [
         {
           type: 'Equipment',
@@ -85,6 +88,41 @@ export default class AGGrid implements OnInit {
           type: 'Pressure sensor',
           status: 'Unknown',
           hwVersion: 'N/A',
+        },
+        {
+          type: 'Flow meter',
+          status: 'Normal',
+          hwVersion: '3.1',
+        },
+        {
+          type: 'Temperature sensor',
+          status: 'Warning',
+          hwVersion: '2.2',
+        },
+        {
+          type: 'Valve',
+          status: 'Normal',
+          hwVersion: '1.5',
+        },
+        {
+          type: 'Actuator',
+          status: 'Maintenance',
+          hwVersion: '2.0',
+        },
+        {
+          type: 'Controller',
+          status: 'Normal',
+          hwVersion: '4.0',
+        },
+        {
+          type: 'Safety relay',
+          status: 'Unknown',
+          hwVersion: 'N/A',
+        },
+        {
+          type: 'Power supply',
+          status: 'Normal',
+          hwVersion: '1.8',
         },
       ],
       suppressCellFocus: true,

--- a/packages/angular-test-app/src/preview-examples/aggrid.ts
+++ b/packages/angular-test-app/src/preview-examples/aggrid.ts
@@ -69,6 +69,9 @@ export default class AGGrid implements OnInit {
           },
         },
       ],
+      autoSizeStrategy: {
+        type: 'fitGridWidth',
+      },
       rowData: [
         {
           type: 'Equipment',
@@ -84,6 +87,41 @@ export default class AGGrid implements OnInit {
           type: 'Pressure sensor',
           status: 'Unknown',
           hwVersion: 'N/A',
+        },
+        {
+          type: 'Flow meter',
+          status: 'Normal',
+          hwVersion: '3.1',
+        },
+        {
+          type: 'Temperature sensor',
+          status: 'Warning',
+          hwVersion: '2.2',
+        },
+        {
+          type: 'Valve',
+          status: 'Normal',
+          hwVersion: '1.5',
+        },
+        {
+          type: 'Actuator',
+          status: 'Maintenance',
+          hwVersion: '2.0',
+        },
+        {
+          type: 'Controller',
+          status: 'Normal',
+          hwVersion: '4.0',
+        },
+        {
+          type: 'Safety relay',
+          status: 'Unknown',
+          hwVersion: 'N/A',
+        },
+        {
+          type: 'Power supply',
+          status: 'Normal',
+          hwVersion: '1.8',
         },
       ],
       suppressCellFocus: true,

--- a/packages/html-test-app/src/preview-examples/aggrid.html
+++ b/packages/html-test-app/src/preview-examples/aggrid.html
@@ -72,6 +72,9 @@ LICENSE file in the root directory of this source tree.
             },
           },
         ],
+        autoSizeStrategy: {
+          type: 'fitGridWidth',
+        },
         rowData: [
           {
             type: 'Equipment',
@@ -87,6 +90,41 @@ LICENSE file in the root directory of this source tree.
             type: 'Pressure sensor',
             status: 'Unknown',
             hwVersion: 'N/A',
+          },
+          {
+            type: 'Flow meter',
+            status: 'Normal',
+            hwVersion: '3.1',
+          },
+          {
+            type: 'Temperature sensor',
+            status: 'Warning',
+            hwVersion: '2.2',
+          },
+          {
+            type: 'Valve',
+            status: 'Normal',
+            hwVersion: '1.5',
+          },
+          {
+            type: 'Actuator',
+            status: 'Maintenance',
+            hwVersion: '2.0',
+          },
+          {
+            type: 'Controller',
+            status: 'Normal',
+            hwVersion: '4.0',
+          },
+          {
+            type: 'Safety relay',
+            status: 'Unknown',
+            hwVersion: 'N/A',
+          },
+          {
+            type: 'Power supply',
+            status: 'Normal',
+            hwVersion: '1.8',
           },
         ],
         suppressCellFocus: true,

--- a/packages/react-test-app/src/preview-examples/aggrid.tsx
+++ b/packages/react-test-app/src/preview-examples/aggrid.tsx
@@ -67,6 +67,9 @@ export default () => {
             },
           },
         ],
+        autoSizeStrategy: {
+          type: 'fitGridWidth',
+        },
         rowData: [
           {
             type: 'Equipment',
@@ -82,6 +85,41 @@ export default () => {
             type: 'Pressure sensor',
             status: 'Unknown',
             hwVersion: 'N/A',
+          },
+          {
+            type: 'Flow meter',
+            status: 'Normal',
+            hwVersion: '3.1',
+          },
+          {
+            type: 'Temperature sensor',
+            status: 'Warning',
+            hwVersion: '2.2',
+          },
+          {
+            type: 'Valve',
+            status: 'Normal',
+            hwVersion: '1.5',
+          },
+          {
+            type: 'Actuator',
+            status: 'Maintenance',
+            hwVersion: '2.0',
+          },
+          {
+            type: 'Controller',
+            status: 'Normal',
+            hwVersion: '4.0',
+          },
+          {
+            type: 'Safety relay',
+            status: 'Unknown',
+            hwVersion: 'N/A',
+          },
+          {
+            type: 'Power supply',
+            status: 'Normal',
+            hwVersion: '1.8',
           },
         ],
         suppressCellFocus: true,

--- a/packages/vue-test-app/src/preview-examples/aggrid.vue
+++ b/packages/vue-test-app/src/preview-examples/aggrid.vue
@@ -65,6 +65,9 @@ onMounted(() => {
         },
       },
     ],
+    autoSizeStrategy: {
+      type: 'fitGridWidth',
+    },
     rowData: [
       {
         type: 'Equipment',
@@ -80,6 +83,41 @@ onMounted(() => {
         type: 'Pressure sensor',
         status: 'Unknown',
         hwVersion: 'N/A',
+      },
+      {
+        type: 'Flow meter',
+        status: 'Normal',
+        hwVersion: '3.1',
+      },
+      {
+        type: 'Temperature sensor',
+        status: 'Warning',
+        hwVersion: '2.2',
+      },
+      {
+        type: 'Valve',
+        status: 'Normal',
+        hwVersion: '1.5',
+      },
+      {
+        type: 'Actuator',
+        status: 'Maintenance',
+        hwVersion: '2.0',
+      },
+      {
+        type: 'Controller',
+        status: 'Normal',
+        hwVersion: '4.0',
+      },
+      {
+        type: 'Safety relay',
+        status: 'Unknown',
+        hwVersion: 'N/A',
+      },
+      {
+        type: 'Power supply',
+        status: 'Normal',
+        hwVersion: '1.8',
       },
     ],
     suppressCellFocus: true,


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: IX-4247

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Rows stretch to fill container width
- Grid has 10 rows to prevent bottom whitespace

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
