### PR TITLE
core/pane: Add noPadding prop #IX-4308

### DIFF
--- a/.changeset/pane-content-padding.md
+++ b/.changeset/pane-content-padding.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix': minor
+---
+
+Added a `noPadding` property to **ix-pane**. When set to `true`, the left, right and bottom padding of the content area is removed while the title keeps its padding.

--- a/packages/angular/src/components.ts
+++ b/packages/angular/src/components.ts
@@ -2106,14 +2106,14 @@ export declare interface IxPagination extends Components.IxPagination {
 
 
 @ProxyCmp({
-  inputs: ['ariaLabelCollapseCloseButton', 'ariaLabelIcon', 'borderless', 'closeOnClickOutside', 'composition', 'expanded', 'heading', 'hideOnCollapse', 'icon', 'size', 'variant']
+  inputs: ['ariaLabelCollapseCloseButton', 'ariaLabelIcon', 'borderless', 'closeOnClickOutside', 'composition', 'expanded', 'heading', 'hideOnCollapse', 'icon', 'noPadding', 'size', 'variant']
 })
 @Component({
   selector: 'ix-pane',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabelCollapseCloseButton', 'ariaLabelIcon', 'borderless', 'closeOnClickOutside', 'composition', 'expanded', 'heading', 'hideOnCollapse', 'icon', 'size', 'variant'],
+  inputs: ['ariaLabelCollapseCloseButton', 'ariaLabelIcon', 'borderless', 'closeOnClickOutside', 'composition', 'expanded', 'heading', 'hideOnCollapse', 'icon', 'noPadding', 'size', 'variant'],
   outputs: ['expandedChanged', 'variantChanged', 'borderlessChanged'],
   standalone: false
 })

--- a/packages/angular/standalone/src/components.ts
+++ b/packages/angular/standalone/src/components.ts
@@ -2206,14 +2206,14 @@ export declare interface IxPagination extends Components.IxPagination {
 
 @ProxyCmp({
   defineCustomElementFn: defineIxPane,
-  inputs: ['ariaLabelCollapseCloseButton', 'ariaLabelIcon', 'borderless', 'closeOnClickOutside', 'composition', 'expanded', 'heading', 'hideOnCollapse', 'icon', 'size', 'variant']
+  inputs: ['ariaLabelCollapseCloseButton', 'ariaLabelIcon', 'borderless', 'closeOnClickOutside', 'composition', 'expanded', 'heading', 'hideOnCollapse', 'icon', 'noPadding', 'size', 'variant']
 })
 @Component({
   selector: 'ix-pane',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabelCollapseCloseButton', 'ariaLabelIcon', 'borderless', 'closeOnClickOutside', 'composition', 'expanded', 'heading', 'hideOnCollapse', 'icon', 'size', 'variant'],
+  inputs: ['ariaLabelCollapseCloseButton', 'ariaLabelIcon', 'borderless', 'closeOnClickOutside', 'composition', 'expanded', 'heading', 'hideOnCollapse', 'icon', 'noPadding', 'size', 'variant'],
   outputs: ['expandedChanged', 'variantChanged', 'borderlessChanged'],
 })
 export class IxPane {

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -3068,6 +3068,11 @@ export namespace Components {
          */
         "isMobile": boolean;
         /**
+          * Remove the padding of the content area. If set to `true` the left, right and bottom padding of the content area is removed. The title always keeps its padding.
+          * @default false
+         */
+        "noPadding": boolean;
+        /**
           * The maximum size of the sidebar, when it is expanded
           * @default '240px'
          */
@@ -9567,6 +9572,11 @@ declare namespace LocalJSX {
          */
         "onVariantChanged"?: (event: IxPaneCustomEvent<VariantChangedEvent>) => void;
         /**
+          * Remove the padding of the content area. If set to `true` the left, right and bottom padding of the content area is removed. The title always keeps its padding.
+          * @default false
+         */
+        "noPadding"?: boolean;
+        /**
           * The maximum size of the sidebar, when it is expanded
           * @default '240px'
          */
@@ -11825,6 +11835,7 @@ declare namespace LocalJSX {
     | '33%'
     | '50%';
         "borderless": boolean;
+        "noPadding": boolean;
         "expanded": boolean;
         "composition": Composition;
         "icon": string;

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -4116,17 +4116,17 @@ export namespace Components {
         /**
           * Interval for hour selection.
           * @since 3.2.0
-          * @default HOUR_INTERVAL_DEFAULT
+          * @default 1
          */
         "hourInterval": number;
         /**
           * Text of the time confirm button.
-          * @default CONFIRM_BUTTON_DEFAULT
+          * @default 'Confirm'
          */
         "i18nConfirmTime": string;
         /**
           * Text for the top header.
-          * @default HEADER_DEFAULT
+          * @default 'Time'
          */
         "i18nHeader": string;
         /**
@@ -4157,7 +4157,7 @@ export namespace Components {
         /**
           * Interval for millisecond selection.
           * @since 3.2.0
-          * @default MILLISECOND_INTERVAL_DEFAULT
+          * @default 100
          */
         "millisecondInterval": number;
         /**
@@ -4168,13 +4168,13 @@ export namespace Components {
         /**
           * Interval for minute selection.
           * @since 3.2.0
-          * @default MINUTE_INTERVAL_DEFAULT
+          * @default 1
          */
         "minuteInterval": number;
         /**
           * Interval for second selection.
           * @since 3.2.0
-          * @default SECOND_INTERVAL_DEFAULT
+          * @default 1
          */
         "secondInterval": number;
         /**
@@ -10682,17 +10682,17 @@ declare namespace LocalJSX {
         /**
           * Interval for hour selection.
           * @since 3.2.0
-          * @default HOUR_INTERVAL_DEFAULT
+          * @default 1
          */
         "hourInterval"?: number;
         /**
           * Text of the time confirm button.
-          * @default CONFIRM_BUTTON_DEFAULT
+          * @default 'Confirm'
          */
         "i18nConfirmTime"?: string;
         /**
           * Text for the top header.
-          * @default HEADER_DEFAULT
+          * @default 'Time'
          */
         "i18nHeader"?: string;
         /**
@@ -10723,7 +10723,7 @@ declare namespace LocalJSX {
         /**
           * Interval for millisecond selection.
           * @since 3.2.0
-          * @default MILLISECOND_INTERVAL_DEFAULT
+          * @default 100
          */
         "millisecondInterval"?: number;
         /**
@@ -10734,7 +10734,7 @@ declare namespace LocalJSX {
         /**
           * Interval for minute selection.
           * @since 3.2.0
-          * @default MINUTE_INTERVAL_DEFAULT
+          * @default 1
          */
         "minuteInterval"?: number;
         /**
@@ -10748,7 +10748,7 @@ declare namespace LocalJSX {
         /**
           * Interval for second selection.
           * @since 3.2.0
-          * @default SECOND_INTERVAL_DEFAULT
+          * @default 1
          */
         "secondInterval"?: number;
         /**

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -625,7 +625,7 @@ export namespace Components {
         "uniqueCategories": boolean;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxCheckbox {
         /**
@@ -666,7 +666,7 @@ export namespace Components {
         "value": string;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxCheckboxGroup {
         /**
@@ -951,7 +951,7 @@ export namespace Components {
         "weekStartIndex": number;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxDateInput {
         /**
@@ -1224,7 +1224,7 @@ export namespace Components {
     }
     /**
      * @since 5.0.0
-     * @form-ready 
+     * @form-ready
      */
     interface IxDatetimeInput {
         /**
@@ -2174,7 +2174,7 @@ export namespace Components {
         "variant": ButtonVariant1;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxInput {
         /**
@@ -2836,7 +2836,7 @@ export namespace Components {
     interface IxModalLoading {
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxNumberInput {
         /**
@@ -3068,7 +3068,7 @@ export namespace Components {
          */
         "isMobile": boolean;
         /**
-          * Remove the padding of the content area. If set to `true` the left, right and bottom padding of the content area is removed. The title always keeps its padding.
+          * Remove the padding of the content area. If set to `true` the left, right and bottom padding of the content area is removed.
           * @default false
          */
         "noPadding": boolean;
@@ -3245,7 +3245,7 @@ export namespace Components {
         "variant": PushCardVariant;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxRadio {
         /**
@@ -3281,7 +3281,7 @@ export namespace Components {
         "value"?: string;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxRadioGroup {
         /**
@@ -3344,7 +3344,7 @@ export namespace Components {
     interface IxRow {
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxSelect {
         /**
@@ -3526,7 +3526,7 @@ export namespace Components {
         "value": string;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxSlider {
         /**
@@ -3797,7 +3797,7 @@ export namespace Components {
         "small": boolean;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxTextarea {
         /**
@@ -3909,7 +3909,7 @@ export namespace Components {
     }
     /**
      * @since 3.2.0
-     * @form-ready 
+     * @form-ready
      */
     interface IxTimeInput {
         /**
@@ -4246,7 +4246,7 @@ export namespace Components {
         "showToast": (config: ToastConfig) => Promise<ShowToastResult>;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxToggle {
         /**
@@ -4998,7 +4998,7 @@ declare global {
         "ixBlur": void;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface HTMLIxCheckboxElement extends Components.IxCheckbox, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxCheckboxElementEventMap>(type: K, listener: (this: HTMLIxCheckboxElement, ev: IxCheckboxCustomEvent<HTMLIxCheckboxElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5015,7 +5015,7 @@ declare global {
         new (): HTMLIxCheckboxElement;
     };
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface HTMLIxCheckboxGroupElement extends Components.IxCheckboxGroup, HTMLStencilElement {
     }
@@ -5112,7 +5112,7 @@ declare global {
         "ixChange": string | undefined;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface HTMLIxDateInputElement extends Components.IxDateInput, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxDateInputElementEventMap>(type: K, listener: (this: HTMLIxDateInputElement, ev: IxDateInputCustomEvent<HTMLIxDateInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5162,7 +5162,7 @@ declare global {
     }
     /**
      * @since 5.0.0
-     * @form-ready 
+     * @form-ready
      */
     interface HTMLIxDatetimeInputElement extends Components.IxDatetimeInput, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxDatetimeInputElementEventMap>(type: K, listener: (this: HTMLIxDatetimeInputElement, ev: IxDatetimeInputCustomEvent<HTMLIxDatetimeInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5459,7 +5459,7 @@ declare global {
         "ixChange": string;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface HTMLIxInputElement extends Components.IxInput, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxInputElementEventMap>(type: K, listener: (this: HTMLIxInputElement, ev: IxInputCustomEvent<HTMLIxInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5767,7 +5767,7 @@ declare global {
         "ixChange": number;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface HTMLIxNumberInputElement extends Components.IxNumberInput, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxNumberInputElementEventMap>(type: K, listener: (this: HTMLIxNumberInputElement, ev: IxNumberInputCustomEvent<HTMLIxNumberInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5855,7 +5855,7 @@ declare global {
         "ixBlur": void;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface HTMLIxRadioElement extends Components.IxRadio, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxRadioElementEventMap>(type: K, listener: (this: HTMLIxRadioElement, ev: IxRadioCustomEvent<HTMLIxRadioElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5875,7 +5875,7 @@ declare global {
         "valueChange": string;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface HTMLIxRadioGroupElement extends Components.IxRadioGroup, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxRadioGroupElementEventMap>(type: K, listener: (this: HTMLIxRadioGroupElement, ev: IxRadioGroupCustomEvent<HTMLIxRadioGroupElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5910,7 +5910,7 @@ declare global {
         "ixBlur": void;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface HTMLIxSelectElement extends Components.IxSelect, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxSelectElementEventMap>(type: K, listener: (this: HTMLIxSelectElement, ev: IxSelectCustomEvent<HTMLIxSelectElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5947,7 +5947,7 @@ declare global {
         "valueChange": number;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface HTMLIxSliderElement extends Components.IxSlider, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxSliderElementEventMap>(type: K, listener: (this: HTMLIxSliderElement, ev: IxSliderCustomEvent<HTMLIxSliderElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -6047,7 +6047,7 @@ declare global {
         "ixChange": string;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface HTMLIxTextareaElement extends Components.IxTextarea, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxTextareaElementEventMap>(type: K, listener: (this: HTMLIxTextareaElement, ev: IxTextareaCustomEvent<HTMLIxTextareaElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -6078,7 +6078,7 @@ declare global {
     }
     /**
      * @since 3.2.0
-     * @form-ready 
+     * @form-ready
      */
     interface HTMLIxTimeInputElement extends Components.IxTimeInput, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxTimeInputElementEventMap>(type: K, listener: (this: HTMLIxTimeInputElement, ev: IxTimeInputCustomEvent<HTMLIxTimeInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -6141,7 +6141,7 @@ declare global {
         "ixBlur": void;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface HTMLIxToggleElement extends Components.IxToggle, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxToggleElementEventMap>(type: K, listener: (this: HTMLIxToggleElement, ev: IxToggleCustomEvent<HTMLIxToggleElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -6960,7 +6960,7 @@ declare namespace LocalJSX {
         "uniqueCategories"?: boolean;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxCheckbox {
         /**
@@ -7014,7 +7014,7 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxCheckboxGroup {
         /**
@@ -7305,7 +7305,7 @@ declare namespace LocalJSX {
         "weekStartIndex"?: number;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxDateInput {
         /**
@@ -7583,7 +7583,7 @@ declare namespace LocalJSX {
     }
     /**
      * @since 5.0.0
-     * @form-ready 
+     * @form-ready
      */
     interface IxDatetimeInput {
         /**
@@ -8596,7 +8596,7 @@ declare namespace LocalJSX {
         "variant"?: ButtonVariant1;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxInput {
         /**
@@ -9311,7 +9311,7 @@ declare namespace LocalJSX {
     interface IxModalLoading {
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxNumberInput {
         /**
@@ -9572,7 +9572,7 @@ declare namespace LocalJSX {
          */
         "onVariantChanged"?: (event: IxPaneCustomEvent<VariantChangedEvent>) => void;
         /**
-          * Remove the padding of the content area. If set to `true` the left, right and bottom padding of the content area is removed. The title always keeps its padding.
+          * Remove the padding of the content area. If set to `true` the left, right and bottom padding of the content area is removed.
           * @default false
          */
         "noPadding"?: boolean;
@@ -9749,7 +9749,7 @@ declare namespace LocalJSX {
         "variant"?: PushCardVariant;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxRadio {
         /**
@@ -9798,7 +9798,7 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxRadioGroup {
         /**
@@ -9862,7 +9862,7 @@ declare namespace LocalJSX {
     interface IxRow {
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxSelect {
         /**
@@ -10053,7 +10053,7 @@ declare namespace LocalJSX {
         "value": string;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxSlider {
         /**
@@ -10356,7 +10356,7 @@ declare namespace LocalJSX {
         "small"?: boolean;
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxTextarea {
         /**
@@ -10475,7 +10475,7 @@ declare namespace LocalJSX {
     }
     /**
      * @since 3.2.0
-     * @form-ready 
+     * @form-ready
      */
     interface IxTimeInput {
         /**
@@ -10806,7 +10806,7 @@ declare namespace LocalJSX {
         "position"?: 'bottom-right' | 'top-right';
     }
     /**
-     * @form-ready 
+     * @form-ready
      */
     interface IxToggle {
         /**
@@ -12310,11 +12310,11 @@ declare module "@stencil/core" {
             "ix-card-title": LocalJSX.IntrinsicElements["ix-card-title"] & JSXBase.HTMLAttributes<HTMLIxCardTitleElement>;
             "ix-category-filter": LocalJSX.IntrinsicElements["ix-category-filter"] & JSXBase.HTMLAttributes<HTMLIxCategoryFilterElement>;
             /**
-             * @form-ready 
+             * @form-ready
              */
             "ix-checkbox": LocalJSX.IntrinsicElements["ix-checkbox"] & JSXBase.HTMLAttributes<HTMLIxCheckboxElement>;
             /**
-             * @form-ready 
+             * @form-ready
              */
             "ix-checkbox-group": LocalJSX.IntrinsicElements["ix-checkbox-group"] & JSXBase.HTMLAttributes<HTMLIxCheckboxGroupElement>;
             "ix-chip": LocalJSX.IntrinsicElements["ix-chip"] & JSXBase.HTMLAttributes<HTMLIxChipElement>;
@@ -12326,14 +12326,14 @@ declare module "@stencil/core" {
             "ix-custom-field": LocalJSX.IntrinsicElements["ix-custom-field"] & JSXBase.HTMLAttributes<HTMLIxCustomFieldElement>;
             "ix-date-dropdown": LocalJSX.IntrinsicElements["ix-date-dropdown"] & JSXBase.HTMLAttributes<HTMLIxDateDropdownElement>;
             /**
-             * @form-ready 
+             * @form-ready
              */
             "ix-date-input": LocalJSX.IntrinsicElements["ix-date-input"] & JSXBase.HTMLAttributes<HTMLIxDateInputElement>;
             "ix-date-picker": LocalJSX.IntrinsicElements["ix-date-picker"] & JSXBase.HTMLAttributes<HTMLIxDatePickerElement>;
             "ix-date-time-card": LocalJSX.IntrinsicElements["ix-date-time-card"] & JSXBase.HTMLAttributes<HTMLIxDateTimeCardElement>;
             /**
              * @since 5.0.0
-             * @form-ready 
+             * @form-ready
              */
             "ix-datetime-input": LocalJSX.IntrinsicElements["ix-datetime-input"] & JSXBase.HTMLAttributes<HTMLIxDatetimeInputElement>;
             "ix-datetime-picker": LocalJSX.IntrinsicElements["ix-datetime-picker"] & JSXBase.HTMLAttributes<HTMLIxDatetimePickerElement>;
@@ -12359,7 +12359,7 @@ declare module "@stencil/core" {
             "ix-icon-button": LocalJSX.IntrinsicElements["ix-icon-button"] & JSXBase.HTMLAttributes<HTMLIxIconButtonElement>;
             "ix-icon-toggle-button": LocalJSX.IntrinsicElements["ix-icon-toggle-button"] & JSXBase.HTMLAttributes<HTMLIxIconToggleButtonElement>;
             /**
-             * @form-ready 
+             * @form-ready
              */
             "ix-input": LocalJSX.IntrinsicElements["ix-input"] & JSXBase.HTMLAttributes<HTMLIxInputElement>;
             "ix-key-value": LocalJSX.IntrinsicElements["ix-key-value"] & JSXBase.HTMLAttributes<HTMLIxKeyValueElement>;
@@ -12392,7 +12392,7 @@ declare module "@stencil/core" {
             "ix-modal-header": LocalJSX.IntrinsicElements["ix-modal-header"] & JSXBase.HTMLAttributes<HTMLIxModalHeaderElement>;
             "ix-modal-loading": LocalJSX.IntrinsicElements["ix-modal-loading"] & JSXBase.HTMLAttributes<HTMLIxModalLoadingElement>;
             /**
-             * @form-ready 
+             * @form-ready
              */
             "ix-number-input": LocalJSX.IntrinsicElements["ix-number-input"] & JSXBase.HTMLAttributes<HTMLIxNumberInputElement>;
             "ix-pagination": LocalJSX.IntrinsicElements["ix-pagination"] & JSXBase.HTMLAttributes<HTMLIxPaginationElement>;
@@ -12405,22 +12405,22 @@ declare module "@stencil/core" {
             "ix-progress-indicator": LocalJSX.IntrinsicElements["ix-progress-indicator"] & JSXBase.HTMLAttributes<HTMLIxProgressIndicatorElement>;
             "ix-push-card": LocalJSX.IntrinsicElements["ix-push-card"] & JSXBase.HTMLAttributes<HTMLIxPushCardElement>;
             /**
-             * @form-ready 
+             * @form-ready
              */
             "ix-radio": LocalJSX.IntrinsicElements["ix-radio"] & JSXBase.HTMLAttributes<HTMLIxRadioElement>;
             /**
-             * @form-ready 
+             * @form-ready
              */
             "ix-radio-group": LocalJSX.IntrinsicElements["ix-radio-group"] & JSXBase.HTMLAttributes<HTMLIxRadioGroupElement>;
             "ix-range-field": LocalJSX.IntrinsicElements["ix-range-field"] & JSXBase.HTMLAttributes<HTMLIxRangeFieldElement>;
             "ix-row": LocalJSX.IntrinsicElements["ix-row"] & JSXBase.HTMLAttributes<HTMLIxRowElement>;
             /**
-             * @form-ready 
+             * @form-ready
              */
             "ix-select": LocalJSX.IntrinsicElements["ix-select"] & JSXBase.HTMLAttributes<HTMLIxSelectElement>;
             "ix-select-item": LocalJSX.IntrinsicElements["ix-select-item"] & JSXBase.HTMLAttributes<HTMLIxSelectItemElement>;
             /**
-             * @form-ready 
+             * @form-ready
              */
             "ix-slider": LocalJSX.IntrinsicElements["ix-slider"] & JSXBase.HTMLAttributes<HTMLIxSliderElement>;
             "ix-spinner": LocalJSX.IntrinsicElements["ix-spinner"] & JSXBase.HTMLAttributes<HTMLIxSpinnerElement>;
@@ -12436,20 +12436,20 @@ declare module "@stencil/core" {
             "ix-tab-set": LocalJSX.IntrinsicElements["ix-tab-set"] & JSXBase.HTMLAttributes<HTMLIxTabSetElement>;
             "ix-tabs": LocalJSX.IntrinsicElements["ix-tabs"] & JSXBase.HTMLAttributes<HTMLIxTabsElement>;
             /**
-             * @form-ready 
+             * @form-ready
              */
             "ix-textarea": LocalJSX.IntrinsicElements["ix-textarea"] & JSXBase.HTMLAttributes<HTMLIxTextareaElement>;
             "ix-tile": LocalJSX.IntrinsicElements["ix-tile"] & JSXBase.HTMLAttributes<HTMLIxTileElement>;
             /**
              * @since 3.2.0
-             * @form-ready 
+             * @form-ready
              */
             "ix-time-input": LocalJSX.IntrinsicElements["ix-time-input"] & JSXBase.HTMLAttributes<HTMLIxTimeInputElement>;
             "ix-time-picker": LocalJSX.IntrinsicElements["ix-time-picker"] & JSXBase.HTMLAttributes<HTMLIxTimePickerElement>;
             "ix-toast": LocalJSX.IntrinsicElements["ix-toast"] & JSXBase.HTMLAttributes<HTMLIxToastElement>;
             "ix-toast-container": LocalJSX.IntrinsicElements["ix-toast-container"] & JSXBase.HTMLAttributes<HTMLIxToastContainerElement>;
             /**
-             * @form-ready 
+             * @form-ready
              */
             "ix-toggle": LocalJSX.IntrinsicElements["ix-toggle"] & JSXBase.HTMLAttributes<HTMLIxToggleElement>;
             "ix-toggle-button": LocalJSX.IntrinsicElements["ix-toggle-button"] & JSXBase.HTMLAttributes<HTMLIxToggleButtonElement>;

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -625,7 +625,7 @@ export namespace Components {
         "uniqueCategories": boolean;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxCheckbox {
         /**
@@ -666,7 +666,7 @@ export namespace Components {
         "value": string;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxCheckboxGroup {
         /**
@@ -951,7 +951,7 @@ export namespace Components {
         "weekStartIndex": number;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxDateInput {
         /**
@@ -1224,7 +1224,7 @@ export namespace Components {
     }
     /**
      * @since 5.0.0
-     * @form-ready
+     * @form-ready 
      */
     interface IxDatetimeInput {
         /**
@@ -2174,7 +2174,7 @@ export namespace Components {
         "variant": ButtonVariant1;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxInput {
         /**
@@ -2836,7 +2836,7 @@ export namespace Components {
     interface IxModalLoading {
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxNumberInput {
         /**
@@ -3069,6 +3069,7 @@ export namespace Components {
         "isMobile": boolean;
         /**
           * Remove the padding of the content area. If set to `true` the left, right and bottom padding of the content area is removed.
+          * @since 5.1.0
           * @default false
          */
         "noPadding": boolean;
@@ -3245,7 +3246,7 @@ export namespace Components {
         "variant": PushCardVariant;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxRadio {
         /**
@@ -3281,7 +3282,7 @@ export namespace Components {
         "value"?: string;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxRadioGroup {
         /**
@@ -3344,7 +3345,7 @@ export namespace Components {
     interface IxRow {
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxSelect {
         /**
@@ -3526,7 +3527,7 @@ export namespace Components {
         "value": string;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxSlider {
         /**
@@ -3797,7 +3798,7 @@ export namespace Components {
         "small": boolean;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxTextarea {
         /**
@@ -3909,7 +3910,7 @@ export namespace Components {
     }
     /**
      * @since 3.2.0
-     * @form-ready
+     * @form-ready 
      */
     interface IxTimeInput {
         /**
@@ -4115,17 +4116,17 @@ export namespace Components {
         /**
           * Interval for hour selection.
           * @since 3.2.0
-          * @default 1
+          * @default HOUR_INTERVAL_DEFAULT
          */
         "hourInterval": number;
         /**
           * Text of the time confirm button.
-          * @default 'Confirm'
+          * @default CONFIRM_BUTTON_DEFAULT
          */
         "i18nConfirmTime": string;
         /**
           * Text for the top header.
-          * @default 'Time'
+          * @default HEADER_DEFAULT
          */
         "i18nHeader": string;
         /**
@@ -4156,7 +4157,7 @@ export namespace Components {
         /**
           * Interval for millisecond selection.
           * @since 3.2.0
-          * @default 100
+          * @default MILLISECOND_INTERVAL_DEFAULT
          */
         "millisecondInterval": number;
         /**
@@ -4167,13 +4168,13 @@ export namespace Components {
         /**
           * Interval for minute selection.
           * @since 3.2.0
-          * @default 1
+          * @default MINUTE_INTERVAL_DEFAULT
          */
         "minuteInterval": number;
         /**
           * Interval for second selection.
           * @since 3.2.0
-          * @default 1
+          * @default SECOND_INTERVAL_DEFAULT
          */
         "secondInterval": number;
         /**
@@ -4246,7 +4247,7 @@ export namespace Components {
         "showToast": (config: ToastConfig) => Promise<ShowToastResult>;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxToggle {
         /**
@@ -4998,7 +4999,7 @@ declare global {
         "ixBlur": void;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface HTMLIxCheckboxElement extends Components.IxCheckbox, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxCheckboxElementEventMap>(type: K, listener: (this: HTMLIxCheckboxElement, ev: IxCheckboxCustomEvent<HTMLIxCheckboxElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5015,7 +5016,7 @@ declare global {
         new (): HTMLIxCheckboxElement;
     };
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface HTMLIxCheckboxGroupElement extends Components.IxCheckboxGroup, HTMLStencilElement {
     }
@@ -5112,7 +5113,7 @@ declare global {
         "ixChange": string | undefined;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface HTMLIxDateInputElement extends Components.IxDateInput, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxDateInputElementEventMap>(type: K, listener: (this: HTMLIxDateInputElement, ev: IxDateInputCustomEvent<HTMLIxDateInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5162,7 +5163,7 @@ declare global {
     }
     /**
      * @since 5.0.0
-     * @form-ready
+     * @form-ready 
      */
     interface HTMLIxDatetimeInputElement extends Components.IxDatetimeInput, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxDatetimeInputElementEventMap>(type: K, listener: (this: HTMLIxDatetimeInputElement, ev: IxDatetimeInputCustomEvent<HTMLIxDatetimeInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5459,7 +5460,7 @@ declare global {
         "ixChange": string;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface HTMLIxInputElement extends Components.IxInput, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxInputElementEventMap>(type: K, listener: (this: HTMLIxInputElement, ev: IxInputCustomEvent<HTMLIxInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5767,7 +5768,7 @@ declare global {
         "ixChange": number;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface HTMLIxNumberInputElement extends Components.IxNumberInput, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxNumberInputElementEventMap>(type: K, listener: (this: HTMLIxNumberInputElement, ev: IxNumberInputCustomEvent<HTMLIxNumberInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5855,7 +5856,7 @@ declare global {
         "ixBlur": void;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface HTMLIxRadioElement extends Components.IxRadio, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxRadioElementEventMap>(type: K, listener: (this: HTMLIxRadioElement, ev: IxRadioCustomEvent<HTMLIxRadioElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5875,7 +5876,7 @@ declare global {
         "valueChange": string;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface HTMLIxRadioGroupElement extends Components.IxRadioGroup, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxRadioGroupElementEventMap>(type: K, listener: (this: HTMLIxRadioGroupElement, ev: IxRadioGroupCustomEvent<HTMLIxRadioGroupElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5910,7 +5911,7 @@ declare global {
         "ixBlur": void;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface HTMLIxSelectElement extends Components.IxSelect, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxSelectElementEventMap>(type: K, listener: (this: HTMLIxSelectElement, ev: IxSelectCustomEvent<HTMLIxSelectElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5947,7 +5948,7 @@ declare global {
         "valueChange": number;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface HTMLIxSliderElement extends Components.IxSlider, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxSliderElementEventMap>(type: K, listener: (this: HTMLIxSliderElement, ev: IxSliderCustomEvent<HTMLIxSliderElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -6047,7 +6048,7 @@ declare global {
         "ixChange": string;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface HTMLIxTextareaElement extends Components.IxTextarea, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxTextareaElementEventMap>(type: K, listener: (this: HTMLIxTextareaElement, ev: IxTextareaCustomEvent<HTMLIxTextareaElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -6078,7 +6079,7 @@ declare global {
     }
     /**
      * @since 3.2.0
-     * @form-ready
+     * @form-ready 
      */
     interface HTMLIxTimeInputElement extends Components.IxTimeInput, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxTimeInputElementEventMap>(type: K, listener: (this: HTMLIxTimeInputElement, ev: IxTimeInputCustomEvent<HTMLIxTimeInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -6141,7 +6142,7 @@ declare global {
         "ixBlur": void;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface HTMLIxToggleElement extends Components.IxToggle, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIxToggleElementEventMap>(type: K, listener: (this: HTMLIxToggleElement, ev: IxToggleCustomEvent<HTMLIxToggleElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -6960,7 +6961,7 @@ declare namespace LocalJSX {
         "uniqueCategories"?: boolean;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxCheckbox {
         /**
@@ -7014,7 +7015,7 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxCheckboxGroup {
         /**
@@ -7305,7 +7306,7 @@ declare namespace LocalJSX {
         "weekStartIndex"?: number;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxDateInput {
         /**
@@ -7583,7 +7584,7 @@ declare namespace LocalJSX {
     }
     /**
      * @since 5.0.0
-     * @form-ready
+     * @form-ready 
      */
     interface IxDatetimeInput {
         /**
@@ -8596,7 +8597,7 @@ declare namespace LocalJSX {
         "variant"?: ButtonVariant1;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxInput {
         /**
@@ -9311,7 +9312,7 @@ declare namespace LocalJSX {
     interface IxModalLoading {
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxNumberInput {
         /**
@@ -9558,6 +9559,12 @@ declare namespace LocalJSX {
          */
         "isMobile"?: boolean;
         /**
+          * Remove the padding of the content area. If set to `true` the left, right and bottom padding of the content area is removed.
+          * @since 5.1.0
+          * @default false
+         */
+        "noPadding"?: boolean;
+        /**
           * This event is triggered when the variant of the pane is changed
          */
         "onBorderlessChanged"?: (event: IxPaneCustomEvent<BorderlessChangedEvent>) => void;
@@ -9571,11 +9578,6 @@ declare namespace LocalJSX {
           * This event is triggered when the variant of the pane is changed
          */
         "onVariantChanged"?: (event: IxPaneCustomEvent<VariantChangedEvent>) => void;
-        /**
-          * Remove the padding of the content area. If set to `true` the left, right and bottom padding of the content area is removed.
-          * @default false
-         */
-        "noPadding"?: boolean;
         /**
           * The maximum size of the sidebar, when it is expanded
           * @default '240px'
@@ -9749,7 +9751,7 @@ declare namespace LocalJSX {
         "variant"?: PushCardVariant;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxRadio {
         /**
@@ -9798,7 +9800,7 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxRadioGroup {
         /**
@@ -9862,7 +9864,7 @@ declare namespace LocalJSX {
     interface IxRow {
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxSelect {
         /**
@@ -10053,7 +10055,7 @@ declare namespace LocalJSX {
         "value": string;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxSlider {
         /**
@@ -10356,7 +10358,7 @@ declare namespace LocalJSX {
         "small"?: boolean;
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxTextarea {
         /**
@@ -10475,7 +10477,7 @@ declare namespace LocalJSX {
     }
     /**
      * @since 3.2.0
-     * @form-ready
+     * @form-ready 
      */
     interface IxTimeInput {
         /**
@@ -10680,17 +10682,17 @@ declare namespace LocalJSX {
         /**
           * Interval for hour selection.
           * @since 3.2.0
-          * @default 1
+          * @default HOUR_INTERVAL_DEFAULT
          */
         "hourInterval"?: number;
         /**
           * Text of the time confirm button.
-          * @default 'Confirm'
+          * @default CONFIRM_BUTTON_DEFAULT
          */
         "i18nConfirmTime"?: string;
         /**
           * Text for the top header.
-          * @default 'Time'
+          * @default HEADER_DEFAULT
          */
         "i18nHeader"?: string;
         /**
@@ -10721,7 +10723,7 @@ declare namespace LocalJSX {
         /**
           * Interval for millisecond selection.
           * @since 3.2.0
-          * @default 100
+          * @default MILLISECOND_INTERVAL_DEFAULT
          */
         "millisecondInterval"?: number;
         /**
@@ -10732,7 +10734,7 @@ declare namespace LocalJSX {
         /**
           * Interval for minute selection.
           * @since 3.2.0
-          * @default 1
+          * @default MINUTE_INTERVAL_DEFAULT
          */
         "minuteInterval"?: number;
         /**
@@ -10746,7 +10748,7 @@ declare namespace LocalJSX {
         /**
           * Interval for second selection.
           * @since 3.2.0
-          * @default 1
+          * @default SECOND_INTERVAL_DEFAULT
          */
         "secondInterval"?: number;
         /**
@@ -10806,7 +10808,7 @@ declare namespace LocalJSX {
         "position"?: 'bottom-right' | 'top-right';
     }
     /**
-     * @form-ready
+     * @form-ready 
      */
     interface IxToggle {
         /**
@@ -12310,11 +12312,11 @@ declare module "@stencil/core" {
             "ix-card-title": LocalJSX.IntrinsicElements["ix-card-title"] & JSXBase.HTMLAttributes<HTMLIxCardTitleElement>;
             "ix-category-filter": LocalJSX.IntrinsicElements["ix-category-filter"] & JSXBase.HTMLAttributes<HTMLIxCategoryFilterElement>;
             /**
-             * @form-ready
+             * @form-ready 
              */
             "ix-checkbox": LocalJSX.IntrinsicElements["ix-checkbox"] & JSXBase.HTMLAttributes<HTMLIxCheckboxElement>;
             /**
-             * @form-ready
+             * @form-ready 
              */
             "ix-checkbox-group": LocalJSX.IntrinsicElements["ix-checkbox-group"] & JSXBase.HTMLAttributes<HTMLIxCheckboxGroupElement>;
             "ix-chip": LocalJSX.IntrinsicElements["ix-chip"] & JSXBase.HTMLAttributes<HTMLIxChipElement>;
@@ -12326,14 +12328,14 @@ declare module "@stencil/core" {
             "ix-custom-field": LocalJSX.IntrinsicElements["ix-custom-field"] & JSXBase.HTMLAttributes<HTMLIxCustomFieldElement>;
             "ix-date-dropdown": LocalJSX.IntrinsicElements["ix-date-dropdown"] & JSXBase.HTMLAttributes<HTMLIxDateDropdownElement>;
             /**
-             * @form-ready
+             * @form-ready 
              */
             "ix-date-input": LocalJSX.IntrinsicElements["ix-date-input"] & JSXBase.HTMLAttributes<HTMLIxDateInputElement>;
             "ix-date-picker": LocalJSX.IntrinsicElements["ix-date-picker"] & JSXBase.HTMLAttributes<HTMLIxDatePickerElement>;
             "ix-date-time-card": LocalJSX.IntrinsicElements["ix-date-time-card"] & JSXBase.HTMLAttributes<HTMLIxDateTimeCardElement>;
             /**
              * @since 5.0.0
-             * @form-ready
+             * @form-ready 
              */
             "ix-datetime-input": LocalJSX.IntrinsicElements["ix-datetime-input"] & JSXBase.HTMLAttributes<HTMLIxDatetimeInputElement>;
             "ix-datetime-picker": LocalJSX.IntrinsicElements["ix-datetime-picker"] & JSXBase.HTMLAttributes<HTMLIxDatetimePickerElement>;
@@ -12359,7 +12361,7 @@ declare module "@stencil/core" {
             "ix-icon-button": LocalJSX.IntrinsicElements["ix-icon-button"] & JSXBase.HTMLAttributes<HTMLIxIconButtonElement>;
             "ix-icon-toggle-button": LocalJSX.IntrinsicElements["ix-icon-toggle-button"] & JSXBase.HTMLAttributes<HTMLIxIconToggleButtonElement>;
             /**
-             * @form-ready
+             * @form-ready 
              */
             "ix-input": LocalJSX.IntrinsicElements["ix-input"] & JSXBase.HTMLAttributes<HTMLIxInputElement>;
             "ix-key-value": LocalJSX.IntrinsicElements["ix-key-value"] & JSXBase.HTMLAttributes<HTMLIxKeyValueElement>;
@@ -12392,7 +12394,7 @@ declare module "@stencil/core" {
             "ix-modal-header": LocalJSX.IntrinsicElements["ix-modal-header"] & JSXBase.HTMLAttributes<HTMLIxModalHeaderElement>;
             "ix-modal-loading": LocalJSX.IntrinsicElements["ix-modal-loading"] & JSXBase.HTMLAttributes<HTMLIxModalLoadingElement>;
             /**
-             * @form-ready
+             * @form-ready 
              */
             "ix-number-input": LocalJSX.IntrinsicElements["ix-number-input"] & JSXBase.HTMLAttributes<HTMLIxNumberInputElement>;
             "ix-pagination": LocalJSX.IntrinsicElements["ix-pagination"] & JSXBase.HTMLAttributes<HTMLIxPaginationElement>;
@@ -12405,22 +12407,22 @@ declare module "@stencil/core" {
             "ix-progress-indicator": LocalJSX.IntrinsicElements["ix-progress-indicator"] & JSXBase.HTMLAttributes<HTMLIxProgressIndicatorElement>;
             "ix-push-card": LocalJSX.IntrinsicElements["ix-push-card"] & JSXBase.HTMLAttributes<HTMLIxPushCardElement>;
             /**
-             * @form-ready
+             * @form-ready 
              */
             "ix-radio": LocalJSX.IntrinsicElements["ix-radio"] & JSXBase.HTMLAttributes<HTMLIxRadioElement>;
             /**
-             * @form-ready
+             * @form-ready 
              */
             "ix-radio-group": LocalJSX.IntrinsicElements["ix-radio-group"] & JSXBase.HTMLAttributes<HTMLIxRadioGroupElement>;
             "ix-range-field": LocalJSX.IntrinsicElements["ix-range-field"] & JSXBase.HTMLAttributes<HTMLIxRangeFieldElement>;
             "ix-row": LocalJSX.IntrinsicElements["ix-row"] & JSXBase.HTMLAttributes<HTMLIxRowElement>;
             /**
-             * @form-ready
+             * @form-ready 
              */
             "ix-select": LocalJSX.IntrinsicElements["ix-select"] & JSXBase.HTMLAttributes<HTMLIxSelectElement>;
             "ix-select-item": LocalJSX.IntrinsicElements["ix-select-item"] & JSXBase.HTMLAttributes<HTMLIxSelectItemElement>;
             /**
-             * @form-ready
+             * @form-ready 
              */
             "ix-slider": LocalJSX.IntrinsicElements["ix-slider"] & JSXBase.HTMLAttributes<HTMLIxSliderElement>;
             "ix-spinner": LocalJSX.IntrinsicElements["ix-spinner"] & JSXBase.HTMLAttributes<HTMLIxSpinnerElement>;
@@ -12436,20 +12438,20 @@ declare module "@stencil/core" {
             "ix-tab-set": LocalJSX.IntrinsicElements["ix-tab-set"] & JSXBase.HTMLAttributes<HTMLIxTabSetElement>;
             "ix-tabs": LocalJSX.IntrinsicElements["ix-tabs"] & JSXBase.HTMLAttributes<HTMLIxTabsElement>;
             /**
-             * @form-ready
+             * @form-ready 
              */
             "ix-textarea": LocalJSX.IntrinsicElements["ix-textarea"] & JSXBase.HTMLAttributes<HTMLIxTextareaElement>;
             "ix-tile": LocalJSX.IntrinsicElements["ix-tile"] & JSXBase.HTMLAttributes<HTMLIxTileElement>;
             /**
              * @since 3.2.0
-             * @form-ready
+             * @form-ready 
              */
             "ix-time-input": LocalJSX.IntrinsicElements["ix-time-input"] & JSXBase.HTMLAttributes<HTMLIxTimeInputElement>;
             "ix-time-picker": LocalJSX.IntrinsicElements["ix-time-picker"] & JSXBase.HTMLAttributes<HTMLIxTimePickerElement>;
             "ix-toast": LocalJSX.IntrinsicElements["ix-toast"] & JSXBase.HTMLAttributes<HTMLIxToastElement>;
             "ix-toast-container": LocalJSX.IntrinsicElements["ix-toast-container"] & JSXBase.HTMLAttributes<HTMLIxToastContainerElement>;
             /**
-             * @form-ready
+             * @form-ready 
              */
             "ix-toggle": LocalJSX.IntrinsicElements["ix-toggle"] & JSXBase.HTMLAttributes<HTMLIxToggleElement>;
             "ix-toggle-button": LocalJSX.IntrinsicElements["ix-toggle-button"] & JSXBase.HTMLAttributes<HTMLIxToggleButtonElement>;

--- a/packages/core/src/components/pane/pane.scss
+++ b/packages/core/src/components/pane/pane.scss
@@ -187,6 +187,11 @@
     overflow: auto;
     height: 100%;
     width: 100%;
+
+    &.no-padding {
+      padding-inline: 0;
+      padding-block-end: 0;
+    }
   }
 
   .slot-header {

--- a/packages/core/src/components/pane/pane.tsx
+++ b/packages/core/src/components/pane/pane.tsx
@@ -94,6 +94,8 @@ export class Pane {
   /**
    * Remove the padding of the content area.
    * If set to `true` the left, right and bottom padding of the content area is removed.
+   *
+   * @since 5.1.0
    */
   @Prop() noPadding: boolean = false;
 

--- a/packages/core/src/components/pane/pane.tsx
+++ b/packages/core/src/components/pane/pane.tsx
@@ -92,6 +92,12 @@ export class Pane {
   @Prop() borderless: boolean = false;
 
   /**
+   * Remove the padding of the content area.
+   * If set to `true` the left, right and bottom padding of the content area is removed. The title always keeps its padding.
+   */
+  @Prop() noPadding: boolean = false;
+
+  /**
    * State of the pane
    */
   @Prop({ mutable: true }) expanded: boolean = false;
@@ -808,7 +814,13 @@ export class Pane {
               )}
             </div>
           </div>
-          <div class="side-pane-content" hidden={!this.showContent}>
+          <div
+            class={{
+              'side-pane-content': true,
+              'no-padding': this.noPadding,
+            }}
+            hidden={!this.showContent}
+          >
             <slot></slot>
           </div>
         </aside>

--- a/packages/core/src/components/pane/pane.tsx
+++ b/packages/core/src/components/pane/pane.tsx
@@ -93,7 +93,7 @@ export class Pane {
 
   /**
    * Remove the padding of the content area.
-   * If set to `true` the left, right and bottom padding of the content area is removed. The title always keeps its padding.
+   * If set to `true` the left, right and bottom padding of the content area is removed.
    */
   @Prop() noPadding: boolean = false;
 

--- a/packages/core/src/components/pane/test/panes.ct.ts
+++ b/packages/core/src/components/pane/test/panes.ct.ts
@@ -38,6 +38,43 @@ regressionTest('expanded', async ({ mount, page }) => {
   await expect(title).toBeVisible();
 });
 
+regressionTest(
+  'no-padding removes content padding except top',
+  async ({ mount, page }) => {
+    await mount(`
+    <ix-pane
+      heading="LEFT"
+      composition="left"
+      expanded="true"
+      no-padding="true"
+    >
+      <h1>Test Heading</h1>
+    </ix-pane>
+  `);
+
+    const pane = page.locator('ix-pane');
+    await expect(pane).toHaveClass(/hydrated/);
+
+    const content = pane.locator('.side-pane-content');
+    await expect(content).toHaveClass(/no-padding/);
+
+    const padding = await content.evaluate((el) => {
+      const style = getComputedStyle(el);
+      return {
+        left: style.paddingLeft,
+        right: style.paddingRight,
+        bottom: style.paddingBottom,
+        top: style.paddingTop,
+      };
+    });
+
+    expect(padding.left).toBe('0px');
+    expect(padding.right).toBe('0px');
+    expect(padding.bottom).toBe('0px');
+    expect(padding.top).not.toBe('0px');
+  }
+);
+
 regressionTest('prevent pane expansion', async ({ mount, page }) => {
   await mount(
     `

--- a/packages/react/src/components/components.server.ts
+++ b/packages/react/src/components/components.server.ts
@@ -130,7 +130,7 @@ export const IxActionCard: StencilReactComponent<IxActionCardElement, IxActionCa
         ariaLabelCard: 'aria-label-card',
         passive: 'passive'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxActionCard as StencilReactComponent<IxActionCardElement, IxActionCardEvents, Components.IxActionCard>,
     serializeShadowRoot
 });
@@ -144,7 +144,7 @@ export const IxApplication: StencilReactComponent<IxApplicationElement, IxApplic
         colorSchema: 'color-schema',
         forceBreakpoint: 'force-breakpoint'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxApplication as StencilReactComponent<IxApplicationElement, IxApplicationEvents, Components.IxApplication>,
     serializeShadowRoot
 });
@@ -170,7 +170,7 @@ export const IxApplicationHeader: StencilReactComponent<IxApplicationHeaderEleme
         ariaLabelMoreMenuIconButton: 'aria-label-more-menu-icon-button',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxApplicationHeader as StencilReactComponent<IxApplicationHeaderElement, IxApplicationHeaderEvents, Components.IxApplicationHeader>,
     serializeShadowRoot
 });
@@ -187,7 +187,7 @@ export const IxAvatar: StencilReactComponent<IxAvatarElement, IxAvatarEvents, Co
         tooltipText: 'tooltip-text',
         ariaLabelTooltip: 'aria-label-tooltip'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxAvatar as StencilReactComponent<IxAvatarElement, IxAvatarEvents, Components.IxAvatar>,
     serializeShadowRoot
 });
@@ -203,7 +203,7 @@ export const IxBlind: StencilReactComponent<IxBlindElement, IxBlindEvents, Compo
         icon: 'icon',
         variant: 'variant'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxBlind as StencilReactComponent<IxBlindElement, IxBlindEvents, Components.IxBlind>,
     serializeShadowRoot
 });
@@ -221,7 +221,7 @@ export const IxBreadcrumb: StencilReactComponent<IxBreadcrumbElement, IxBreadcru
         ariaLabelPreviousButton: 'aria-label-previous-button',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxBreadcrumb as StencilReactComponent<IxBreadcrumbElement, IxBreadcrumbEvents, Components.IxBreadcrumb>,
     serializeShadowRoot
 });
@@ -243,7 +243,7 @@ export const IxBreadcrumbItem: StencilReactComponent<IxBreadcrumbItemElement, Ix
         isDropdownTrigger: 'is-dropdown-trigger',
         isCurrentPage: 'is-current-page'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxBreadcrumbItem as StencilReactComponent<IxBreadcrumbItemElement, IxBreadcrumbItemEvents, Components.IxBreadcrumbItem>,
     serializeShadowRoot
 });
@@ -266,7 +266,7 @@ export const IxButton: StencilReactComponent<IxButtonElement, IxButtonEvents, Co
         target: 'target',
         rel: 'rel'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxButton as StencilReactComponent<IxButtonElement, IxButtonEvents, Components.IxButton>,
     serializeShadowRoot
 });
@@ -280,7 +280,7 @@ export const IxCard: StencilReactComponent<IxCardElement, IxCardEvents, Componen
         selected: 'selected',
         passive: 'passive'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxCard as StencilReactComponent<IxCardElement, IxCardEvents, Components.IxCard>,
     serializeShadowRoot
 });
@@ -294,7 +294,7 @@ export const IxCardAccordion: StencilReactComponent<IxCardAccordionElement, IxCa
         collapse: 'collapse',
         variant: 'variant'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxCardAccordion as StencilReactComponent<IxCardAccordionElement, IxCardAccordionEvents, Components.IxCardAccordion>,
     serializeShadowRoot
 });
@@ -304,7 +304,7 @@ export type IxCardContentEvents = NonNullable<unknown>;
 export const IxCardContent: StencilReactComponent<IxCardContentElement, IxCardContentEvents, Components.IxCardContent> = /*@__PURE__*/ createComponent<IxCardContentElement, IxCardContentEvents, Components.IxCardContent>({
     tagName: 'ix-card-content',
     properties: {},
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxCardContent as StencilReactComponent<IxCardContentElement, IxCardContentEvents, Components.IxCardContent>,
     serializeShadowRoot
 });
@@ -330,7 +330,7 @@ export const IxCardList: StencilReactComponent<IxCardListElement, IxCardListEven
         i18nShowLess: 'i18n-show-less',
         i18nMoreCards: 'i18n-more-cards'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxCardList as StencilReactComponent<IxCardListElement, IxCardListEvents, Components.IxCardList>,
     serializeShadowRoot
 });
@@ -340,7 +340,7 @@ export type IxCardTitleEvents = NonNullable<unknown>;
 export const IxCardTitle: StencilReactComponent<IxCardTitleElement, IxCardTitleEvents, Components.IxCardTitle> = /*@__PURE__*/ createComponent<IxCardTitleElement, IxCardTitleEvents, Components.IxCardTitle>({
     tagName: 'ix-card-title',
     properties: {},
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxCardTitle as StencilReactComponent<IxCardTitleElement, IxCardTitleEvents, Components.IxCardTitle>,
     serializeShadowRoot
 });
@@ -369,7 +369,7 @@ export const IxCategoryFilter: StencilReactComponent<IxCategoryFilterElement, Ix
         ariaLabelFilterInput: 'aria-label-filter-input',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxCategoryFilter as StencilReactComponent<IxCategoryFilterElement, IxCategoryFilterEvents, Components.IxCategoryFilter>,
     serializeShadowRoot
 });
@@ -391,7 +391,7 @@ export const IxCheckbox: StencilReactComponent<IxCheckboxElement, IxCheckboxEven
         indeterminate: 'indeterminate',
         required: 'required'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxCheckbox as StencilReactComponent<IxCheckboxElement, IxCheckboxEvents, Components.IxCheckbox>,
     serializeShadowRoot
 });
@@ -411,7 +411,7 @@ export const IxCheckboxGroup: StencilReactComponent<IxCheckboxGroupElement, IxCh
         showTextAsTooltip: 'show-text-as-tooltip',
         required: 'required'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxCheckboxGroup as StencilReactComponent<IxCheckboxGroupElement, IxCheckboxGroupEvents, Components.IxCheckboxGroup>,
     serializeShadowRoot
 });
@@ -433,7 +433,7 @@ export const IxChip: StencilReactComponent<IxChipElement, IxChipEvents, Componen
         centerContent: 'center-content',
         ariaLabelCloseButton: 'aria-label-close-button'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxChip as StencilReactComponent<IxChipElement, IxChipEvents, Components.IxChip>,
     serializeShadowRoot
 });
@@ -448,7 +448,7 @@ export const IxCol: StencilReactComponent<IxColElement, IxColEvents, Components.
         sizeMd: 'size-md',
         sizeLg: 'size-lg'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxCol as StencilReactComponent<IxColElement, IxColEvents, Components.IxCol>,
     serializeShadowRoot
 });
@@ -458,7 +458,7 @@ export type IxContentEvents = NonNullable<unknown>;
 export const IxContent: StencilReactComponent<IxContentElement, IxContentEvents, Components.IxContent> = /*@__PURE__*/ createComponent<IxContentElement, IxContentEvents, Components.IxContent>({
     tagName: 'ix-content',
     properties: {},
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxContent as StencilReactComponent<IxContentElement, IxContentEvents, Components.IxContent>,
     serializeShadowRoot
 });
@@ -473,7 +473,7 @@ export const IxContentHeader: StencilReactComponent<IxContentHeaderElement, IxCo
         headerSubtitle: 'header-subtitle',
         hasBackButton: 'has-back-button'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxContentHeader as StencilReactComponent<IxContentHeaderElement, IxContentHeaderEvents, Components.IxContentHeader>,
     serializeShadowRoot
 });
@@ -492,7 +492,7 @@ export const IxCustomField: StencilReactComponent<IxCustomFieldElement, IxCustom
         validText: 'valid-text',
         showTextAsTooltip: 'show-text-as-tooltip'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxCustomField as StencilReactComponent<IxCustomFieldElement, IxCustomFieldEvents, Components.IxCustomField>,
     serializeShadowRoot
 });
@@ -520,7 +520,7 @@ export const IxDateDropdown: StencilReactComponent<IxDateDropdownElement, IxDate
         today: 'today',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxDateDropdown as StencilReactComponent<IxDateDropdownElement, IxDateDropdownEvents, Components.IxDateDropdown>,
     serializeShadowRoot
 });
@@ -561,7 +561,7 @@ export const IxDateInput: StencilReactComponent<IxDateInputElement, IxDateInputE
         textAlignment: 'text-alignment',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxDateInput as StencilReactComponent<IxDateInputElement, IxDateInputEvents, Components.IxDateInput>,
     serializeShadowRoot
 });
@@ -594,7 +594,7 @@ export const IxDatePicker: StencilReactComponent<IxDatePickerElement, IxDatePick
         today: 'today',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxDatePicker as StencilReactComponent<IxDatePickerElement, IxDatePickerEvents, Components.IxDatePicker>,
     serializeShadowRoot
 });
@@ -641,7 +641,7 @@ export const IxDatetimeInput: StencilReactComponent<IxDatetimeInputElement, IxDa
         textAlignment: 'text-alignment',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxDatetimeInput as StencilReactComponent<IxDatetimeInputElement, IxDatetimeInputEvents, Components.IxDatetimeInput>,
     serializeShadowRoot
 });
@@ -676,7 +676,7 @@ export const IxDatetimePicker: StencilReactComponent<IxDatetimePickerElement, Ix
         showWeekNumbers: 'show-week-numbers',
         embedded: 'embedded'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxDatetimePicker as StencilReactComponent<IxDatetimePickerElement, IxDatetimePickerEvents, Components.IxDatetimePicker>,
     serializeShadowRoot
 });
@@ -686,7 +686,7 @@ export type IxDividerEvents = NonNullable<unknown>;
 export const IxDivider: StencilReactComponent<IxDividerElement, IxDividerEvents, Components.IxDivider> = /*@__PURE__*/ createComponent<IxDividerElement, IxDividerEvents, Components.IxDivider>({
     tagName: 'ix-divider',
     properties: {},
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxDivider as StencilReactComponent<IxDividerElement, IxDividerEvents, Components.IxDivider>,
     serializeShadowRoot
 });
@@ -717,7 +717,7 @@ export const IxDropdown: StencilReactComponent<IxDropdownElement, IxDropdownEven
         suppressOverflowBehavior: 'suppress-overflow-behavior',
         hostRole: 'host-role'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxDropdown as StencilReactComponent<IxDropdownElement, IxDropdownEvents, Components.IxDropdown>,
     serializeShadowRoot
 });
@@ -741,7 +741,7 @@ export const IxDropdownButton: StencilReactComponent<IxDropdownButtonElement, Ix
         enableTopLayer: 'enable-top-layer',
         suppressAriaActiveDescendant: 'suppress-aria-active-descendant'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxDropdownButton as StencilReactComponent<IxDropdownButtonElement, IxDropdownButtonEvents, Components.IxDropdownButton>,
     serializeShadowRoot
 });
@@ -751,7 +751,7 @@ export type IxDropdownHeaderEvents = NonNullable<unknown>;
 export const IxDropdownHeader: StencilReactComponent<IxDropdownHeaderElement, IxDropdownHeaderEvents, Components.IxDropdownHeader> = /*@__PURE__*/ createComponent<IxDropdownHeaderElement, IxDropdownHeaderEvents, Components.IxDropdownHeader>({
     tagName: 'ix-dropdown-header',
     properties: { label: 'label' },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxDropdownHeader as StencilReactComponent<IxDropdownHeaderElement, IxDropdownHeaderEvents, Components.IxDropdownHeader>,
     serializeShadowRoot
 });
@@ -775,7 +775,7 @@ export const IxDropdownItem: StencilReactComponent<IxDropdownItemElement, IxDrop
         suppressChecked: 'suppress-checked',
         hasVisualFocus: 'has-visual-focus'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxDropdownItem as StencilReactComponent<IxDropdownItemElement, IxDropdownItemEvents, Components.IxDropdownItem>,
     serializeShadowRoot
 });
@@ -785,7 +785,7 @@ export type IxDropdownQuickActionsEvents = NonNullable<unknown>;
 export const IxDropdownQuickActions: StencilReactComponent<IxDropdownQuickActionsElement, IxDropdownQuickActionsEvents, Components.IxDropdownQuickActions> = /*@__PURE__*/ createComponent<IxDropdownQuickActionsElement, IxDropdownQuickActionsEvents, Components.IxDropdownQuickActions>({
     tagName: 'ix-dropdown-quick-actions',
     properties: {},
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxDropdownQuickActions as StencilReactComponent<IxDropdownQuickActionsElement, IxDropdownQuickActionsEvents, Components.IxDropdownQuickActions>,
     serializeShadowRoot
 });
@@ -802,7 +802,7 @@ export const IxEmptyState: StencilReactComponent<IxEmptyStateElement, IxEmptySta
         action: 'action',
         ariaLabelEmptyStateIcon: 'aria-label-empty-state-icon'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxEmptyState as StencilReactComponent<IxEmptyStateElement, IxEmptyStateEvents, Components.IxEmptyState>,
     serializeShadowRoot
 });
@@ -817,7 +817,7 @@ export const IxEventList: StencilReactComponent<IxEventListElement, IxEventListE
         animated: 'animated',
         chevron: 'chevron'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxEventList as StencilReactComponent<IxEventListElement, IxEventListEvents, Components.IxEventList>,
     serializeShadowRoot
 });
@@ -833,7 +833,7 @@ export const IxEventListItem: StencilReactComponent<IxEventListItemElement, IxEv
         disabled: 'disabled',
         chevron: 'chevron'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxEventListItem as StencilReactComponent<IxEventListItemElement, IxEventListItemEvents, Components.IxEventListItem>,
     serializeShadowRoot
 });
@@ -852,7 +852,7 @@ export const IxExpandingSearch: StencilReactComponent<IxExpandingSearchElement, 
         ariaLabelClearIconButton: 'aria-label-clear-icon-button',
         ariaLabelSearchInput: 'aria-label-search-input'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxExpandingSearch as StencilReactComponent<IxExpandingSearchElement, IxExpandingSearchEvents, Components.IxExpandingSearch>,
     serializeShadowRoot
 });
@@ -866,7 +866,7 @@ export const IxFieldLabel: StencilReactComponent<IxFieldLabelElement, IxFieldLab
         htmlFor: 'html-for',
         isInvalid: 'is-invalid'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxFieldLabel as StencilReactComponent<IxFieldLabelElement, IxFieldLabelEvents, Components.IxFieldLabel>,
     serializeShadowRoot
 });
@@ -880,7 +880,7 @@ export const IxFilterChip: StencilReactComponent<IxFilterChipElement, IxFilterCh
         readonly: 'readonly',
         ariaLabelCloseIconButton: 'aria-label-close-icon-button'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxFilterChip as StencilReactComponent<IxFilterChipElement, IxFilterChipEvents, Components.IxFilterChip>,
     serializeShadowRoot
 });
@@ -896,7 +896,7 @@ export const IxFlipTile: StencilReactComponent<IxFlipTileElement, IxFlipTileEven
         index: 'index',
         ariaLabelEyeIconButton: 'aria-label-eye-icon-button'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxFlipTile as StencilReactComponent<IxFlipTileElement, IxFlipTileEvents, Components.IxFlipTile>,
     serializeShadowRoot
 });
@@ -906,7 +906,7 @@ export type IxFlipTileContentEvents = NonNullable<unknown>;
 export const IxFlipTileContent: StencilReactComponent<IxFlipTileContentElement, IxFlipTileContentEvents, Components.IxFlipTileContent> = /*@__PURE__*/ createComponent<IxFlipTileContentElement, IxFlipTileContentEvents, Components.IxFlipTileContent>({
     tagName: 'ix-flip-tile-content',
     properties: { contentVisible: 'content-visible' },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxFlipTileContent as StencilReactComponent<IxFlipTileContentElement, IxFlipTileContentEvents, Components.IxFlipTileContent>,
     serializeShadowRoot
 });
@@ -928,7 +928,7 @@ export const IxGroup: StencilReactComponent<IxGroupElement, IxGroupEvents, Compo
         index: 'index',
         expandOnHeaderClick: 'expand-on-header-click'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxGroup as StencilReactComponent<IxGroupElement, IxGroupEvents, Components.IxGroup>,
     serializeShadowRoot
 });
@@ -938,7 +938,7 @@ export type IxGroupContextMenuEvents = NonNullable<unknown>;
 export const IxGroupContextMenu: StencilReactComponent<IxGroupContextMenuElement, IxGroupContextMenuEvents, Components.IxGroupContextMenu> = /*@__PURE__*/ createComponent<IxGroupContextMenuElement, IxGroupContextMenuEvents, Components.IxGroupContextMenu>({
     tagName: 'ix-group-context-menu',
     properties: {},
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxGroupContextMenu as StencilReactComponent<IxGroupContextMenuElement, IxGroupContextMenuEvents, Components.IxGroupContextMenu>,
     serializeShadowRoot
 });
@@ -958,7 +958,7 @@ export const IxGroupItem: StencilReactComponent<IxGroupItemElement, IxGroupItemE
         disabled: 'disabled',
         index: 'index'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxGroupItem as StencilReactComponent<IxGroupItemElement, IxGroupItemEvents, Components.IxGroupItem>,
     serializeShadowRoot
 });
@@ -975,7 +975,7 @@ export const IxHelperText: StencilReactComponent<IxHelperTextElement, IxHelperTe
         infoText: 'info-text',
         warningText: 'warning-text'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxHelperText as StencilReactComponent<IxHelperTextElement, IxHelperTextEvents, Components.IxHelperText>,
     serializeShadowRoot
 });
@@ -994,7 +994,7 @@ export const IxIconButton: StencilReactComponent<IxIconButtonElement, IxIconButt
         type: 'type',
         loading: 'loading'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxIconButton as StencilReactComponent<IxIconButtonElement, IxIconButtonEvents, Components.IxIconButton>,
     serializeShadowRoot
 });
@@ -1014,7 +1014,7 @@ export const IxIconToggleButton: StencilReactComponent<IxIconToggleButtonElement
         disabled: 'disabled',
         loading: 'loading'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxIconToggleButton as StencilReactComponent<IxIconToggleButtonElement, IxIconToggleButtonEvents, Components.IxIconToggleButton>,
     serializeShadowRoot
 });
@@ -1050,7 +1050,7 @@ export const IxInput: StencilReactComponent<IxInputElement, IxInputEvents, Compo
         suppressSubmitOnEnter: 'suppress-submit-on-enter',
         textAlignment: 'text-alignment'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxInput as StencilReactComponent<IxInputElement, IxInputEvents, Components.IxInput>,
     serializeShadowRoot
 });
@@ -1066,7 +1066,7 @@ export const IxKeyValue: StencilReactComponent<IxKeyValueElement, IxKeyValueEven
         labelPosition: 'label-position',
         value: 'value'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxKeyValue as StencilReactComponent<IxKeyValueElement, IxKeyValueEvents, Components.IxKeyValue>,
     serializeShadowRoot
 });
@@ -1076,7 +1076,7 @@ export type IxKeyValueListEvents = NonNullable<unknown>;
 export const IxKeyValueList: StencilReactComponent<IxKeyValueListElement, IxKeyValueListEvents, Components.IxKeyValueList> = /*@__PURE__*/ createComponent<IxKeyValueListElement, IxKeyValueListEvents, Components.IxKeyValueList>({
     tagName: 'ix-key-value-list',
     properties: { striped: 'striped' },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxKeyValueList as StencilReactComponent<IxKeyValueListElement, IxKeyValueListEvents, Components.IxKeyValueList>,
     serializeShadowRoot
 });
@@ -1094,7 +1094,7 @@ export const IxKpi: StencilReactComponent<IxKpiElement, IxKpiEvents, Components.
         state: 'state',
         orientation: 'orientation'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxKpi as StencilReactComponent<IxKpiElement, IxKpiEvents, Components.IxKpi>,
     serializeShadowRoot
 });
@@ -1104,7 +1104,7 @@ export type IxLayoutAutoEvents = NonNullable<unknown>;
 export const IxLayoutAuto: StencilReactComponent<IxLayoutAutoElement, IxLayoutAutoEvents, Components.IxLayoutAuto> = /*@__PURE__*/ createComponent<IxLayoutAutoElement, IxLayoutAutoEvents, Components.IxLayoutAuto>({
     tagName: 'ix-layout-auto',
     properties: {},
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxLayoutAuto as StencilReactComponent<IxLayoutAutoElement, IxLayoutAutoEvents, Components.IxLayoutAuto>,
     serializeShadowRoot
 });
@@ -1118,7 +1118,7 @@ export const IxLayoutGrid: StencilReactComponent<IxLayoutGridElement, IxLayoutGr
         gap: 'gap',
         columns: 'columns'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxLayoutGrid as StencilReactComponent<IxLayoutGridElement, IxLayoutGridEvents, Components.IxLayoutGrid>,
     serializeShadowRoot
 });
@@ -1132,7 +1132,7 @@ export const IxLinkButton: StencilReactComponent<IxLinkButtonElement, IxLinkButt
         url: 'url',
         target: 'target'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxLinkButton as StencilReactComponent<IxLinkButtonElement, IxLinkButtonEvents, Components.IxLinkButton>,
     serializeShadowRoot
 });
@@ -1162,7 +1162,7 @@ export const IxMenu: StencilReactComponent<IxMenuElement, IxMenuEvents, Componen
         i18nExpand: 'i18n-expand',
         i18nCollapse: 'i18n-collapse'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxMenu as StencilReactComponent<IxMenuElement, IxMenuEvents, Components.IxMenu>,
     serializeShadowRoot
 });
@@ -1181,7 +1181,7 @@ export const IxMenuAbout: StencilReactComponent<IxMenuAboutElement, IxMenuAboutE
         ariaLabelCloseButton: 'aria-label-close-button',
         show: 'show'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxMenuAbout as StencilReactComponent<IxMenuAboutElement, IxMenuAboutEvents, Components.IxMenuAbout>,
     serializeShadowRoot
 });
@@ -1194,7 +1194,7 @@ export const IxMenuAboutItem: StencilReactComponent<IxMenuAboutItemElement, IxMe
         tabKey: 'tab-key',
         label: 'label'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxMenuAboutItem as StencilReactComponent<IxMenuAboutItemElement, IxMenuAboutItemEvents, Components.IxMenuAboutItem>,
     serializeShadowRoot
 });
@@ -1214,7 +1214,7 @@ export const IxMenuAboutNews: StencilReactComponent<IxMenuAboutNewsElement, IxMe
         activeAboutTabKey: 'active-about-tab-key',
         expanded: 'expanded'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxMenuAboutNews as StencilReactComponent<IxMenuAboutNewsElement, IxMenuAboutNewsEvents, Components.IxMenuAboutNews>,
     serializeShadowRoot
 });
@@ -1234,7 +1234,7 @@ export const IxMenuAvatar: StencilReactComponent<IxMenuAvatarElement, IxMenuAvat
         hideLogoutButton: 'hide-logout-button',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxMenuAvatar as StencilReactComponent<IxMenuAvatarElement, IxMenuAvatarEvents, Components.IxMenuAvatar>,
     serializeShadowRoot
 });
@@ -1247,7 +1247,7 @@ export const IxMenuAvatarItem: StencilReactComponent<IxMenuAvatarItemElement, Ix
         icon: 'icon',
         label: 'label'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxMenuAvatarItem as StencilReactComponent<IxMenuAvatarItemElement, IxMenuAvatarItemEvents, Components.IxMenuAvatarItem>,
     serializeShadowRoot
 });
@@ -1262,7 +1262,7 @@ export const IxMenuCategory: StencilReactComponent<IxMenuCategoryElement, IxMenu
         notifications: 'notifications',
         tooltipText: 'tooltip-text'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxMenuCategory as StencilReactComponent<IxMenuCategoryElement, IxMenuCategoryEvents, Components.IxMenuCategory>,
     serializeShadowRoot
 });
@@ -1285,7 +1285,7 @@ export const IxMenuItem: StencilReactComponent<IxMenuItemElement, IxMenuItemEven
         rel: 'rel',
         isCategory: 'is-category'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxMenuItem as StencilReactComponent<IxMenuItemElement, IxMenuItemEvents, Components.IxMenuItem>,
     serializeShadowRoot
 });
@@ -1304,7 +1304,7 @@ export const IxMenuSettings: StencilReactComponent<IxMenuSettingsElement, IxMenu
         ariaLabelCloseButton: 'aria-label-close-button',
         show: 'show'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxMenuSettings as StencilReactComponent<IxMenuSettingsElement, IxMenuSettingsEvents, Components.IxMenuSettings>,
     serializeShadowRoot
 });
@@ -1317,7 +1317,7 @@ export const IxMenuSettingsItem: StencilReactComponent<IxMenuSettingsItemElement
         tabKey: 'tab-key',
         label: 'label'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxMenuSettingsItem as StencilReactComponent<IxMenuSettingsItemElement, IxMenuSettingsItemEvents, Components.IxMenuSettingsItem>,
     serializeShadowRoot
 });
@@ -1333,7 +1333,7 @@ export const IxMessageBar: StencilReactComponent<IxMessageBarElement, IxMessageB
         type: 'type',
         persistent: 'persistent'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxMessageBar as StencilReactComponent<IxMessageBarElement, IxMessageBarEvents, Components.IxMessageBar>,
     serializeShadowRoot
 });
@@ -1353,7 +1353,7 @@ export const IxModal: StencilReactComponent<IxModalElement, IxModalEvents, Compo
         centered: 'centered',
         isNonBlocking: 'is-non-blocking'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxModal as StencilReactComponent<IxModalElement, IxModalEvents, Components.IxModal>,
     serializeShadowRoot
 });
@@ -1363,7 +1363,7 @@ export type IxModalContentEvents = NonNullable<unknown>;
 export const IxModalContent: StencilReactComponent<IxModalContentElement, IxModalContentEvents, Components.IxModalContent> = /*@__PURE__*/ createComponent<IxModalContentElement, IxModalContentEvents, Components.IxModalContent>({
     tagName: 'ix-modal-content',
     properties: {},
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxModalContent as StencilReactComponent<IxModalContentElement, IxModalContentEvents, Components.IxModalContent>,
     serializeShadowRoot
 });
@@ -1373,7 +1373,7 @@ export type IxModalFooterEvents = NonNullable<unknown>;
 export const IxModalFooter: StencilReactComponent<IxModalFooterElement, IxModalFooterEvents, Components.IxModalFooter> = /*@__PURE__*/ createComponent<IxModalFooterElement, IxModalFooterEvents, Components.IxModalFooter>({
     tagName: 'ix-modal-footer',
     properties: {},
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxModalFooter as StencilReactComponent<IxModalFooterElement, IxModalFooterEvents, Components.IxModalFooter>,
     serializeShadowRoot
 });
@@ -1389,7 +1389,7 @@ export const IxModalHeader: StencilReactComponent<IxModalHeaderElement, IxModalH
         ariaLabelCloseIconButton: 'aria-label-close-icon-button',
         iconColor: 'icon-color'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxModalHeader as StencilReactComponent<IxModalHeaderElement, IxModalHeaderEvents, Components.IxModalHeader>,
     serializeShadowRoot
 });
@@ -1427,7 +1427,7 @@ export const IxNumberInput: StencilReactComponent<IxNumberInputElement, IxNumber
         textAlignment: 'text-alignment',
         allowEmptyValueChange: 'allow-empty-value-change'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxNumberInput as StencilReactComponent<IxNumberInputElement, IxNumberInputEvents, Components.IxNumberInput>,
     serializeShadowRoot
 });
@@ -1452,7 +1452,7 @@ export const IxPagination: StencilReactComponent<IxPaginationElement, IxPaginati
         ariaLabelChevronRightIconButton: 'aria-label-chevron-right-icon-button',
         ariaLabelPageSelection: 'aria-label-page-selection'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxPagination as StencilReactComponent<IxPaginationElement, IxPaginationEvents, Components.IxPagination>,
     serializeShadowRoot
 });
@@ -1481,7 +1481,7 @@ export const IxPane: StencilReactComponent<IxPaneElement, IxPaneEvents, Componen
         ignoreLayoutSettings: 'ignore-layout-settings',
         isMobile: 'is-mobile'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxPane as StencilReactComponent<IxPaneElement, IxPaneEvents, Components.IxPane>,
     serializeShadowRoot
 });
@@ -1495,7 +1495,7 @@ export const IxPaneLayout: StencilReactComponent<IxPaneLayoutElement, IxPaneLayo
         variant: 'variant',
         borderless: 'borderless'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxPaneLayout as StencilReactComponent<IxPaneLayoutElement, IxPaneLayoutEvents, Components.IxPaneLayout>,
     serializeShadowRoot
 });
@@ -1514,7 +1514,7 @@ export const IxPill: StencilReactComponent<IxPillElement, IxPillEvents, Componen
         alignLeft: 'align-left',
         tooltipText: 'tooltip-text'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxPill as StencilReactComponent<IxPillElement, IxPillEvents, Components.IxPill>,
     serializeShadowRoot
 });
@@ -1535,7 +1535,7 @@ export const IxProgressIndicator: StencilReactComponent<IxProgressIndicatorEleme
         textAlignment: 'text-alignment',
         showTextAsTooltip: 'show-text-as-tooltip'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxProgressIndicator as StencilReactComponent<IxProgressIndicatorElement, IxProgressIndicatorEvents, Components.IxProgressIndicator>,
     serializeShadowRoot
 });
@@ -1554,7 +1554,7 @@ export const IxPushCard: StencilReactComponent<IxPushCardElement, IxPushCardEven
         expanded: 'expanded',
         passive: 'passive'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxPushCard as StencilReactComponent<IxPushCardElement, IxPushCardEvents, Components.IxPushCard>,
     serializeShadowRoot
 });
@@ -1575,7 +1575,7 @@ export const IxRadio: StencilReactComponent<IxRadioElement, IxRadioEvents, Compo
         checked: 'checked',
         required: 'required'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxRadio as StencilReactComponent<IxRadioElement, IxRadioEvents, Components.IxRadio>,
     serializeShadowRoot
 });
@@ -1596,7 +1596,7 @@ export const IxRadioGroup: StencilReactComponent<IxRadioGroupElement, IxRadioGro
         direction: 'direction',
         required: 'required'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxRadioGroup as StencilReactComponent<IxRadioGroupElement, IxRadioGroupEvents, Components.IxRadioGroup>,
     serializeShadowRoot
 });
@@ -1609,7 +1609,7 @@ export const IxRangeField: StencilReactComponent<IxRangeFieldElement, IxRangeFie
         type: 'type',
         hideArrow: 'hide-arrow'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxRangeField as StencilReactComponent<IxRangeFieldElement, IxRangeFieldEvents, Components.IxRangeField>,
     serializeShadowRoot
 });
@@ -1619,7 +1619,7 @@ export type IxRowEvents = NonNullable<unknown>;
 export const IxRow: StencilReactComponent<IxRowElement, IxRowEvents, Components.IxRow> = /*@__PURE__*/ createComponent<IxRowElement, IxRowEvents, Components.IxRow>({
     tagName: 'ix-row',
     properties: {},
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxRow as StencilReactComponent<IxRowElement, IxRowEvents, Components.IxRow>,
     serializeShadowRoot
 });
@@ -1663,7 +1663,7 @@ export const IxSelect: StencilReactComponent<IxSelectElement, IxSelectEvents, Co
         collapseMultipleSelection: 'collapse-multiple-selection',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxSelect as StencilReactComponent<IxSelectElement, IxSelectEvents, Components.IxSelect>,
     serializeShadowRoot
 });
@@ -1680,7 +1680,7 @@ export const IxSelectItem: StencilReactComponent<IxSelectItemElement, IxSelectIt
         selected: 'selected',
         hover: 'hover'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxSelectItem as StencilReactComponent<IxSelectItemElement, IxSelectItemEvents, Components.IxSelectItem>,
     serializeShadowRoot
 });
@@ -1705,7 +1705,7 @@ export const IxSlider: StencilReactComponent<IxSliderElement, IxSliderEvents, Co
         traceReference: 'trace-reference',
         disabled: 'disabled'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxSlider as StencilReactComponent<IxSliderElement, IxSliderEvents, Components.IxSlider>,
     serializeShadowRoot
 });
@@ -1719,7 +1719,7 @@ export const IxSpinner: StencilReactComponent<IxSpinnerElement, IxSpinnerEvents,
         size: 'size',
         hideTrack: 'hide-track'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxSpinner as StencilReactComponent<IxSpinnerElement, IxSpinnerEvents, Components.IxSpinner>,
     serializeShadowRoot
 });
@@ -1741,7 +1741,7 @@ export const IxSplitButton: StencilReactComponent<IxSplitButtonElement, IxSplitB
         disableDropdownButton: 'disable-dropdown-button',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxSplitButton as StencilReactComponent<IxSplitButtonElement, IxSplitButtonEvents, Components.IxSplitButton>,
     serializeShadowRoot
 });
@@ -1768,7 +1768,7 @@ export const IxTabItem: StencilReactComponent<IxTabItemElement, IxTabItemEvents,
         layout: 'layout',
         iconOnly: 'icon-only'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxTabItem as StencilReactComponent<IxTabItemElement, IxTabItemEvents, Components.IxTabItem>,
     serializeShadowRoot
 });
@@ -1789,7 +1789,7 @@ export const IxTabs: StencilReactComponent<IxTabsElement, IxTabsEvents, Componen
         activeTabKey: 'active-tab-key',
         keyboardNavigation: 'keyboard-navigation'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxTabs as StencilReactComponent<IxTabsElement, IxTabsEvents, Components.IxTabs>,
     serializeShadowRoot
 });
@@ -1825,7 +1825,7 @@ export const IxTextarea: StencilReactComponent<IxTextareaElement, IxTextareaEven
         maxLength: 'max-length',
         minLength: 'min-length'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxTextarea as StencilReactComponent<IxTextareaElement, IxTextareaEvents, Components.IxTextarea>,
     serializeShadowRoot
 });
@@ -1835,7 +1835,7 @@ export type IxTileEvents = NonNullable<unknown>;
 export const IxTile: StencilReactComponent<IxTileElement, IxTileEvents, Components.IxTile> = /*@__PURE__*/ createComponent<IxTileElement, IxTileEvents, Components.IxTile>({
     tagName: 'ix-tile',
     properties: { size: 'size' },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxTile as StencilReactComponent<IxTileElement, IxTileEvents, Components.IxTile>,
     serializeShadowRoot
 });
@@ -1882,7 +1882,7 @@ export const IxTimeInput: StencilReactComponent<IxTimeInputElement, IxTimeInputE
         enableTopLayer: 'enable-top-layer',
         ariaLabelTimeToggleButton: 'aria-label-time-toggle-button'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxTimeInput as StencilReactComponent<IxTimeInputElement, IxTimeInputEvents, Components.IxTimeInput>,
     serializeShadowRoot
 });
@@ -1914,7 +1914,7 @@ export const IxTimePicker: StencilReactComponent<IxTimePickerElement, IxTimePick
         i18nSecondColumnHeader: 'i18n-second-column-header',
         i18nMillisecondColumnHeader: 'i18n-millisecond-column-header'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxTimePicker as StencilReactComponent<IxTimePickerElement, IxTimePickerEvents, Components.IxTimePicker>,
     serializeShadowRoot
 });
@@ -1933,7 +1933,7 @@ export const IxToast: StencilReactComponent<IxToastElement, IxToastEvents, Compo
         hideIcon: 'hide-icon',
         ariaLabelCloseIconButton: 'aria-label-close-icon-button'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxToast as StencilReactComponent<IxToastElement, IxToastEvents, Components.IxToast>,
     serializeShadowRoot
 });
@@ -1943,7 +1943,7 @@ export type IxToastContainerEvents = NonNullable<unknown>;
 export const IxToastContainer: StencilReactComponent<IxToastContainerElement, IxToastContainerEvents, Components.IxToastContainer> = /*@__PURE__*/ createComponent<IxToastContainerElement, IxToastContainerEvents, Components.IxToastContainer>({
     tagName: 'ix-toast-container',
     properties: { position: 'position' },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxToastContainer as StencilReactComponent<IxToastContainerElement, IxToastContainerEvents, Components.IxToastContainer>,
     serializeShadowRoot
 });
@@ -1967,7 +1967,7 @@ export const IxToggle: StencilReactComponent<IxToggleElement, IxToggleEvents, Co
         hideText: 'hide-text',
         required: 'required'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxToggle as StencilReactComponent<IxToggleElement, IxToggleEvents, Components.IxToggle>,
     serializeShadowRoot
 });
@@ -1984,7 +1984,7 @@ export const IxToggleButton: StencilReactComponent<IxToggleButtonElement, IxTogg
         iconRight: 'icon-right',
         pressed: 'pressed'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxToggleButton as StencilReactComponent<IxToggleButtonElement, IxToggleButtonEvents, Components.IxToggleButton>,
     serializeShadowRoot
 });
@@ -2002,7 +2002,7 @@ export const IxTooltip: StencilReactComponent<IxTooltipElement, IxTooltipEvents,
         hideDelay: 'hide-delay',
         animationFrame: 'animation-frame'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxTooltip as StencilReactComponent<IxTooltipElement, IxTooltipEvents, Components.IxTooltip>,
     serializeShadowRoot
 });
@@ -2017,7 +2017,7 @@ export const IxTypography: StencilReactComponent<IxTypographyElement, IxTypograp
         bold: 'bold',
         textDecoration: 'text-decoration'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxTypography as StencilReactComponent<IxTypographyElement, IxTypographyEvents, Components.IxTypography>,
     serializeShadowRoot
 });
@@ -2040,7 +2040,7 @@ export const IxUpload: StencilReactComponent<IxUploadElement, IxUploadEvents, Co
         i18nUploadFile: 'i18n-upload-file',
         i18nUploadDisabled: 'i18n-upload-disabled'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxUpload as StencilReactComponent<IxUploadElement, IxUploadEvents, Components.IxUpload>,
     serializeShadowRoot
 });
@@ -2057,7 +2057,7 @@ export const IxWorkflowStep: StencilReactComponent<IxWorkflowStepElement, IxWork
         selected: 'selected',
         position: 'position'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxWorkflowStep as StencilReactComponent<IxWorkflowStepElement, IxWorkflowStepEvents, Components.IxWorkflowStep>,
     serializeShadowRoot
 });
@@ -2071,7 +2071,7 @@ export const IxWorkflowSteps: StencilReactComponent<IxWorkflowStepsElement, IxWo
         clickable: 'clickable',
         selectedIndex: 'selected-index'
     },
-    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
+    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
     clientModule: clientComponents.IxWorkflowSteps as StencilReactComponent<IxWorkflowStepsElement, IxWorkflowStepsEvents, Components.IxWorkflowSteps>,
     serializeShadowRoot
 });

--- a/packages/react/src/components/components.server.ts
+++ b/packages/react/src/components/components.server.ts
@@ -130,7 +130,7 @@ export const IxActionCard: StencilReactComponent<IxActionCardElement, IxActionCa
         ariaLabelCard: 'aria-label-card',
         passive: 'passive'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxActionCard as StencilReactComponent<IxActionCardElement, IxActionCardEvents, Components.IxActionCard>,
     serializeShadowRoot
 });
@@ -144,7 +144,7 @@ export const IxApplication: StencilReactComponent<IxApplicationElement, IxApplic
         colorSchema: 'color-schema',
         forceBreakpoint: 'force-breakpoint'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxApplication as StencilReactComponent<IxApplicationElement, IxApplicationEvents, Components.IxApplication>,
     serializeShadowRoot
 });
@@ -170,7 +170,7 @@ export const IxApplicationHeader: StencilReactComponent<IxApplicationHeaderEleme
         ariaLabelMoreMenuIconButton: 'aria-label-more-menu-icon-button',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxApplicationHeader as StencilReactComponent<IxApplicationHeaderElement, IxApplicationHeaderEvents, Components.IxApplicationHeader>,
     serializeShadowRoot
 });
@@ -187,7 +187,7 @@ export const IxAvatar: StencilReactComponent<IxAvatarElement, IxAvatarEvents, Co
         tooltipText: 'tooltip-text',
         ariaLabelTooltip: 'aria-label-tooltip'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxAvatar as StencilReactComponent<IxAvatarElement, IxAvatarEvents, Components.IxAvatar>,
     serializeShadowRoot
 });
@@ -203,7 +203,7 @@ export const IxBlind: StencilReactComponent<IxBlindElement, IxBlindEvents, Compo
         icon: 'icon',
         variant: 'variant'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxBlind as StencilReactComponent<IxBlindElement, IxBlindEvents, Components.IxBlind>,
     serializeShadowRoot
 });
@@ -221,7 +221,7 @@ export const IxBreadcrumb: StencilReactComponent<IxBreadcrumbElement, IxBreadcru
         ariaLabelPreviousButton: 'aria-label-previous-button',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxBreadcrumb as StencilReactComponent<IxBreadcrumbElement, IxBreadcrumbEvents, Components.IxBreadcrumb>,
     serializeShadowRoot
 });
@@ -243,7 +243,7 @@ export const IxBreadcrumbItem: StencilReactComponent<IxBreadcrumbItemElement, Ix
         isDropdownTrigger: 'is-dropdown-trigger',
         isCurrentPage: 'is-current-page'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxBreadcrumbItem as StencilReactComponent<IxBreadcrumbItemElement, IxBreadcrumbItemEvents, Components.IxBreadcrumbItem>,
     serializeShadowRoot
 });
@@ -266,7 +266,7 @@ export const IxButton: StencilReactComponent<IxButtonElement, IxButtonEvents, Co
         target: 'target',
         rel: 'rel'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxButton as StencilReactComponent<IxButtonElement, IxButtonEvents, Components.IxButton>,
     serializeShadowRoot
 });
@@ -280,7 +280,7 @@ export const IxCard: StencilReactComponent<IxCardElement, IxCardEvents, Componen
         selected: 'selected',
         passive: 'passive'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxCard as StencilReactComponent<IxCardElement, IxCardEvents, Components.IxCard>,
     serializeShadowRoot
 });
@@ -294,7 +294,7 @@ export const IxCardAccordion: StencilReactComponent<IxCardAccordionElement, IxCa
         collapse: 'collapse',
         variant: 'variant'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxCardAccordion as StencilReactComponent<IxCardAccordionElement, IxCardAccordionEvents, Components.IxCardAccordion>,
     serializeShadowRoot
 });
@@ -304,7 +304,7 @@ export type IxCardContentEvents = NonNullable<unknown>;
 export const IxCardContent: StencilReactComponent<IxCardContentElement, IxCardContentEvents, Components.IxCardContent> = /*@__PURE__*/ createComponent<IxCardContentElement, IxCardContentEvents, Components.IxCardContent>({
     tagName: 'ix-card-content',
     properties: {},
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxCardContent as StencilReactComponent<IxCardContentElement, IxCardContentEvents, Components.IxCardContent>,
     serializeShadowRoot
 });
@@ -330,7 +330,7 @@ export const IxCardList: StencilReactComponent<IxCardListElement, IxCardListEven
         i18nShowLess: 'i18n-show-less',
         i18nMoreCards: 'i18n-more-cards'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxCardList as StencilReactComponent<IxCardListElement, IxCardListEvents, Components.IxCardList>,
     serializeShadowRoot
 });
@@ -340,7 +340,7 @@ export type IxCardTitleEvents = NonNullable<unknown>;
 export const IxCardTitle: StencilReactComponent<IxCardTitleElement, IxCardTitleEvents, Components.IxCardTitle> = /*@__PURE__*/ createComponent<IxCardTitleElement, IxCardTitleEvents, Components.IxCardTitle>({
     tagName: 'ix-card-title',
     properties: {},
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxCardTitle as StencilReactComponent<IxCardTitleElement, IxCardTitleEvents, Components.IxCardTitle>,
     serializeShadowRoot
 });
@@ -369,7 +369,7 @@ export const IxCategoryFilter: StencilReactComponent<IxCategoryFilterElement, Ix
         ariaLabelFilterInput: 'aria-label-filter-input',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxCategoryFilter as StencilReactComponent<IxCategoryFilterElement, IxCategoryFilterEvents, Components.IxCategoryFilter>,
     serializeShadowRoot
 });
@@ -391,7 +391,7 @@ export const IxCheckbox: StencilReactComponent<IxCheckboxElement, IxCheckboxEven
         indeterminate: 'indeterminate',
         required: 'required'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxCheckbox as StencilReactComponent<IxCheckboxElement, IxCheckboxEvents, Components.IxCheckbox>,
     serializeShadowRoot
 });
@@ -411,7 +411,7 @@ export const IxCheckboxGroup: StencilReactComponent<IxCheckboxGroupElement, IxCh
         showTextAsTooltip: 'show-text-as-tooltip',
         required: 'required'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxCheckboxGroup as StencilReactComponent<IxCheckboxGroupElement, IxCheckboxGroupEvents, Components.IxCheckboxGroup>,
     serializeShadowRoot
 });
@@ -433,7 +433,7 @@ export const IxChip: StencilReactComponent<IxChipElement, IxChipEvents, Componen
         centerContent: 'center-content',
         ariaLabelCloseButton: 'aria-label-close-button'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxChip as StencilReactComponent<IxChipElement, IxChipEvents, Components.IxChip>,
     serializeShadowRoot
 });
@@ -448,7 +448,7 @@ export const IxCol: StencilReactComponent<IxColElement, IxColEvents, Components.
         sizeMd: 'size-md',
         sizeLg: 'size-lg'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxCol as StencilReactComponent<IxColElement, IxColEvents, Components.IxCol>,
     serializeShadowRoot
 });
@@ -458,7 +458,7 @@ export type IxContentEvents = NonNullable<unknown>;
 export const IxContent: StencilReactComponent<IxContentElement, IxContentEvents, Components.IxContent> = /*@__PURE__*/ createComponent<IxContentElement, IxContentEvents, Components.IxContent>({
     tagName: 'ix-content',
     properties: {},
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxContent as StencilReactComponent<IxContentElement, IxContentEvents, Components.IxContent>,
     serializeShadowRoot
 });
@@ -473,7 +473,7 @@ export const IxContentHeader: StencilReactComponent<IxContentHeaderElement, IxCo
         headerSubtitle: 'header-subtitle',
         hasBackButton: 'has-back-button'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxContentHeader as StencilReactComponent<IxContentHeaderElement, IxContentHeaderEvents, Components.IxContentHeader>,
     serializeShadowRoot
 });
@@ -492,7 +492,7 @@ export const IxCustomField: StencilReactComponent<IxCustomFieldElement, IxCustom
         validText: 'valid-text',
         showTextAsTooltip: 'show-text-as-tooltip'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxCustomField as StencilReactComponent<IxCustomFieldElement, IxCustomFieldEvents, Components.IxCustomField>,
     serializeShadowRoot
 });
@@ -520,7 +520,7 @@ export const IxDateDropdown: StencilReactComponent<IxDateDropdownElement, IxDate
         today: 'today',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxDateDropdown as StencilReactComponent<IxDateDropdownElement, IxDateDropdownEvents, Components.IxDateDropdown>,
     serializeShadowRoot
 });
@@ -561,7 +561,7 @@ export const IxDateInput: StencilReactComponent<IxDateInputElement, IxDateInputE
         textAlignment: 'text-alignment',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxDateInput as StencilReactComponent<IxDateInputElement, IxDateInputEvents, Components.IxDateInput>,
     serializeShadowRoot
 });
@@ -594,7 +594,7 @@ export const IxDatePicker: StencilReactComponent<IxDatePickerElement, IxDatePick
         today: 'today',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxDatePicker as StencilReactComponent<IxDatePickerElement, IxDatePickerEvents, Components.IxDatePicker>,
     serializeShadowRoot
 });
@@ -641,7 +641,7 @@ export const IxDatetimeInput: StencilReactComponent<IxDatetimeInputElement, IxDa
         textAlignment: 'text-alignment',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxDatetimeInput as StencilReactComponent<IxDatetimeInputElement, IxDatetimeInputEvents, Components.IxDatetimeInput>,
     serializeShadowRoot
 });
@@ -676,7 +676,7 @@ export const IxDatetimePicker: StencilReactComponent<IxDatetimePickerElement, Ix
         showWeekNumbers: 'show-week-numbers',
         embedded: 'embedded'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxDatetimePicker as StencilReactComponent<IxDatetimePickerElement, IxDatetimePickerEvents, Components.IxDatetimePicker>,
     serializeShadowRoot
 });
@@ -686,7 +686,7 @@ export type IxDividerEvents = NonNullable<unknown>;
 export const IxDivider: StencilReactComponent<IxDividerElement, IxDividerEvents, Components.IxDivider> = /*@__PURE__*/ createComponent<IxDividerElement, IxDividerEvents, Components.IxDivider>({
     tagName: 'ix-divider',
     properties: {},
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxDivider as StencilReactComponent<IxDividerElement, IxDividerEvents, Components.IxDivider>,
     serializeShadowRoot
 });
@@ -717,7 +717,7 @@ export const IxDropdown: StencilReactComponent<IxDropdownElement, IxDropdownEven
         suppressOverflowBehavior: 'suppress-overflow-behavior',
         hostRole: 'host-role'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxDropdown as StencilReactComponent<IxDropdownElement, IxDropdownEvents, Components.IxDropdown>,
     serializeShadowRoot
 });
@@ -741,7 +741,7 @@ export const IxDropdownButton: StencilReactComponent<IxDropdownButtonElement, Ix
         enableTopLayer: 'enable-top-layer',
         suppressAriaActiveDescendant: 'suppress-aria-active-descendant'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxDropdownButton as StencilReactComponent<IxDropdownButtonElement, IxDropdownButtonEvents, Components.IxDropdownButton>,
     serializeShadowRoot
 });
@@ -751,7 +751,7 @@ export type IxDropdownHeaderEvents = NonNullable<unknown>;
 export const IxDropdownHeader: StencilReactComponent<IxDropdownHeaderElement, IxDropdownHeaderEvents, Components.IxDropdownHeader> = /*@__PURE__*/ createComponent<IxDropdownHeaderElement, IxDropdownHeaderEvents, Components.IxDropdownHeader>({
     tagName: 'ix-dropdown-header',
     properties: { label: 'label' },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxDropdownHeader as StencilReactComponent<IxDropdownHeaderElement, IxDropdownHeaderEvents, Components.IxDropdownHeader>,
     serializeShadowRoot
 });
@@ -775,7 +775,7 @@ export const IxDropdownItem: StencilReactComponent<IxDropdownItemElement, IxDrop
         suppressChecked: 'suppress-checked',
         hasVisualFocus: 'has-visual-focus'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxDropdownItem as StencilReactComponent<IxDropdownItemElement, IxDropdownItemEvents, Components.IxDropdownItem>,
     serializeShadowRoot
 });
@@ -785,7 +785,7 @@ export type IxDropdownQuickActionsEvents = NonNullable<unknown>;
 export const IxDropdownQuickActions: StencilReactComponent<IxDropdownQuickActionsElement, IxDropdownQuickActionsEvents, Components.IxDropdownQuickActions> = /*@__PURE__*/ createComponent<IxDropdownQuickActionsElement, IxDropdownQuickActionsEvents, Components.IxDropdownQuickActions>({
     tagName: 'ix-dropdown-quick-actions',
     properties: {},
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxDropdownQuickActions as StencilReactComponent<IxDropdownQuickActionsElement, IxDropdownQuickActionsEvents, Components.IxDropdownQuickActions>,
     serializeShadowRoot
 });
@@ -802,7 +802,7 @@ export const IxEmptyState: StencilReactComponent<IxEmptyStateElement, IxEmptySta
         action: 'action',
         ariaLabelEmptyStateIcon: 'aria-label-empty-state-icon'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxEmptyState as StencilReactComponent<IxEmptyStateElement, IxEmptyStateEvents, Components.IxEmptyState>,
     serializeShadowRoot
 });
@@ -817,7 +817,7 @@ export const IxEventList: StencilReactComponent<IxEventListElement, IxEventListE
         animated: 'animated',
         chevron: 'chevron'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxEventList as StencilReactComponent<IxEventListElement, IxEventListEvents, Components.IxEventList>,
     serializeShadowRoot
 });
@@ -833,7 +833,7 @@ export const IxEventListItem: StencilReactComponent<IxEventListItemElement, IxEv
         disabled: 'disabled',
         chevron: 'chevron'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxEventListItem as StencilReactComponent<IxEventListItemElement, IxEventListItemEvents, Components.IxEventListItem>,
     serializeShadowRoot
 });
@@ -852,7 +852,7 @@ export const IxExpandingSearch: StencilReactComponent<IxExpandingSearchElement, 
         ariaLabelClearIconButton: 'aria-label-clear-icon-button',
         ariaLabelSearchInput: 'aria-label-search-input'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxExpandingSearch as StencilReactComponent<IxExpandingSearchElement, IxExpandingSearchEvents, Components.IxExpandingSearch>,
     serializeShadowRoot
 });
@@ -866,7 +866,7 @@ export const IxFieldLabel: StencilReactComponent<IxFieldLabelElement, IxFieldLab
         htmlFor: 'html-for',
         isInvalid: 'is-invalid'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxFieldLabel as StencilReactComponent<IxFieldLabelElement, IxFieldLabelEvents, Components.IxFieldLabel>,
     serializeShadowRoot
 });
@@ -880,7 +880,7 @@ export const IxFilterChip: StencilReactComponent<IxFilterChipElement, IxFilterCh
         readonly: 'readonly',
         ariaLabelCloseIconButton: 'aria-label-close-icon-button'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxFilterChip as StencilReactComponent<IxFilterChipElement, IxFilterChipEvents, Components.IxFilterChip>,
     serializeShadowRoot
 });
@@ -896,7 +896,7 @@ export const IxFlipTile: StencilReactComponent<IxFlipTileElement, IxFlipTileEven
         index: 'index',
         ariaLabelEyeIconButton: 'aria-label-eye-icon-button'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxFlipTile as StencilReactComponent<IxFlipTileElement, IxFlipTileEvents, Components.IxFlipTile>,
     serializeShadowRoot
 });
@@ -906,7 +906,7 @@ export type IxFlipTileContentEvents = NonNullable<unknown>;
 export const IxFlipTileContent: StencilReactComponent<IxFlipTileContentElement, IxFlipTileContentEvents, Components.IxFlipTileContent> = /*@__PURE__*/ createComponent<IxFlipTileContentElement, IxFlipTileContentEvents, Components.IxFlipTileContent>({
     tagName: 'ix-flip-tile-content',
     properties: { contentVisible: 'content-visible' },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxFlipTileContent as StencilReactComponent<IxFlipTileContentElement, IxFlipTileContentEvents, Components.IxFlipTileContent>,
     serializeShadowRoot
 });
@@ -928,7 +928,7 @@ export const IxGroup: StencilReactComponent<IxGroupElement, IxGroupEvents, Compo
         index: 'index',
         expandOnHeaderClick: 'expand-on-header-click'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxGroup as StencilReactComponent<IxGroupElement, IxGroupEvents, Components.IxGroup>,
     serializeShadowRoot
 });
@@ -938,7 +938,7 @@ export type IxGroupContextMenuEvents = NonNullable<unknown>;
 export const IxGroupContextMenu: StencilReactComponent<IxGroupContextMenuElement, IxGroupContextMenuEvents, Components.IxGroupContextMenu> = /*@__PURE__*/ createComponent<IxGroupContextMenuElement, IxGroupContextMenuEvents, Components.IxGroupContextMenu>({
     tagName: 'ix-group-context-menu',
     properties: {},
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxGroupContextMenu as StencilReactComponent<IxGroupContextMenuElement, IxGroupContextMenuEvents, Components.IxGroupContextMenu>,
     serializeShadowRoot
 });
@@ -958,7 +958,7 @@ export const IxGroupItem: StencilReactComponent<IxGroupItemElement, IxGroupItemE
         disabled: 'disabled',
         index: 'index'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxGroupItem as StencilReactComponent<IxGroupItemElement, IxGroupItemEvents, Components.IxGroupItem>,
     serializeShadowRoot
 });
@@ -975,7 +975,7 @@ export const IxHelperText: StencilReactComponent<IxHelperTextElement, IxHelperTe
         infoText: 'info-text',
         warningText: 'warning-text'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxHelperText as StencilReactComponent<IxHelperTextElement, IxHelperTextEvents, Components.IxHelperText>,
     serializeShadowRoot
 });
@@ -994,7 +994,7 @@ export const IxIconButton: StencilReactComponent<IxIconButtonElement, IxIconButt
         type: 'type',
         loading: 'loading'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxIconButton as StencilReactComponent<IxIconButtonElement, IxIconButtonEvents, Components.IxIconButton>,
     serializeShadowRoot
 });
@@ -1014,7 +1014,7 @@ export const IxIconToggleButton: StencilReactComponent<IxIconToggleButtonElement
         disabled: 'disabled',
         loading: 'loading'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxIconToggleButton as StencilReactComponent<IxIconToggleButtonElement, IxIconToggleButtonEvents, Components.IxIconToggleButton>,
     serializeShadowRoot
 });
@@ -1050,7 +1050,7 @@ export const IxInput: StencilReactComponent<IxInputElement, IxInputEvents, Compo
         suppressSubmitOnEnter: 'suppress-submit-on-enter',
         textAlignment: 'text-alignment'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxInput as StencilReactComponent<IxInputElement, IxInputEvents, Components.IxInput>,
     serializeShadowRoot
 });
@@ -1066,7 +1066,7 @@ export const IxKeyValue: StencilReactComponent<IxKeyValueElement, IxKeyValueEven
         labelPosition: 'label-position',
         value: 'value'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxKeyValue as StencilReactComponent<IxKeyValueElement, IxKeyValueEvents, Components.IxKeyValue>,
     serializeShadowRoot
 });
@@ -1076,7 +1076,7 @@ export type IxKeyValueListEvents = NonNullable<unknown>;
 export const IxKeyValueList: StencilReactComponent<IxKeyValueListElement, IxKeyValueListEvents, Components.IxKeyValueList> = /*@__PURE__*/ createComponent<IxKeyValueListElement, IxKeyValueListEvents, Components.IxKeyValueList>({
     tagName: 'ix-key-value-list',
     properties: { striped: 'striped' },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxKeyValueList as StencilReactComponent<IxKeyValueListElement, IxKeyValueListEvents, Components.IxKeyValueList>,
     serializeShadowRoot
 });
@@ -1094,7 +1094,7 @@ export const IxKpi: StencilReactComponent<IxKpiElement, IxKpiEvents, Components.
         state: 'state',
         orientation: 'orientation'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxKpi as StencilReactComponent<IxKpiElement, IxKpiEvents, Components.IxKpi>,
     serializeShadowRoot
 });
@@ -1104,7 +1104,7 @@ export type IxLayoutAutoEvents = NonNullable<unknown>;
 export const IxLayoutAuto: StencilReactComponent<IxLayoutAutoElement, IxLayoutAutoEvents, Components.IxLayoutAuto> = /*@__PURE__*/ createComponent<IxLayoutAutoElement, IxLayoutAutoEvents, Components.IxLayoutAuto>({
     tagName: 'ix-layout-auto',
     properties: {},
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxLayoutAuto as StencilReactComponent<IxLayoutAutoElement, IxLayoutAutoEvents, Components.IxLayoutAuto>,
     serializeShadowRoot
 });
@@ -1118,7 +1118,7 @@ export const IxLayoutGrid: StencilReactComponent<IxLayoutGridElement, IxLayoutGr
         gap: 'gap',
         columns: 'columns'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxLayoutGrid as StencilReactComponent<IxLayoutGridElement, IxLayoutGridEvents, Components.IxLayoutGrid>,
     serializeShadowRoot
 });
@@ -1132,7 +1132,7 @@ export const IxLinkButton: StencilReactComponent<IxLinkButtonElement, IxLinkButt
         url: 'url',
         target: 'target'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxLinkButton as StencilReactComponent<IxLinkButtonElement, IxLinkButtonEvents, Components.IxLinkButton>,
     serializeShadowRoot
 });
@@ -1162,7 +1162,7 @@ export const IxMenu: StencilReactComponent<IxMenuElement, IxMenuEvents, Componen
         i18nExpand: 'i18n-expand',
         i18nCollapse: 'i18n-collapse'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxMenu as StencilReactComponent<IxMenuElement, IxMenuEvents, Components.IxMenu>,
     serializeShadowRoot
 });
@@ -1181,7 +1181,7 @@ export const IxMenuAbout: StencilReactComponent<IxMenuAboutElement, IxMenuAboutE
         ariaLabelCloseButton: 'aria-label-close-button',
         show: 'show'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxMenuAbout as StencilReactComponent<IxMenuAboutElement, IxMenuAboutEvents, Components.IxMenuAbout>,
     serializeShadowRoot
 });
@@ -1194,7 +1194,7 @@ export const IxMenuAboutItem: StencilReactComponent<IxMenuAboutItemElement, IxMe
         tabKey: 'tab-key',
         label: 'label'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxMenuAboutItem as StencilReactComponent<IxMenuAboutItemElement, IxMenuAboutItemEvents, Components.IxMenuAboutItem>,
     serializeShadowRoot
 });
@@ -1214,7 +1214,7 @@ export const IxMenuAboutNews: StencilReactComponent<IxMenuAboutNewsElement, IxMe
         activeAboutTabKey: 'active-about-tab-key',
         expanded: 'expanded'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxMenuAboutNews as StencilReactComponent<IxMenuAboutNewsElement, IxMenuAboutNewsEvents, Components.IxMenuAboutNews>,
     serializeShadowRoot
 });
@@ -1234,7 +1234,7 @@ export const IxMenuAvatar: StencilReactComponent<IxMenuAvatarElement, IxMenuAvat
         hideLogoutButton: 'hide-logout-button',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxMenuAvatar as StencilReactComponent<IxMenuAvatarElement, IxMenuAvatarEvents, Components.IxMenuAvatar>,
     serializeShadowRoot
 });
@@ -1247,7 +1247,7 @@ export const IxMenuAvatarItem: StencilReactComponent<IxMenuAvatarItemElement, Ix
         icon: 'icon',
         label: 'label'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxMenuAvatarItem as StencilReactComponent<IxMenuAvatarItemElement, IxMenuAvatarItemEvents, Components.IxMenuAvatarItem>,
     serializeShadowRoot
 });
@@ -1262,7 +1262,7 @@ export const IxMenuCategory: StencilReactComponent<IxMenuCategoryElement, IxMenu
         notifications: 'notifications',
         tooltipText: 'tooltip-text'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxMenuCategory as StencilReactComponent<IxMenuCategoryElement, IxMenuCategoryEvents, Components.IxMenuCategory>,
     serializeShadowRoot
 });
@@ -1285,7 +1285,7 @@ export const IxMenuItem: StencilReactComponent<IxMenuItemElement, IxMenuItemEven
         rel: 'rel',
         isCategory: 'is-category'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxMenuItem as StencilReactComponent<IxMenuItemElement, IxMenuItemEvents, Components.IxMenuItem>,
     serializeShadowRoot
 });
@@ -1304,7 +1304,7 @@ export const IxMenuSettings: StencilReactComponent<IxMenuSettingsElement, IxMenu
         ariaLabelCloseButton: 'aria-label-close-button',
         show: 'show'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxMenuSettings as StencilReactComponent<IxMenuSettingsElement, IxMenuSettingsEvents, Components.IxMenuSettings>,
     serializeShadowRoot
 });
@@ -1317,7 +1317,7 @@ export const IxMenuSettingsItem: StencilReactComponent<IxMenuSettingsItemElement
         tabKey: 'tab-key',
         label: 'label'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxMenuSettingsItem as StencilReactComponent<IxMenuSettingsItemElement, IxMenuSettingsItemEvents, Components.IxMenuSettingsItem>,
     serializeShadowRoot
 });
@@ -1333,7 +1333,7 @@ export const IxMessageBar: StencilReactComponent<IxMessageBarElement, IxMessageB
         type: 'type',
         persistent: 'persistent'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxMessageBar as StencilReactComponent<IxMessageBarElement, IxMessageBarEvents, Components.IxMessageBar>,
     serializeShadowRoot
 });
@@ -1353,7 +1353,7 @@ export const IxModal: StencilReactComponent<IxModalElement, IxModalEvents, Compo
         centered: 'centered',
         isNonBlocking: 'is-non-blocking'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxModal as StencilReactComponent<IxModalElement, IxModalEvents, Components.IxModal>,
     serializeShadowRoot
 });
@@ -1363,7 +1363,7 @@ export type IxModalContentEvents = NonNullable<unknown>;
 export const IxModalContent: StencilReactComponent<IxModalContentElement, IxModalContentEvents, Components.IxModalContent> = /*@__PURE__*/ createComponent<IxModalContentElement, IxModalContentEvents, Components.IxModalContent>({
     tagName: 'ix-modal-content',
     properties: {},
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxModalContent as StencilReactComponent<IxModalContentElement, IxModalContentEvents, Components.IxModalContent>,
     serializeShadowRoot
 });
@@ -1373,7 +1373,7 @@ export type IxModalFooterEvents = NonNullable<unknown>;
 export const IxModalFooter: StencilReactComponent<IxModalFooterElement, IxModalFooterEvents, Components.IxModalFooter> = /*@__PURE__*/ createComponent<IxModalFooterElement, IxModalFooterEvents, Components.IxModalFooter>({
     tagName: 'ix-modal-footer',
     properties: {},
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxModalFooter as StencilReactComponent<IxModalFooterElement, IxModalFooterEvents, Components.IxModalFooter>,
     serializeShadowRoot
 });
@@ -1389,7 +1389,7 @@ export const IxModalHeader: StencilReactComponent<IxModalHeaderElement, IxModalH
         ariaLabelCloseIconButton: 'aria-label-close-icon-button',
         iconColor: 'icon-color'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxModalHeader as StencilReactComponent<IxModalHeaderElement, IxModalHeaderEvents, Components.IxModalHeader>,
     serializeShadowRoot
 });
@@ -1427,7 +1427,7 @@ export const IxNumberInput: StencilReactComponent<IxNumberInputElement, IxNumber
         textAlignment: 'text-alignment',
         allowEmptyValueChange: 'allow-empty-value-change'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxNumberInput as StencilReactComponent<IxNumberInputElement, IxNumberInputEvents, Components.IxNumberInput>,
     serializeShadowRoot
 });
@@ -1452,7 +1452,7 @@ export const IxPagination: StencilReactComponent<IxPaginationElement, IxPaginati
         ariaLabelChevronRightIconButton: 'aria-label-chevron-right-icon-button',
         ariaLabelPageSelection: 'aria-label-page-selection'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxPagination as StencilReactComponent<IxPaginationElement, IxPaginationEvents, Components.IxPagination>,
     serializeShadowRoot
 });
@@ -1471,6 +1471,7 @@ export const IxPane: StencilReactComponent<IxPaneElement, IxPaneEvents, Componen
         hideOnCollapse: 'hide-on-collapse',
         size: 'size',
         borderless: 'borderless',
+        noPadding: 'no-padding',
         expanded: 'expanded',
         composition: 'composition',
         icon: 'icon',
@@ -1480,7 +1481,7 @@ export const IxPane: StencilReactComponent<IxPaneElement, IxPaneEvents, Componen
         ignoreLayoutSettings: 'ignore-layout-settings',
         isMobile: 'is-mobile'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxPane as StencilReactComponent<IxPaneElement, IxPaneEvents, Components.IxPane>,
     serializeShadowRoot
 });
@@ -1494,7 +1495,7 @@ export const IxPaneLayout: StencilReactComponent<IxPaneLayoutElement, IxPaneLayo
         variant: 'variant',
         borderless: 'borderless'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxPaneLayout as StencilReactComponent<IxPaneLayoutElement, IxPaneLayoutEvents, Components.IxPaneLayout>,
     serializeShadowRoot
 });
@@ -1513,7 +1514,7 @@ export const IxPill: StencilReactComponent<IxPillElement, IxPillEvents, Componen
         alignLeft: 'align-left',
         tooltipText: 'tooltip-text'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxPill as StencilReactComponent<IxPillElement, IxPillEvents, Components.IxPill>,
     serializeShadowRoot
 });
@@ -1534,7 +1535,7 @@ export const IxProgressIndicator: StencilReactComponent<IxProgressIndicatorEleme
         textAlignment: 'text-alignment',
         showTextAsTooltip: 'show-text-as-tooltip'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxProgressIndicator as StencilReactComponent<IxProgressIndicatorElement, IxProgressIndicatorEvents, Components.IxProgressIndicator>,
     serializeShadowRoot
 });
@@ -1553,7 +1554,7 @@ export const IxPushCard: StencilReactComponent<IxPushCardElement, IxPushCardEven
         expanded: 'expanded',
         passive: 'passive'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxPushCard as StencilReactComponent<IxPushCardElement, IxPushCardEvents, Components.IxPushCard>,
     serializeShadowRoot
 });
@@ -1574,7 +1575,7 @@ export const IxRadio: StencilReactComponent<IxRadioElement, IxRadioEvents, Compo
         checked: 'checked',
         required: 'required'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxRadio as StencilReactComponent<IxRadioElement, IxRadioEvents, Components.IxRadio>,
     serializeShadowRoot
 });
@@ -1595,7 +1596,7 @@ export const IxRadioGroup: StencilReactComponent<IxRadioGroupElement, IxRadioGro
         direction: 'direction',
         required: 'required'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxRadioGroup as StencilReactComponent<IxRadioGroupElement, IxRadioGroupEvents, Components.IxRadioGroup>,
     serializeShadowRoot
 });
@@ -1608,7 +1609,7 @@ export const IxRangeField: StencilReactComponent<IxRangeFieldElement, IxRangeFie
         type: 'type',
         hideArrow: 'hide-arrow'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxRangeField as StencilReactComponent<IxRangeFieldElement, IxRangeFieldEvents, Components.IxRangeField>,
     serializeShadowRoot
 });
@@ -1618,7 +1619,7 @@ export type IxRowEvents = NonNullable<unknown>;
 export const IxRow: StencilReactComponent<IxRowElement, IxRowEvents, Components.IxRow> = /*@__PURE__*/ createComponent<IxRowElement, IxRowEvents, Components.IxRow>({
     tagName: 'ix-row',
     properties: {},
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxRow as StencilReactComponent<IxRowElement, IxRowEvents, Components.IxRow>,
     serializeShadowRoot
 });
@@ -1662,7 +1663,7 @@ export const IxSelect: StencilReactComponent<IxSelectElement, IxSelectEvents, Co
         collapseMultipleSelection: 'collapse-multiple-selection',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxSelect as StencilReactComponent<IxSelectElement, IxSelectEvents, Components.IxSelect>,
     serializeShadowRoot
 });
@@ -1679,7 +1680,7 @@ export const IxSelectItem: StencilReactComponent<IxSelectItemElement, IxSelectIt
         selected: 'selected',
         hover: 'hover'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxSelectItem as StencilReactComponent<IxSelectItemElement, IxSelectItemEvents, Components.IxSelectItem>,
     serializeShadowRoot
 });
@@ -1704,7 +1705,7 @@ export const IxSlider: StencilReactComponent<IxSliderElement, IxSliderEvents, Co
         traceReference: 'trace-reference',
         disabled: 'disabled'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxSlider as StencilReactComponent<IxSliderElement, IxSliderEvents, Components.IxSlider>,
     serializeShadowRoot
 });
@@ -1718,7 +1719,7 @@ export const IxSpinner: StencilReactComponent<IxSpinnerElement, IxSpinnerEvents,
         size: 'size',
         hideTrack: 'hide-track'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxSpinner as StencilReactComponent<IxSpinnerElement, IxSpinnerEvents, Components.IxSpinner>,
     serializeShadowRoot
 });
@@ -1740,7 +1741,7 @@ export const IxSplitButton: StencilReactComponent<IxSplitButtonElement, IxSplitB
         disableDropdownButton: 'disable-dropdown-button',
         enableTopLayer: 'enable-top-layer'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxSplitButton as StencilReactComponent<IxSplitButtonElement, IxSplitButtonEvents, Components.IxSplitButton>,
     serializeShadowRoot
 });
@@ -1767,7 +1768,7 @@ export const IxTabItem: StencilReactComponent<IxTabItemElement, IxTabItemEvents,
         layout: 'layout',
         iconOnly: 'icon-only'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxTabItem as StencilReactComponent<IxTabItemElement, IxTabItemEvents, Components.IxTabItem>,
     serializeShadowRoot
 });
@@ -1788,7 +1789,7 @@ export const IxTabs: StencilReactComponent<IxTabsElement, IxTabsEvents, Componen
         activeTabKey: 'active-tab-key',
         keyboardNavigation: 'keyboard-navigation'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxTabs as StencilReactComponent<IxTabsElement, IxTabsEvents, Components.IxTabs>,
     serializeShadowRoot
 });
@@ -1824,7 +1825,7 @@ export const IxTextarea: StencilReactComponent<IxTextareaElement, IxTextareaEven
         maxLength: 'max-length',
         minLength: 'min-length'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxTextarea as StencilReactComponent<IxTextareaElement, IxTextareaEvents, Components.IxTextarea>,
     serializeShadowRoot
 });
@@ -1834,7 +1835,7 @@ export type IxTileEvents = NonNullable<unknown>;
 export const IxTile: StencilReactComponent<IxTileElement, IxTileEvents, Components.IxTile> = /*@__PURE__*/ createComponent<IxTileElement, IxTileEvents, Components.IxTile>({
     tagName: 'ix-tile',
     properties: { size: 'size' },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxTile as StencilReactComponent<IxTileElement, IxTileEvents, Components.IxTile>,
     serializeShadowRoot
 });
@@ -1881,7 +1882,7 @@ export const IxTimeInput: StencilReactComponent<IxTimeInputElement, IxTimeInputE
         enableTopLayer: 'enable-top-layer',
         ariaLabelTimeToggleButton: 'aria-label-time-toggle-button'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxTimeInput as StencilReactComponent<IxTimeInputElement, IxTimeInputEvents, Components.IxTimeInput>,
     serializeShadowRoot
 });
@@ -1913,7 +1914,7 @@ export const IxTimePicker: StencilReactComponent<IxTimePickerElement, IxTimePick
         i18nSecondColumnHeader: 'i18n-second-column-header',
         i18nMillisecondColumnHeader: 'i18n-millisecond-column-header'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxTimePicker as StencilReactComponent<IxTimePickerElement, IxTimePickerEvents, Components.IxTimePicker>,
     serializeShadowRoot
 });
@@ -1932,7 +1933,7 @@ export const IxToast: StencilReactComponent<IxToastElement, IxToastEvents, Compo
         hideIcon: 'hide-icon',
         ariaLabelCloseIconButton: 'aria-label-close-icon-button'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxToast as StencilReactComponent<IxToastElement, IxToastEvents, Components.IxToast>,
     serializeShadowRoot
 });
@@ -1942,7 +1943,7 @@ export type IxToastContainerEvents = NonNullable<unknown>;
 export const IxToastContainer: StencilReactComponent<IxToastContainerElement, IxToastContainerEvents, Components.IxToastContainer> = /*@__PURE__*/ createComponent<IxToastContainerElement, IxToastContainerEvents, Components.IxToastContainer>({
     tagName: 'ix-toast-container',
     properties: { position: 'position' },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxToastContainer as StencilReactComponent<IxToastContainerElement, IxToastContainerEvents, Components.IxToastContainer>,
     serializeShadowRoot
 });
@@ -1966,7 +1967,7 @@ export const IxToggle: StencilReactComponent<IxToggleElement, IxToggleEvents, Co
         hideText: 'hide-text',
         required: 'required'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxToggle as StencilReactComponent<IxToggleElement, IxToggleEvents, Components.IxToggle>,
     serializeShadowRoot
 });
@@ -1983,7 +1984,7 @@ export const IxToggleButton: StencilReactComponent<IxToggleButtonElement, IxTogg
         iconRight: 'icon-right',
         pressed: 'pressed'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxToggleButton as StencilReactComponent<IxToggleButtonElement, IxToggleButtonEvents, Components.IxToggleButton>,
     serializeShadowRoot
 });
@@ -2001,7 +2002,7 @@ export const IxTooltip: StencilReactComponent<IxTooltipElement, IxTooltipEvents,
         hideDelay: 'hide-delay',
         animationFrame: 'animation-frame'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxTooltip as StencilReactComponent<IxTooltipElement, IxTooltipEvents, Components.IxTooltip>,
     serializeShadowRoot
 });
@@ -2016,7 +2017,7 @@ export const IxTypography: StencilReactComponent<IxTypographyElement, IxTypograp
         bold: 'bold',
         textDecoration: 'text-decoration'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxTypography as StencilReactComponent<IxTypographyElement, IxTypographyEvents, Components.IxTypography>,
     serializeShadowRoot
 });
@@ -2039,7 +2040,7 @@ export const IxUpload: StencilReactComponent<IxUploadElement, IxUploadEvents, Co
         i18nUploadFile: 'i18n-upload-file',
         i18nUploadDisabled: 'i18n-upload-disabled'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxUpload as StencilReactComponent<IxUploadElement, IxUploadEvents, Components.IxUpload>,
     serializeShadowRoot
 });
@@ -2056,7 +2057,7 @@ export const IxWorkflowStep: StencilReactComponent<IxWorkflowStepElement, IxWork
         selected: 'selected',
         position: 'position'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxWorkflowStep as StencilReactComponent<IxWorkflowStepElement, IxWorkflowStepEvents, Components.IxWorkflowStep>,
     serializeShadowRoot
 });
@@ -2070,7 +2071,7 @@ export const IxWorkflowSteps: StencilReactComponent<IxWorkflowStepsElement, IxWo
         clickable: 'clickable',
         selectedIndex: 'selected-index'
     },
-    hydrateModule: typeof window === 'undefined' ? (import('@siemens/ix/hydrate') as Promise<HydrateModule>) : undefined,
+    hydrateModule: import('@siemens/ix/hydrate') as Promise<HydrateModule>,
     clientModule: clientComponents.IxWorkflowSteps as StencilReactComponent<IxWorkflowStepsElement, IxWorkflowStepsEvents, Components.IxWorkflowSteps>,
     serializeShadowRoot
 });

--- a/packages/vue/src/components/ix-pane.ts
+++ b/packages/vue/src/components/ix-pane.ts
@@ -12,6 +12,7 @@ export const IxPane: StencilVueComponent<JSX.IxPane> = /*@__PURE__*/ defineConta
   'hideOnCollapse',
   'size',
   'borderless',
+  'noPadding',
   'expanded',
   'composition',
   'icon',


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

JIRA Ref: IX-4308
Docs PR: https://github.com/siemens/ix-docs/pull/250

## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

New prop "noPadding" added to remove inline and bottom padding in the content area of the ix-pane component.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [x] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
