### PR TITLE
fix(action-card): render a button for proper accessibility

### DIFF
--- a/.changeset/pink-sloths-drop.md
+++ b/.changeset/pink-sloths-drop.md
@@ -1,0 +1,7 @@
+---
+'@siemens/ix': patch
+---
+
+Fix **ix-action-card** to render its content inside a `button` element so it is keyboard-focusable and exposed as a button to assistive technologies, improving accessibility.
+
+Note: the default slot is intended for non-interactive content. Nested interactive elements (links, buttons, inputs) inside the card are not supported, as the card is now a single button.

--- a/packages/core/src/components/action-card/action-card.scss
+++ b/packages/core/src/components/action-card/action-card.scss
@@ -21,8 +21,31 @@
 
   @include component.ix-component;
 
+
+  button {
+    width: 100%;
+    height: 100%;
+    display: block;
+    background: transparent;
+    text-align: start;
+    padding: 0;
+    border: 0;
+    border-radius: var(--theme-btn--border-radius);
+    box-shadow: initial;
+
+    &:focus-visible {
+      outline: 1px solid var(--theme-color-focus-bdr);
+      outline-offset: var(--theme-btn--focus--outline-offset);
+    }
+
+    &[disabled] {
+      cursor: default;
+    }
+  }
+
   ix-card {
     width: 100%;
     height: 100%;
   }
 }
+

--- a/packages/core/src/components/action-card/action-card.tsx
+++ b/packages/core/src/components/action-card/action-card.tsx
@@ -8,9 +8,12 @@
  */
 
 import { Component, h, Host, Prop } from '@stencil/core';
-import type { ActionCardVariant } from './action-card.types';
 import { a11yBoolean, getFallbackLabelFromIconName } from '../utils/a11y';
+import type { ActionCardVariant } from './action-card.types';
 
+/**
+ * @slot - Place additional non-interactive content inside the card. Avoid interactive elements (links, buttons, inputs) as the card itself is rendered as a single button.
+ */
 @Component({
   tag: 'ix-action-card',
   styleUrl: 'action-card.scss',
@@ -75,48 +78,53 @@ export class IxActionCard {
 
     return (
       <Host>
-        <ix-card
-          selected={this.selected}
-          variant={this.variant}
-          passive={this.passive}
-          class={'pointer'}
+        <button
+          type="button"
+          disabled={this.passive}
           aria-label={this.ariaLabelCard}
           aria-labelledby={ariaLabelledBy}
-          role={ariaLabelledBy ? 'group' : undefined}
         >
-          <ix-card-content>
-            {this.icon ? (
-              <ix-icon
-                class={'icon'}
-                name={this.icon}
-                size="32"
-                aria-label={
-                  this.ariaLabelIcon || getFallbackLabelFromIconName(this.icon)
-                }
-              ></ix-icon>
-            ) : null}
-            <div>
-              {this.heading ? (
-                <ix-typography
-                  id="ix-action-card-heading"
-                  aria-hidden={a11yBoolean(!ariaLabelledBy)}
-                  format="h4"
-                >
-                  {this.heading}
-                </ix-typography>
+          <ix-card
+            selected={this.selected}
+            variant={this.variant}
+            passive={this.passive}
+            class={this.passive ? undefined : 'pointer'}
+          >
+            <ix-card-content>
+              {this.icon ? (
+                <ix-icon
+                  class={'icon'}
+                  name={this.icon}
+                  size="32"
+                  aria-label={
+                    this.ariaLabelIcon ||
+                    getFallbackLabelFromIconName(this.icon)
+                  }
+                ></ix-icon>
               ) : null}
-              {this.subheading ? (
-                <ix-typography
-                  format="h5"
-                  text-color={this.getSubheadingTextColor()}
-                >
-                  {this.subheading}
-                </ix-typography>
-              ) : null}
-              <slot></slot>
-            </div>
-          </ix-card-content>
-        </ix-card>
+              <div>
+                {this.heading ? (
+                  <ix-typography
+                    id="ix-action-card-heading"
+                    aria-hidden={a11yBoolean(!ariaLabelledBy)}
+                    format="h4"
+                  >
+                    {this.heading}
+                  </ix-typography>
+                ) : null}
+                {this.subheading ? (
+                  <ix-typography
+                    format="h5"
+                    text-color={this.getSubheadingTextColor()}
+                  >
+                    {this.subheading}
+                  </ix-typography>
+                ) : null}
+                <slot></slot>
+              </div>
+            </ix-card-content>
+          </ix-card>
+        </button>
       </Host>
     );
   }

--- a/packages/core/src/components/action-card/test/action-card.ct.ts
+++ b/packages/core/src/components/action-card/test/action-card.ct.ts
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { expect } from '@playwright/test';
+import { regressionTest } from '@utils/test';
+
+regressionTest('renders', async ({ mount, page }) => {
+  await mount(`
+    <ix-action-card heading="Heading" subheading="Subheading"></ix-action-card>
+  `);
+  const actionCard = page.locator('ix-action-card');
+  await expect(actionCard).toHaveClass(/\bhydrated\b/);
+  await expect(actionCard.locator('button')).toBeVisible();
+});
+
+regressionTest(
+  'passive card renders a disabled button',
+  async ({ mount, page }) => {
+    await mount(`
+      <ix-action-card heading="Heading" subheading="Subheading" passive></ix-action-card>
+    `);
+    const actionCard = page.locator('ix-action-card');
+    await expect(actionCard).toHaveClass(/\bhydrated\b/);
+    await expect(actionCard.locator('button')).toBeDisabled();
+  }
+);
+
+regressionTest.describe('accessibility', () => {
+  regressionTest('default', async ({ mount, makeAxeBuilder }) => {
+    await mount(`
+      <ix-action-card heading="Heading" subheading="Subheading"></ix-action-card>
+    `);
+
+    const accessibilityScanResults = await makeAxeBuilder().analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+
+  regressionTest('passive', async ({ mount, makeAxeBuilder }) => {
+    await mount(`
+      <ix-action-card heading="Heading" subheading="Subheading" passive></ix-action-card>
+    `);
+
+    const accessibilityScanResults = await makeAxeBuilder().analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Description

Wraps the inner `ix-card` of `ix-action-card` in a `button` element so the card is keyboard-focusable and exposed as a button to assistive technologies.

## User-facing impact

`ix-action-card` is now properly accessible: it is focusable and announced as a button.

## Affected packages

- `@siemens/ix` (patch)

## Validation

- Changeset added (`@siemens/ix` patch)

## Release impact

Patch — accessibility bug fix, no breaking change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for `ix-action-card` by rendering the card as a native `<button>` with focus-visible styling.
  * Ensured the entire card area is the interactive target and added appropriate button semantics (`aria-label`/`aria-labelledby`).
  * When `passive` is set, the card’s button is disabled.
* **Tests**
  * Added Playwright regression coverage and Axe accessibility scans for both default and `passive` variants.
* **Chores**
  * Published a patch release note for `ix-action-card` accessibility improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->