### PR TITLE
fix(angular/modal): Fix programmatic modal closing

### DIFF
--- a/.changeset/fix-modal-closing-race.md
+++ b/.changeset/fix-modal-closing-race.md
@@ -1,0 +1,7 @@
+---
+'@siemens/ix-angular': patch
+---
+
+Fix modal closing race condition where `close()` or `dismiss()` called before modal element initialization would silently fail. Pending actions are now queued and executed once the modal element is set.
+
+Fixes #2595

--- a/packages/angular/common/src/providers/modal/modal-ref.ts
+++ b/packages/angular/common/src/providers/modal/modal-ref.ts
@@ -8,8 +8,19 @@
  */
 import { closeModal, dismissModal } from '@siemens/ix';
 
+type PendingModalAction<TReason> =
+  | {
+      type: 'close';
+      reason: TReason;
+    }
+  | {
+      type: 'dismiss';
+      reason?: TReason;
+    };
+
 export class IxActiveModal<TData = any, TReason = any> {
   modalElement: HTMLElement;
+  protected pendingAction?: PendingModalAction<TReason>;
 
   constructor(private readonly modalData?: TData) {}
 
@@ -23,6 +34,14 @@ export class IxActiveModal<TData = any, TReason = any> {
    * @param reason
    */
   public close(reason: TReason) {
+    if (!this.modalElement) {
+      this.pendingAction ??= {
+        type: 'close',
+        reason,
+      };
+      return;
+    }
+
     closeModal(this.modalElement, reason);
   }
 
@@ -32,6 +51,14 @@ export class IxActiveModal<TData = any, TReason = any> {
    * @param reason
    */
   public dismiss(reason?: TReason) {
+    if (!this.modalElement) {
+      this.pendingAction ??= {
+        type: 'dismiss',
+        reason,
+      };
+      return;
+    }
+
     dismissModal(this.modalElement, reason);
   }
 }
@@ -42,5 +69,17 @@ export class InternalIxActiveModal<
 > extends IxActiveModal<TData, TReason> {
   setModalElement(element: HTMLElement) {
     this.modalElement = element;
+
+    const pendingAction = this.pendingAction;
+    this.pendingAction = undefined;
+
+    if (pendingAction?.type === 'close') {
+      this.close(pendingAction.reason);
+      return;
+    }
+
+    if (pendingAction?.type === 'dismiss') {
+      this.dismiss(pendingAction.reason);
+    }
   }
 }

--- a/packages/angular/common/src/providers/modal/modal.service.spec.ts
+++ b/packages/angular/common/src/providers/modal/modal.service.spec.ts
@@ -6,10 +6,14 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { expect, test, jest } from '@jest/globals';
+import { beforeEach, expect, test, jest } from '@jest/globals';
+import { closeModal, dismissModal } from '@siemens/ix';
 import { ModalService, IxActiveModal } from './';
+import { InternalIxActiveModal } from './modal-ref';
 
 jest.mock('@siemens/ix', () => ({
+  closeModal: jest.fn(),
+  dismissModal: jest.fn(),
   showModal: jest.fn(() =>
     Promise.resolve({
       onClose: {
@@ -22,6 +26,10 @@ jest.mock('@siemens/ix', () => ({
     })
   ),
 }));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 test('should create modal by templateRef', () => {
   const appRefMock = {
@@ -136,4 +144,64 @@ test('should throw TypeError if instance cannot be closed', () => {
   expect(() => modalService.close(instance)).toThrow(
     'Invalid modal instance: cannot close'
   );
+});
+
+test('should close active modal immediately when modal element exists', () => {
+  const activeModal = new InternalIxActiveModal();
+  const modalElement = { type: 'html-element' } as any;
+
+  activeModal.setModalElement(modalElement);
+  activeModal.close('close-reason');
+
+  expect(closeModal).toHaveBeenCalledWith(modalElement, 'close-reason');
+});
+
+test('should dismiss active modal immediately when modal element exists', () => {
+  const activeModal = new InternalIxActiveModal();
+  const modalElement = { type: 'html-element' } as any;
+
+  activeModal.setModalElement(modalElement);
+  activeModal.dismiss('dismiss-reason');
+
+  expect(dismissModal).toHaveBeenCalledWith(modalElement, 'dismiss-reason');
+});
+
+test('should close active modal after modal element is set', () => {
+  const activeModal = new InternalIxActiveModal();
+  const modalElement = { type: 'html-element' } as any;
+
+  expect(() => activeModal.close('close-reason')).not.toThrow();
+  expect(closeModal).not.toHaveBeenCalled();
+
+  activeModal.setModalElement(modalElement);
+
+  expect(closeModal).toHaveBeenCalledTimes(1);
+  expect(closeModal).toHaveBeenCalledWith(modalElement, 'close-reason');
+});
+
+test('should dismiss active modal after modal element is set', () => {
+  const activeModal = new InternalIxActiveModal();
+  const modalElement = { type: 'html-element' } as any;
+
+  expect(() => activeModal.dismiss('dismiss-reason')).not.toThrow();
+  expect(dismissModal).not.toHaveBeenCalled();
+
+  activeModal.setModalElement(modalElement);
+
+  expect(dismissModal).toHaveBeenCalledTimes(1);
+  expect(dismissModal).toHaveBeenCalledWith(modalElement, 'dismiss-reason');
+});
+
+test('should only run first pending active modal action', () => {
+  const activeModal = new InternalIxActiveModal();
+  const modalElement = { type: 'html-element' } as any;
+
+  activeModal.close('close-reason');
+  activeModal.dismiss('dismiss-reason');
+
+  activeModal.setModalElement(modalElement);
+
+  expect(closeModal).toHaveBeenCalledTimes(1);
+  expect(closeModal).toHaveBeenCalledWith(modalElement, 'close-reason');
+  expect(dismissModal).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

GitHub Issue Number: #2595 
JIRA Ref:  #IX-4365

## 💡 What is the new behavior?

[Angular package]: Fixes modal closing race condition where `close()` or `dismiss()` called before modal element initialization would silently fail. Pending actions are now queued and executed once the modal element is set.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition where modal `close()`/`dismiss()` could be missed if called before the modal was fully initialized.
  * Modal actions are now queued and automatically executed once the modal becomes ready.
  * If both `close` and `dismiss` are requested early, only the first pending action is applied to keep behavior consistent.
* **Tests**
  * Expanded modal service coverage to validate immediate vs deferred close/dismiss behavior and the “first action wins” scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->