### PR TITLE
Handle invalid text and classes for input controls.

### DIFF
--- a/packages/core/src/components/input/input.tsx
+++ b/packages/core/src/components/input/input.tsx
@@ -40,6 +40,7 @@ import {
   onInputFocus,
   onInputBlurWithChange,
   onEnterKeyChangeEmit,
+  syncInvalidClassWithText,
 } from './input.util';
 
 let inputIds = 0;
@@ -210,9 +211,15 @@ export class Input implements IxInputFieldComponent<string> {
     this.inputType = this.type;
   }
 
+  @Watch('invalidText')
+  onInvalidTextChange(invalidText?: string) {
+    syncInvalidClassWithText(this, invalidText);
+  }
+
   componentWillLoad() {
     this.updateFormInternalValue(this.value);
     this.inputType = this.type;
+    this.onInvalidTextChange(this.invalidText);
   }
 
   connectedCallback(): void {

--- a/packages/core/src/components/input/input.util.ts
+++ b/packages/core/src/components/input/input.util.ts
@@ -100,6 +100,30 @@ export function onInputBlur<T>(
   checkInternalValidity(comp, input);
 }
 
+const invalidClassManagedHosts = new WeakSet<HTMLElement>();
+
+export function syncInvalidClassWithText<T>(
+  comp: IxFormComponent<T>,
+  invalidText?: string
+) {
+  const hostElement = comp.hostElement;
+
+  if (invalidText) {
+    invalidClassManagedHosts.add(hostElement);
+    hostElement.classList.add('ix-invalid');
+    return;
+  }
+
+  if (
+    invalidClassManagedHosts.has(hostElement) &&
+    !hostElement.classList.contains('ix-invalid--validity-invalid') &&
+    !hostElement.classList.contains('ix-invalid--required')
+  ) {
+    hostElement.classList.remove('ix-invalid');
+    invalidClassManagedHosts.delete(hostElement);
+  }
+}
+
 export function applyPaddingEnd(
   inputElement: HTMLElement | null,
   width: number,

--- a/packages/core/src/components/input/number-input.tsx
+++ b/packages/core/src/components/input/number-input.tsx
@@ -38,6 +38,7 @@ import {
   onInputFocus,
   onInputBlurWithChange,
   onEnterKeyChangeEmit,
+  syncInvalidClassWithText,
 } from './input.util';
 
 let numberInputIds = 0;
@@ -223,6 +224,12 @@ export class NumberInput implements IxInputFieldComponent<number> {
 
   componentWillLoad() {
     this.updateFormInternalValue(this.value!);
+    this.onInvalidTextChange(this.invalidText);
+  }
+
+  @Watch('invalidText')
+  onInvalidTextChange(invalidText?: string) {
+    syncInvalidClassWithText(this, invalidText);
   }
 
   connectedCallback() {

--- a/packages/core/src/components/input/textarea.tsx
+++ b/packages/core/src/components/input/textarea.tsx
@@ -33,6 +33,7 @@ import {
   onInputFocus,
   onInputBlurWithChange,
   checkInternalValidity,
+  syncInvalidClassWithText,
 } from './input.util';
 import { normalizeCssDimension } from '../utils/unit-conversion.util';
 import type { TextareaResizeBehavior } from './textarea.types';
@@ -220,6 +221,12 @@ export class Textarea implements IxInputFieldComponent<string> {
 
   componentWillLoad() {
     this.updateFormInternalValue(this.value);
+    this.onInvalidTextChange(this.invalidText);
+  }
+
+  @Watch('invalidText')
+  onInvalidTextChange(invalidText?: string) {
+    syncInvalidClassWithText(this, invalidText);
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
## 💡 What is the current behavior?

The Input field Invalid State post inputting invalid input reappears even after removing the invalid input and start entering valid input. 

GitHub Issue Number: #2617 

## 🆕 What is the new behavior?
Fixes the issue where ix-input incorrectly removed a user-provided ix-invalid class on load when the invalidText prop wasn't set. The class is now only auto-removed if it was previously added by the component itself, so manually-applied validation classes are preserved as before.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):


- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [x] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [x] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
