### PR TITLE
Replace ComponentFactoryResolver with modern Angular API

### DIFF
--- a/.changeset/twenty-spies-love.md
+++ b/.changeset/twenty-spies-love.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix-angular': patch
+---
+
+Replaced deprecated ComponentFactoryResolver API

--- a/.changeset/twenty-spies-love.md
+++ b/.changeset/twenty-spies-love.md
@@ -2,4 +2,4 @@
 '@siemens/ix-angular': patch
 ---
 
-Replaced deprecated ComponentFactoryResolver API
+Replaced deprecated ComponentFactoryResolver API. Fixes #2608

--- a/packages/angular/common/src/providers/modal/modal.service.spec.ts
+++ b/packages/angular/common/src/providers/modal/modal.service.spec.ts
@@ -50,7 +50,11 @@ test('should create modal by templateRef', () => {
     rootNodes: [{}],
     detectChanges: jest.fn(),
   }));
-  const modalService = new ModalService(appRefMock as any, {} as any);
+  const modalService = new ModalService(
+    appRefMock as any,
+    {} as any,
+    {} as any
+  );
   modalService.open({
     content: {
       createEmbeddedView: createEmbeddedViewMock,
@@ -73,7 +77,6 @@ test('should create modal by templateRef', () => {
 test('should create modal by component type', async () => {
   const appRefMock = {
     attachView: jest.fn(),
-    injector: {},
   };
   const nativeElement: { style: { display?: string } } = { style: {} };
   const hostView = {
@@ -88,11 +91,16 @@ test('should create modal by component type', async () => {
       })),
     },
   };
+  const environmentInjectorMock = {};
   const injectorMock = {};
 
   jest.mocked(createComponent).mockReturnValue(componentRef as any);
 
-  const modalService = new ModalService(appRefMock as any, injectorMock as any);
+  const modalService = new ModalService(
+    appRefMock as any,
+    environmentInjectorMock as any,
+    injectorMock as any
+  );
 
   class TestComponent {
     foo = 'bar';
@@ -109,7 +117,7 @@ test('should create modal by component type', async () => {
     .calls as any;
 
   expect(createComponent).toHaveBeenCalledWith(TestComponent, {
-    environmentInjector: appRefMock.injector as any,
+    environmentInjector: environmentInjectorMock as any,
     elementInjector: createOptions.elementInjector,
   });
   expect(componentType).toBe(TestComponent);
@@ -137,7 +145,7 @@ test('should close modal instance with reason and mark as closed', () => {
       closed: false,
     },
   };
-  const modalService = new ModalService({} as any, {} as any);
+  const modalService = new ModalService({} as any, {} as any, {} as any);
   const reason = 'user-dismissed';
   modalService.close(instance, reason);
   expect(closeModalMock).toHaveBeenCalledWith(reason);
@@ -148,7 +156,7 @@ test('should throw TypeError if instance cannot be closed', () => {
   const instance = {
     htmlElement: {},
   };
-  const modalService = new ModalService({} as any, {} as any);
+  const modalService = new ModalService({} as any, {} as any, {} as any);
 
   expect(() => modalService.close(instance)).toThrow(TypeError);
   expect(() => modalService.close(instance)).toThrow(

--- a/packages/angular/common/src/providers/modal/modal.service.spec.ts
+++ b/packages/angular/common/src/providers/modal/modal.service.spec.ts
@@ -50,11 +50,7 @@ test('should create modal by templateRef', () => {
     rootNodes: [{}],
     detectChanges: jest.fn(),
   }));
-  const modalService = new ModalService(
-    appRefMock as any,
-    {} as any,
-    {} as any
-  );
+  const modalService = new ModalService(appRefMock as any, {} as any);
   modalService.open({
     content: {
       createEmbeddedView: createEmbeddedViewMock,
@@ -77,6 +73,7 @@ test('should create modal by templateRef', () => {
 test('should create modal by component type', async () => {
   const appRefMock = {
     attachView: jest.fn(),
+    injector: {},
   };
   const nativeElement: { style: { display?: string } } = { style: {} };
   const hostView = {
@@ -91,16 +88,11 @@ test('should create modal by component type', async () => {
       })),
     },
   };
-  const environmentInjectorMock = {};
   const injectorMock = {};
 
   jest.mocked(createComponent).mockReturnValue(componentRef as any);
 
-  const modalService = new ModalService(
-    appRefMock as any,
-    environmentInjectorMock as any,
-    injectorMock as any
-  );
+  const modalService = new ModalService(appRefMock as any, injectorMock as any);
 
   class TestComponent {
     foo = 'bar';
@@ -117,7 +109,7 @@ test('should create modal by component type', async () => {
     .calls as any;
 
   expect(createComponent).toHaveBeenCalledWith(TestComponent, {
-    environmentInjector: environmentInjectorMock as any,
+    environmentInjector: appRefMock.injector as any,
     elementInjector: createOptions.elementInjector,
   });
   expect(componentType).toBe(TestComponent);
@@ -145,7 +137,7 @@ test('should close modal instance with reason and mark as closed', () => {
       closed: false,
     },
   };
-  const modalService = new ModalService({} as any, {} as any, {} as any);
+  const modalService = new ModalService({} as any, {} as any);
   const reason = 'user-dismissed';
   modalService.close(instance, reason);
   expect(closeModalMock).toHaveBeenCalledWith(reason);
@@ -156,7 +148,7 @@ test('should throw TypeError if instance cannot be closed', () => {
   const instance = {
     htmlElement: {},
   };
-  const modalService = new ModalService({} as any, {} as any, {} as any);
+  const modalService = new ModalService({} as any, {} as any);
 
   expect(() => modalService.close(instance)).toThrow(TypeError);
   expect(() => modalService.close(instance)).toThrow(

--- a/packages/angular/common/src/providers/modal/modal.service.spec.ts
+++ b/packages/angular/common/src/providers/modal/modal.service.spec.ts
@@ -10,6 +10,21 @@ import { beforeEach, expect, test, jest } from '@jest/globals';
 import { closeModal, dismissModal } from '@siemens/ix';
 import { ModalService, IxActiveModal } from './';
 import { InternalIxActiveModal } from './modal-ref';
+import { createComponent } from '@angular/core';
+
+jest.mock('@angular/core', () => {
+  const actual =
+    jest.requireActual<typeof import('@angular/core')>('@angular/core');
+
+  return {
+    ...actual,
+    createComponent: jest.fn(),
+    Injector: {
+      ...actual.Injector,
+      create: jest.fn(actual.Injector.create.bind(actual.Injector)),
+    },
+  };
+});
 
 jest.mock('@siemens/ix', () => ({
   closeModal: jest.fn(),
@@ -63,31 +78,31 @@ test('should create modal by templateRef', () => {
   expect(appRefMock.attachView).toHaveBeenCalled();
 });
 
-test('should create modal by component typ', async () => {
+test('should create modal by component type', async () => {
   const appRefMock = {
     attachView: jest.fn(),
   };
-  const factory = {
-    create: jest.fn(() => ({
-      hostView: {
-        rootNodes: [jest.fn()],
-        detectChanges: jest.fn(),
-      },
-      injector: {
-        get: jest.fn(() => ({
-          nativeElement: { style: {} },
-        })),
-      },
-    })),
+  const nativeElement: { style: { display?: string } } = { style: {} };
+  const hostView = {
+    detectChanges: jest.fn(),
+    destroy: jest.fn(),
   };
-  const componentFactoryMock = {
-    resolveComponentFactory: jest.fn(() => factory),
+  const componentRef = {
+    hostView,
+    injector: {
+      get: jest.fn(() => ({
+        nativeElement,
+      })),
+    },
   };
-  const injectorMock = jest.fn();
+  const environmentInjectorMock = {};
+  const injectorMock = {};
+
+  jest.mocked(createComponent).mockReturnValue(componentRef as any);
 
   const modalService = new ModalService(
     appRefMock as any,
-    componentFactoryMock as any,
+    environmentInjectorMock as any,
     injectorMock as any
   );
 
@@ -102,14 +117,21 @@ test('should create modal by component typ', async () => {
     },
   });
 
-  const [[{ records }]] = factory.create.mock.calls as any;
+  const [[componentType, createOptions]] = jest.mocked(createComponent).mock
+    .calls as any;
 
-  const injectorRecords = records as Map<Function, any>;
-
-  expect(injectorRecords.get(IxActiveModal).value).toEqual({
-    modalData: { foo: 'bar' },
-    modalElement: { type: 'html-element' },
+  expect(createComponent).toHaveBeenCalledWith(TestComponent, {
+    environmentInjector: environmentInjectorMock as any,
+    elementInjector: createOptions.elementInjector,
   });
+  expect(componentType).toBe(TestComponent);
+
+  const activeModal = createOptions.elementInjector.get(
+    IxActiveModal
+  ) as IxActiveModal;
+
+  expect(activeModal.data).toEqual({ foo: 'bar' });
+  expect(activeModal.modalElement).toEqual({ type: 'html-element' });
 });
 
 test('should close modal instance with reason and mark as closed', () => {

--- a/packages/angular/common/src/providers/modal/modal.service.spec.ts
+++ b/packages/angular/common/src/providers/modal/modal.service.spec.ts
@@ -19,10 +19,6 @@ jest.mock('@angular/core', () => {
   return {
     ...actual,
     createComponent: jest.fn(),
-    Injector: {
-      ...actual.Injector,
-      create: jest.fn(actual.Injector.create.bind(actual.Injector)),
-    },
   };
 });
 

--- a/packages/angular/common/src/providers/modal/modal.service.ts
+++ b/packages/angular/common/src/providers/modal/modal.service.ts
@@ -10,7 +10,6 @@ import {
   ApplicationRef,
   createComponent,
   ElementRef,
-  EnvironmentInjector,
   Injectable,
   Injector,
   TemplateRef,
@@ -33,7 +32,6 @@ export type ModalContext<T> = {
 export class ModalService {
   constructor(
     private readonly appRef: ApplicationRef,
-    private readonly environmentInjector: EnvironmentInjector,
     private readonly injector: Injector
   ) {}
 
@@ -90,7 +88,7 @@ export class ModalService {
     });
 
     const instance = createComponent(componentType, {
-      environmentInjector: this.environmentInjector,
+      environmentInjector: this.appRef.injector,
       elementInjector: elementInjector,
     });
     this.appRef.attachView(instance.hostView);

--- a/packages/angular/common/src/providers/modal/modal.service.ts
+++ b/packages/angular/common/src/providers/modal/modal.service.ts
@@ -8,8 +8,9 @@
  */
 import {
   ApplicationRef,
-  ComponentFactoryResolver,
+  createComponent,
   ElementRef,
+  EnvironmentInjector,
   Injectable,
   Injector,
   TemplateRef,
@@ -32,7 +33,7 @@ export type ModalContext<T> = {
 export class ModalService {
   constructor(
     private appRef: ApplicationRef,
-    private componentFactoryResolver: ComponentFactoryResolver,
+    private environmentInjector: EnvironmentInjector,
     private injector: Injector
   ) {}
 
@@ -78,10 +79,7 @@ export class ModalService {
   ) {
     const activeModal = new InternalIxActiveModal<TData>(context.data);
 
-    const modalFactory =
-      this.componentFactoryResolver.resolveComponentFactory(componentType);
-
-    const modalInjector = Injector.create({
+    const elementInjector = Injector.create({
       providers: [
         {
           provide: IxActiveModal,
@@ -91,7 +89,10 @@ export class ModalService {
       parent: this.injector,
     });
 
-    const instance = modalFactory.create(modalInjector);
+    const instance = createComponent(componentType, {
+      environmentInjector: this.environmentInjector,
+      elementInjector: elementInjector,
+    });
     this.appRef.attachView(instance.hostView);
 
     const element = instance.injector.get(ElementRef);

--- a/packages/angular/common/src/providers/modal/modal.service.ts
+++ b/packages/angular/common/src/providers/modal/modal.service.ts
@@ -32,9 +32,9 @@ export type ModalContext<T> = {
 })
 export class ModalService {
   constructor(
-    private appRef: ApplicationRef,
-    private environmentInjector: EnvironmentInjector,
-    private injector: Injector
+    private readonly appRef: ApplicationRef,
+    private readonly environmentInjector: EnvironmentInjector,
+    private readonly injector: Injector
   ) {}
 
   public close<TReason = any>(

--- a/packages/angular/common/src/providers/modal/modal.service.ts
+++ b/packages/angular/common/src/providers/modal/modal.service.ts
@@ -10,6 +10,7 @@ import {
   ApplicationRef,
   createComponent,
   ElementRef,
+  EnvironmentInjector,
   Injectable,
   Injector,
   TemplateRef,
@@ -32,6 +33,7 @@ export type ModalContext<T> = {
 export class ModalService {
   constructor(
     private readonly appRef: ApplicationRef,
+    private readonly environmentInjector: EnvironmentInjector,
     private readonly injector: Injector
   ) {}
 
@@ -88,7 +90,7 @@ export class ModalService {
     });
 
     const instance = createComponent(componentType, {
-      environmentInjector: this.appRef.injector,
+      environmentInjector: this.environmentInjector,
       elementInjector: elementInjector,
     });
     this.appRef.attachView(instance.hostView);

--- a/packages/angular/src/providers/modal/modal.service.ts
+++ b/packages/angular/src/providers/modal/modal.service.ts
@@ -8,6 +8,7 @@
  */
 import {
   ApplicationRef,
+  EnvironmentInjector,
   Injectable,
   Injector,
 } from '@angular/core';
@@ -27,8 +28,12 @@ export type ModalContext<T> = {
   providedIn: 'root',
 })
 export class ModalService extends BaseModalService {
-  constructor(appRef: ApplicationRef, injector: Injector) {
-    super(appRef, injector);
+  constructor(
+    appRef: ApplicationRef,
+    environmentInjector: EnvironmentInjector,
+    injector: Injector
+  ) {
+    super(appRef, environmentInjector, injector);
   }
 
   /**

--- a/packages/angular/src/providers/modal/modal.service.ts
+++ b/packages/angular/src/providers/modal/modal.service.ts
@@ -8,7 +8,7 @@
  */
 import {
   ApplicationRef,
-  ComponentFactoryResolver,
+  EnvironmentInjector,
   Injectable,
   Injector,
 } from '@angular/core';
@@ -30,10 +30,10 @@ export type ModalContext<T> = {
 export class ModalService extends BaseModalService {
   constructor(
     appRef: ApplicationRef,
-    componentFactoryResolver: ComponentFactoryResolver,
+    environmentInjector: EnvironmentInjector,
     injector: Injector
   ) {
-    super(appRef, componentFactoryResolver, injector);
+    super(appRef, environmentInjector, injector);
   }
 
   /**

--- a/packages/angular/src/providers/modal/modal.service.ts
+++ b/packages/angular/src/providers/modal/modal.service.ts
@@ -8,7 +8,6 @@
  */
 import {
   ApplicationRef,
-  EnvironmentInjector,
   Injectable,
   Injector,
 } from '@angular/core';
@@ -28,12 +27,8 @@ export type ModalContext<T> = {
   providedIn: 'root',
 })
 export class ModalService extends BaseModalService {
-  constructor(
-    appRef: ApplicationRef,
-    environmentInjector: EnvironmentInjector,
-    injector: Injector
-  ) {
-    super(appRef, environmentInjector, injector);
+  constructor(appRef: ApplicationRef, injector: Injector) {
+    super(appRef, injector);
   }
 
   /**

--- a/packages/angular/standalone/src/providers/modal.ts
+++ b/packages/angular/standalone/src/providers/modal.ts
@@ -13,7 +13,7 @@ import {
 import { ModalInstance } from '@siemens/ix';
 import {
   ApplicationRef,
-  ComponentFactoryResolver,
+  EnvironmentInjector,
   Injectable,
   Injector,
 } from '@angular/core';
@@ -25,10 +25,10 @@ export { IxActiveModal } from '@siemens/ix-angular/common';
 export class ModalService extends BaseModalService {
   constructor(
     appRef: ApplicationRef,
-    componentFactoryResolver: ComponentFactoryResolver,
+    environmentInjector: EnvironmentInjector,
     injector: Injector
   ) {
-    super(appRef, componentFactoryResolver, injector);
+    super(appRef, environmentInjector, injector);
 
     defineCustomElement();
   }

--- a/packages/angular/standalone/src/providers/modal.ts
+++ b/packages/angular/standalone/src/providers/modal.ts
@@ -13,7 +13,6 @@ import {
 import { ModalInstance } from '@siemens/ix';
 import {
   ApplicationRef,
-  EnvironmentInjector,
   Injectable,
   Injector,
 } from '@angular/core';
@@ -23,12 +22,8 @@ export { IxActiveModal } from '@siemens/ix-angular/common';
 
 @Injectable({ providedIn: 'root' })
 export class ModalService extends BaseModalService {
-  constructor(
-    appRef: ApplicationRef,
-    environmentInjector: EnvironmentInjector,
-    injector: Injector
-  ) {
-    super(appRef, environmentInjector, injector);
+  constructor(appRef: ApplicationRef, injector: Injector) {
+    super(appRef, injector);
 
     defineCustomElement();
   }

--- a/packages/angular/standalone/src/providers/modal.ts
+++ b/packages/angular/standalone/src/providers/modal.ts
@@ -13,6 +13,7 @@ import {
 import { ModalInstance } from '@siemens/ix';
 import {
   ApplicationRef,
+  EnvironmentInjector,
   Injectable,
   Injector,
 } from '@angular/core';
@@ -22,8 +23,12 @@ export { IxActiveModal } from '@siemens/ix-angular/common';
 
 @Injectable({ providedIn: 'root' })
 export class ModalService extends BaseModalService {
-  constructor(appRef: ApplicationRef, injector: Injector) {
-    super(appRef, injector);
+  constructor(
+    appRef: ApplicationRef,
+    environmentInjector: EnvironmentInjector,
+    injector: Injector
+  ) {
+    super(appRef, environmentInjector, injector);
 
     defineCustomElement();
   }


### PR DESCRIPTION
ComponentFactoryResolver has been deprecated since Angular 13. With Angular 22, the API has been removed, which breaks modals if  you're trying to upgrade to Angular 22 with Ix v5.

This PR replaces the ComponentFactoryResolver with a modern equivalent.

Fixes #2608 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal component creation by switching to Angular’s current dynamic component API and the appropriate injector-based setup.
  * Updated modal dependency-injection wiring across Angular variants to remove reliance on a deprecated factory-resolver approach.
* **Tests**
  * Refreshed modal unit tests to match the new creation and injection flow, including updated assertions for active modal values.
* **Chores**
  * Released a patch update for the Angular package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->