### PR TITLE
fix(core/toggle-button): accessibility consistency in toggle-button

### DIFF
--- a/.changeset/eight-maps-drive.md
+++ b/.changeset/eight-maps-drive.md
@@ -1,0 +1,8 @@
+---
+"@siemens/ix": patch
+"@siemens/ix-angular": patch
+"@siemens/ix-react": patch
+"@siemens/ix-vue": patch
+---
+
+Disabled buttons are now correctly inaccessible, preventing unintended interactions.

--- a/packages/core/src/components/button/base-button.tsx
+++ b/packages/core/src/components/button/base-button.tsx
@@ -167,6 +167,7 @@ export const BaseButton: FunctionalComponent<BaseButtonProps> = (
     <button
       {...commonAttributes}
       aria-disabled={a11yBoolean(props.disabled)}
+      disabled={props.disabled || props.loading}
       onClick={(e: Event) => handleOnClick(e, props)}
       type={props.type}
     >

--- a/packages/react-test-app/src/main.tsx
+++ b/packages/react-test-app/src/main.tsx
@@ -243,10 +243,10 @@ import ToastCustom from './preview-examples/toast-custom';
 import ToastPosition from './preview-examples/toast-position';
 import Toggle from './preview-examples/toggle';
 import toggleButtonPrimary from './preview-examples/toggle-button-primary.tsx';
+import ToggleButtonSecondary from './preview-examples/toggle-button-secondary';
 import ToggleButtonSubtlePrimary from './preview-examples/toggle-button-subtle-primary';
 import ToggleButtonSubtleSecondary from './preview-examples/toggle-button-subtle-secondary';
 import ToggleButtonSubtleTertiary from './preview-examples/toggle-button-subtle-tertiary';
-import ToggleButtonSecondary from './preview-examples/toggle-button-secondary';
 import ToggleButtonTertiary from './preview-examples/toggle-button-tertiary';
 import ToggleChecked from './preview-examples/toggle-checked';
 import ToggleCustomLabel from './preview-examples/toggle-custom-label';
@@ -455,11 +455,11 @@ const routes: IxPreviewRoutes = {
   '/preview/toast-custom': ToastCustom,
   '/preview/toast-position': ToastPosition,
   '/preview/toast': Toast,
-  '/preview/toggle-button-tertiary': ToggleButtonTertiary,
   '/preview/toggle-button-secondary': ToggleButtonSecondary,
   '/preview/toggle-button-subtle-primary': ToggleButtonSubtlePrimary,
   '/preview/toggle-button-subtle-secondary': ToggleButtonSubtleSecondary,
   '/preview/toggle-button-subtle-tertiary': ToggleButtonSubtleTertiary,
+  '/preview/toggle-button-tertiary': ToggleButtonTertiary,
   '/preview/toggle-checked': ToggleChecked,
   '/preview/toggle-custom-label': ToggleCustomLabel,
   '/preview/toggle-disabled': ToggleDisabled,

--- a/packages/react-test-app/src/main.tsx
+++ b/packages/react-test-app/src/main.tsx
@@ -246,6 +246,7 @@ import toggleButtonPrimary from './preview-examples/toggle-button-primary.tsx';
 import ToggleButtonSubtlePrimary from './preview-examples/toggle-button-subtle-primary';
 import ToggleButtonSubtleSecondary from './preview-examples/toggle-button-subtle-secondary';
 import ToggleButtonSubtleTertiary from './preview-examples/toggle-button-subtle-tertiary';
+import ToggleButtonSecondary from './preview-examples/toggle-button-secondary';
 import ToggleButtonTertiary from './preview-examples/toggle-button-tertiary';
 import ToggleChecked from './preview-examples/toggle-checked';
 import ToggleCustomLabel from './preview-examples/toggle-custom-label';
@@ -455,6 +456,7 @@ const routes: IxPreviewRoutes = {
   '/preview/toast-position': ToastPosition,
   '/preview/toast': Toast,
   '/preview/toggle-button-tertiary': ToggleButtonTertiary,
+  '/preview/toggle-button-secondary': ToggleButtonSecondary,
   '/preview/toggle-button-subtle-primary': ToggleButtonSubtlePrimary,
   '/preview/toggle-button-subtle-secondary': ToggleButtonSubtleSecondary,
   '/preview/toggle-button-subtle-tertiary': ToggleButtonSubtleTertiary,


### PR DESCRIPTION
## 💡 What is the current behavior?

- The toggle-button-secondary preview example was missing from the main.tsx React preview examples file.
- Disabled buttons were accessible.

GitHub Issue Number: #<ISSUE NUMBER>
Jira Issue Number: 4337

## 🆕 What is the new behavior?

- The toggle-button-secondary preview example has been successfully integrated into the main.tsx React file.
- Disabled buttons are now correctly inaccessible, preventing unintended interactions.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled buttons are now correctly inaccessible, preventing unintended interactions and improving application reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->