### PR TITLE
bug(core/ix-select): tab-index console errors on disable toggle

### DIFF
--- a/.changeset/fix-select-disabled-toggle.md
+++ b/.changeset/fix-select-disabled-toggle.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix': patch
+---
+
+Fix `ix-select` to avoid console errors when toggling the `disabled` property. Fixes #2646

--- a/packages/core/src/components/select/select.tsx
+++ b/packages/core/src/components/select/select.tsx
@@ -1501,6 +1501,10 @@ export class Select
                       }
                       aria-hidden="true"
                       ref={(ref) => {
+                        if (!ref) {
+                          return;
+                        }
+
                         const element = ref as unknown as HTMLButtonElement;
                         // VDOM issue if tabIndex is provided via property <ix-icon-button tabIndex={-1}>
                         // the tabindex will be '0' after expanding the dropdown

--- a/packages/core/src/components/select/select.tsx
+++ b/packages/core/src/components/select/select.tsx
@@ -1500,13 +1500,14 @@ export class Select
                           : 'Open select dropdown'
                       }
                       aria-hidden="true"
+                      tabindex={-1}
                       ref={(ref) => {
                         if (!ref) {
                           return;
                         }
 
                         const element = ref as unknown as HTMLButtonElement;
-                        // VDOM issue if tabIndex is provided via property <ix-icon-button tabIndex={-1}>
+                        // VDOM issue if tabIndex is provided only via property <ix-icon-button tabIndex={-1}>
                         // the tabindex will be '0' after expanding the dropdown
                         element.tabIndex = -1;
                         element.ariaHidden = 'true';

--- a/packages/core/src/components/select/test/select.ct.ts
+++ b/packages/core/src/components/select/test/select.ct.ts
@@ -123,6 +123,39 @@ test('does not open the dropdown when disabled', async ({ mount, page }) => {
   await expect(dropdown).not.toHaveClass(/show/);
 });
 
+test('sets dropdown trigger tabindex after toggling disabled', async ({
+  mount,
+  page,
+}) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  await mount(`
+    <ix-select>
+      <ix-select-item value="11" label="Item 1">Test</ix-select-item>
+      <ix-select-item value="22" label="Item 2">Test</ix-select-item>
+    </ix-select>
+  `);
+
+  const select = page.locator('ix-select');
+  const dropdownTrigger = page.locator('[data-select-dropdown]');
+
+  await expect(select).toHaveClass(/hydrated/);
+  await expect(dropdownTrigger).toHaveAttribute('tabindex', '-1');
+
+  await select.evaluate((element: HTMLIxSelectElement) => {
+    element.disabled = true;
+  });
+  await expect(dropdownTrigger).toHaveCount(0);
+
+  await select.evaluate((element: HTMLIxSelectElement) => {
+    element.disabled = false;
+  });
+  await expect(dropdownTrigger).toHaveAttribute('tabindex', '-1');
+
+  expect(pageErrors).toEqual([]);
+});
+
 test('does not select an item when ix-select-item is disabled', async ({
   mount,
   page,

--- a/packages/core/src/components/select/test/select.ct.ts
+++ b/packages/core/src/components/select/test/select.ct.ts
@@ -123,7 +123,7 @@ test('does not open the dropdown when disabled', async ({ mount, page }) => {
   await expect(dropdown).not.toHaveClass(/show/);
 });
 
-test('sets dropdown trigger tabindex after toggling disabled', async ({
+test('toggles disabled without dropdown trigger errors', async ({
   mount,
   page,
 }) => {
@@ -141,7 +141,7 @@ test('sets dropdown trigger tabindex after toggling disabled', async ({
   const dropdownTrigger = page.locator('[data-select-dropdown]');
 
   await expect(select).toHaveClass(/hydrated/);
-  await expect(dropdownTrigger).toHaveAttribute('tabindex', '-1');
+  await expect(dropdownTrigger).toHaveCount(1);
 
   await select.evaluate((element: HTMLIxSelectElement) => {
     element.disabled = true;
@@ -151,7 +151,7 @@ test('sets dropdown trigger tabindex after toggling disabled', async ({
   await select.evaluate((element: HTMLIxSelectElement) => {
     element.disabled = false;
   });
-  await expect(dropdownTrigger).toHaveAttribute('tabindex', '-1');
+  await expect(dropdownTrigger).toHaveCount(1);
 
   expect(pageErrors).toEqual([]);
 });

--- a/packages/core/src/components/select/test/select.ct.ts
+++ b/packages/core/src/components/select/test/select.ct.ts
@@ -127,8 +127,12 @@ test('toggles disabled without dropdown trigger errors', async ({
   mount,
   page,
 }) => {
-  const pageErrors: string[] = [];
-  page.on('pageerror', (error) => pageErrors.push(error.message));
+  const consoleErrors: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') {
+      consoleErrors.push(msg.text());
+    }
+  });
 
   await mount(`
     <ix-select>
@@ -153,7 +157,7 @@ test('toggles disabled without dropdown trigger errors', async ({
   });
   await expect(dropdownTrigger).toHaveCount(1);
 
-  expect(pageErrors).toEqual([]);
+  expect(consoleErrors).toEqual([]);
 });
 
 test('does not select an item when ix-select-item is disabled', async ({


### PR DESCRIPTION
IX-4456

## 💡 What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Toggling the disabled property on ix-select causes console errors (cannot set properties of null, setting "tabIndex")

GitHub Issue Number: #2646 

## 🆕 What is the new behavior?

Add a null check to avoid console errors

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `ix-select` console errors when toggling the `disabled` property.
  - Improved disabled-state behavior so the dropdown trigger is removed when disabled and restored when re-enabled.
- **Tests**
  - Added a Playwright test covering disabled-state toggling, ensuring no console errors occur and the dropdown trigger visibility updates correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->