### PR TITLE
docs: Add missing slot descriptions

### DIFF
--- a/packages/core/src/components/action-card/action-card.tsx
+++ b/packages/core/src/components/action-card/action-card.tsx
@@ -12,7 +12,7 @@ import { a11yBoolean, getFallbackLabelFromIconName } from '../utils/a11y';
 import type { ActionCardVariant } from './action-card.types';
 
 /**
- * @slot - Place additional non-interactive content inside the card. Avoid interactive elements (links, buttons, inputs) as the card itself is rendered as a single button.
+ * @slot default - Place additional non-interactive content inside the card. Avoid interactive elements (links, buttons, inputs) as the card itself is rendered as a single button.
  */
 @Component({
   tag: 'ix-action-card',

--- a/packages/core/src/components/application-header/application-header.tsx
+++ b/packages/core/src/components/application-header/application-header.tsx
@@ -37,6 +37,7 @@ import { Disposable } from '../utils/typed-event';
  * @slot secondary - Place additional items inside the header. They will appear after logo and name. If the screen size is small, the items will be shown inside a dropdown.
  * @slot overflow - Use this slot to display additional items that do not fit in the default or secondary slot.
  * @slot logo - Place a company logo inside the header. Alternatively the companyLogo property can be set.
+ * @slot ix-application-header-avatar - Place an avatar at the end of the header.
  */
 @Component({
   tag: 'ix-application-header',

--- a/packages/core/src/components/application/application.tsx
+++ b/packages/core/src/components/application/application.tsx
@@ -20,6 +20,13 @@ import { hasSlottedElements } from '../utils/shadow-dom';
 import { themeSwitcher, ThemeVariant } from '../utils/theme-switcher';
 import { Disposable } from '../utils/typed-event';
 
+/**
+ * @slot application-header - Header displayed at the top of the application.
+ * @slot menu - Main application navigation.
+ * @slot application-sidebar - Sidebar displayed next to the main content.
+ * @slot default - Main application content.
+ * @slot bottom - Footer displayed below the main content.
+ */
 @Component({
   tag: 'ix-application',
   styleUrl: 'application.scss',

--- a/packages/core/src/components/avatar/avatar.tsx
+++ b/packages/core/src/components/avatar/avatar.tsx
@@ -130,6 +130,9 @@ function UserInfo(
   );
 }
 
+/**
+ * @slot default - Custom content displayed inside the avatar dropdown when placed inside header.
+ */
 @Component({
   tag: 'ix-avatar',
   styleUrl: 'avatar.scss',

--- a/packages/core/src/components/blind/blind.tsx
+++ b/packages/core/src/components/blind/blind.tsx
@@ -27,7 +27,7 @@ import Animation from '../utils/animation';
 let sequentialInstanceId = 0;
 
 /**
- * @slot custom-header - Custom content replacing the default header.
+ * @slot custom-header - Custom content inside blind header.
  * @slot header-actions - Actions displayed at the end of the header.
  * @slot default - Expandable blind content.
  */

--- a/packages/core/src/components/blind/blind.tsx
+++ b/packages/core/src/components/blind/blind.tsx
@@ -26,6 +26,11 @@ import Animation from '../utils/animation';
 
 let sequentialInstanceId = 0;
 
+/**
+ * @slot custom-header - Custom content replacing the default header.
+ * @slot header-actions - Actions displayed at the end of the header.
+ * @slot default - Expandable blind content.
+ */
 @Component({
   tag: 'ix-blind',
   styleUrl: 'blind.scss',

--- a/packages/core/src/components/breadcrumb-item/breadcrumb-item.tsx
+++ b/packages/core/src/components/breadcrumb-item/breadcrumb-item.tsx
@@ -29,6 +29,9 @@ import {
 } from '../utils/internal/mixins/accessibility/inherit-aria-attributes.mixin';
 import type { BreadcrumbClick } from '../breadcrumb/breadcrumb.types';
 
+/**
+ * @slot default - Breadcrumb item label.
+ */
 @Component({
   tag: 'ix-breadcrumb-item',
   styleUrl: 'breadcrumb-item.scss',

--- a/packages/core/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/core/src/components/breadcrumb/breadcrumb.tsx
@@ -25,6 +25,9 @@ import { DefaultMixins } from '../utils/internal/component';
 import { createMutationObserver } from '../utils/mutation-observer';
 import type { BreadcrumbClick } from './breadcrumb.types';
 
+/**
+ * @slot default - Breadcrumb items.
+ */
 @Component({
   tag: 'ix-breadcrumb',
   styleUrl: 'breadcrumb.scss',

--- a/packages/core/src/components/button/button.tsx
+++ b/packages/core/src/components/button/button.tsx
@@ -31,6 +31,9 @@ export type ButtonVariant =
   | `${BaseButtonVariant}`
   | `${BaseButtonStyle}-${BaseButtonVariant}`;
 
+/**
+ * @slot default - Button label.
+ */
 @Component({
   tag: 'ix-button',
   shadow: {

--- a/packages/core/src/components/card-accordion/card-accordion.tsx
+++ b/packages/core/src/components/card-accordion/card-accordion.tsx
@@ -20,6 +20,9 @@ const getAriaControlsId = (prefix: string = 'expand-content') => {
   return [prefix, accordionControlId++].join('-');
 };
 
+/**
+ * @slot default - Accordion content.
+ */
 @Component({
   tag: 'ix-card-accordion',
   styleUrl: 'card-accordion.scss',

--- a/packages/core/src/components/card-content/card-content.tsx
+++ b/packages/core/src/components/card-content/card-content.tsx
@@ -1,5 +1,8 @@
 import { Component, h, Host } from '@stencil/core';
 
+/**
+ * @slot default - Card body content.
+ */
 @Component({
   tag: 'ix-card-content',
   styleUrl: 'card-content.scss',

--- a/packages/core/src/components/card-list/card-list.tsx
+++ b/packages/core/src/components/card-list/card-list.tsx
@@ -70,6 +70,9 @@ function CardListTitle(props: {
   );
 }
 
+/**
+ * @slot default - Cards displayed in the list.
+ */
 @Component({
   tag: 'ix-card-list',
   styleUrl: 'card-list.scss',

--- a/packages/core/src/components/card-title/card-title.tsx
+++ b/packages/core/src/components/card-title/card-title.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Host } from '@stencil/core';
 
 /**
+ * @slot default - Card title.
  * @slot title-actions - Place additional actions inside title
  */
 @Component({

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -1,6 +1,10 @@
 import { Component, Element, h, Host, Prop } from '@stencil/core';
 import type { CardVariant } from './card.types';
 
+/**
+ * @slot default - Main card content.
+ * @slot card-accordion - Accordion displayed in the card footer.
+ */
 @Component({
   tag: 'ix-card',
   styleUrl: 'card.scss',

--- a/packages/core/src/components/checkbox-group/checkbox-group.tsx
+++ b/packages/core/src/components/checkbox-group/checkbox-group.tsx
@@ -19,6 +19,9 @@ import { makeRef } from '../utils/make-ref';
 /**
  * @form-ready
  */
+/**
+ * @slot default - Checkboxes displayed in the group.
+ */
 @Component({
   tag: 'ix-checkbox-group',
   styleUrl: 'checkbox-group.scss',

--- a/packages/core/src/components/checkbox-group/checkbox-group.tsx
+++ b/packages/core/src/components/checkbox-group/checkbox-group.tsx
@@ -18,8 +18,6 @@ import { makeRef } from '../utils/make-ref';
 
 /**
  * @form-ready
- */
-/**
  * @slot default - Checkboxes displayed in the group.
  */
 @Component({

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -28,8 +28,6 @@ import { hasSlottedContent } from '../utils/shadow-dom';
 
 /**
  * @form-ready
- */
-/**
  * @slot default - Checkbox label.
  */
 @Component({

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -29,6 +29,9 @@ import { hasSlottedContent } from '../utils/shadow-dom';
 /**
  * @form-ready
  */
+/**
+ * @slot default - Checkbox label.
+ */
 @Component({
   tag: 'ix-checkbox',
   styleUrl: 'checkbox.scss',

--- a/packages/core/src/components/chip/chip.tsx
+++ b/packages/core/src/components/chip/chip.tsx
@@ -27,6 +27,9 @@ import {
 import { makeRef } from '../utils/make-ref';
 import { CHIP_VARIANTS, ChipVariant } from './chip.types';
 
+/**
+ * @slot default - Chip label.
+ */
 @Component({
   tag: 'ix-chip',
   styleUrl: 'chip.scss',

--- a/packages/core/src/components/col/col.tsx
+++ b/packages/core/src/components/col/col.tsx
@@ -13,6 +13,9 @@ import type { ColumnSize } from './col.types';
 
 type GridBreakpoint = Breakpoint | '';
 
+/**
+ * @slot default - Column content.
+ */
 @Component({
   tag: 'ix-col',
   styleUrl: 'col.scss',

--- a/packages/core/src/components/content-header/content-header.tsx
+++ b/packages/core/src/components/content-header/content-header.tsx
@@ -13,7 +13,7 @@ import type { ContentHeaderVariant } from './content-header.types';
 
 /**
  * @slot header - Content to be placed in the header area next to the title
- * @slot - Default slot for action buttons or other content
+ * @slot default - Default slot for action buttons or other content
  */
 @Component({
   tag: 'ix-content-header',

--- a/packages/core/src/components/content/content.tsx
+++ b/packages/core/src/components/content/content.tsx
@@ -12,6 +12,7 @@ import { hasSlottedElements } from '../utils/shadow-dom';
 
 /**
  * @slot header - Display content at the top of the content page
+ * @slot default - Main page content.
  */
 @Component({
   tag: 'ix-content',

--- a/packages/core/src/components/css-grid/css-grid-item.tsx
+++ b/packages/core/src/components/css-grid/css-grid-item.tsx
@@ -11,6 +11,7 @@ import { Component, h, Host, Prop } from '@stencil/core';
 
 /**
  * @internal
+ * @slot default - Grid item content.
  */
 @Component({
   tag: 'ix-css-grid-item',

--- a/packages/core/src/components/css-grid/css-grid.tsx
+++ b/packages/core/src/components/css-grid/css-grid.tsx
@@ -26,6 +26,7 @@ const mediaQueryCollection: Array<{
 
 /**
  * @internal
+ * @slot default - Grid items arranged by the configured template.
  */
 @Component({
   tag: 'ix-css-grid',

--- a/packages/core/src/components/custom-field/custom-field.tsx
+++ b/packages/core/src/components/custom-field/custom-field.tsx
@@ -16,6 +16,9 @@ import {
 } from '../utils/input';
 import { IxComponentInterface } from '../utils/internal';
 
+/**
+ * @slot default - The form control.
+ */
 @Component({
   tag: 'ix-custom-field',
   styleUrl: 'custom-field.scss',

--- a/packages/core/src/components/dropdown-button/dropdown-button.tsx
+++ b/packages/core/src/components/dropdown-button/dropdown-button.tsx
@@ -43,6 +43,10 @@ import {
 } from '../utils/internal/mixins/id.mixin';
 import { closestPassShadow } from '../utils/shadow-dom';
 
+/**
+ * @slot button-label - Custom content displayed next to the button label.
+ * @slot default - Dropdown items.
+ */
 @Component({
   tag: 'ix-dropdown-button',
   styleUrl: 'dropdown-button.scss',

--- a/packages/core/src/components/dropdown-item/dropdown-item.tsx
+++ b/packages/core/src/components/dropdown-item/dropdown-item.tsx
@@ -33,6 +33,9 @@ import {
 import { FocusVisibleMixin } from '../utils/internal/mixins/focus-visible.mixin';
 import type { IxDropdownItemRole } from './dropdown-item.types';
 
+/**
+ * @slot default - Dropdown item content.
+ */
 @Component({
   tag: 'ix-dropdown-item',
   styleUrl: 'dropdown-item.scss',

--- a/packages/core/src/components/dropdown-quick-actions/dropdown-quick-actions.tsx
+++ b/packages/core/src/components/dropdown-quick-actions/dropdown-quick-actions.tsx
@@ -8,6 +8,9 @@
  */
 import { Component, h, Host } from '@stencil/core';
 
+/**
+ * @slot default - Quick action items.
+ */
 @Component({
   tag: 'ix-dropdown-quick-actions',
   styleUrl: 'dropdown-quick-actions.scss',

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -66,6 +66,9 @@ import { AlignedPlacement } from './placement';
 
 let sequenceId = 0;
 
+/**
+ * @slot default - Dropdown items.
+ */
 @Component({
   tag: 'ix-dropdown',
   styleUrl: 'dropdown.scss',

--- a/packages/core/src/components/event-list-item/event-list-item.tsx
+++ b/packages/core/src/components/event-list-item/event-list-item.tsx
@@ -19,6 +19,9 @@ import {
 } from '@stencil/core';
 import { a11yBoolean } from '../utils/a11y';
 
+/**
+ * @slot default - Event list item content.
+ */
 @Component({
   tag: 'ix-event-list-item',
   styleUrl: 'event-list-item.scss',

--- a/packages/core/src/components/event-list/event-list.tsx
+++ b/packages/core/src/components/event-list/event-list.tsx
@@ -12,6 +12,9 @@ import { createMutationObserver } from '../utils/mutation-observer';
 import { convertToRemString } from '../utils/rwd.util';
 import { animate } from 'animejs';
 
+/**
+ * @slot default - Event list items.
+ */
 @Component({
   tag: 'ix-event-list',
   styleUrl: 'event-list.scss',

--- a/packages/core/src/components/field-label/field-label.tsx
+++ b/packages/core/src/components/field-label/field-label.tsx
@@ -19,6 +19,9 @@ import { IxComponentInterface } from '../utils/internal';
 import { MakeRef, makeRef } from '../utils/make-ref';
 import { closestPassShadow } from '../utils/shadow-dom';
 
+/**
+ * @slot default - Field label content.
+ */
 @Component({
   tag: 'ix-field-label',
   styleUrl: 'field-label.scss',

--- a/packages/core/src/components/filter-chip/filter-chip.tsx
+++ b/packages/core/src/components/filter-chip/filter-chip.tsx
@@ -18,6 +18,9 @@ import {
   Prop,
 } from '@stencil/core';
 
+/**
+ * @slot default - Filter chip label.
+ */
 @Component({
   tag: 'ix-filter-chip',
   styleUrl: 'filter-chip.scss',

--- a/packages/core/src/components/flip-tile-content/flip-tile-content.tsx
+++ b/packages/core/src/components/flip-tile-content/flip-tile-content.tsx
@@ -8,6 +8,9 @@
  */
 import { Component, h, Host, Prop } from '@stencil/core';
 
+/**
+ * @slot default - Flip tile body content.
+ */
 @Component({
   tag: 'ix-flip-tile-content',
   styleUrl: 'flip-tile-content.css',

--- a/packages/core/src/components/flip-tile/flip-tile.tsx
+++ b/packages/core/src/components/flip-tile/flip-tile.tsx
@@ -25,6 +25,11 @@ import { createMutationObserver } from '../utils/mutation-observer';
 import { FlipTileVariant } from './flip-tile.types';
 import { hasSlottedElements } from '../utils/shadow-dom';
 
+/**
+ * @slot header - Content displayed in the tile header.
+ * @slot default - Flip tile pages.
+ * @slot footer - Content displayed in the tile footer.
+ */
 @Component({
   tag: 'ix-flip-tile',
   styleUrl: 'flip-tile.scss',

--- a/packages/core/src/components/group-item/group-item.tsx
+++ b/packages/core/src/components/group-item/group-item.tsx
@@ -18,6 +18,9 @@ import {
   Prop,
 } from '@stencil/core';
 
+/**
+ * @slot default - Group item content.
+ */
 @Component({
   tag: 'ix-group-item',
   styleUrl: 'group-item.scss',

--- a/packages/core/src/components/group/group-context-menu.tsx
+++ b/packages/core/src/components/group/group-context-menu.tsx
@@ -11,6 +11,9 @@ import { Component, Element, h, Host, State } from '@stencil/core';
 import { getSlottedElements } from '../utils/shadow-dom';
 import { iconContextMenu } from '@siemens/ix-icons/icons';
 
+/**
+ * @slot default - Context menu items.
+ */
 @Component({
   tag: 'ix-group-context-menu',
   styleUrl: './group-context-menu.scss',

--- a/packages/core/src/components/group/group.tsx
+++ b/packages/core/src/components/group/group.tsx
@@ -26,6 +26,12 @@ import {
   iconChevronUpSmall,
 } from '@siemens/ix-icons/icons';
 
+/**
+ * @slot header - Content displayed in the group header.
+ * @slot dropdown - Dropdown used for the group context menu.
+ * @slot default - Group items.
+ * @slot footer - Content displayed below the group items.
+ */
 @Component({
   tag: 'ix-group',
   styleUrl: 'group.scss',

--- a/packages/core/src/components/key-value-list/key-value-list.tsx
+++ b/packages/core/src/components/key-value-list/key-value-list.tsx
@@ -9,6 +9,9 @@
 
 import { Component, h, Host, Prop } from '@stencil/core';
 
+/**
+ * @slot default - Key-value entries.
+ */
 @Component({
   tag: 'ix-key-value-list',
   styleUrl: 'key-value-list.scss',

--- a/packages/core/src/components/layout-auto/layout-auto.tsx
+++ b/packages/core/src/components/layout-auto/layout-auto.tsx
@@ -1,6 +1,9 @@
 import { Component, Element, Host, Prop, Watch, h } from '@stencil/core';
 import { IxComponentInterface } from '../utils/internal';
 
+/**
+ * @slot default - Content arranged by the automatic layout.
+ */
 @Component({
   tag: 'ix-layout-auto',
   styleUrl: 'layout-auto.scss',

--- a/packages/core/src/components/layout-grid/layout-grid.tsx
+++ b/packages/core/src/components/layout-grid/layout-grid.tsx
@@ -9,6 +9,9 @@
 
 import { Component, h, Host, Prop } from '@stencil/core';
 
+/**
+ * @slot default - Content arranged in the grid.
+ */
 @Component({
   tag: 'ix-layout-grid',
   styleUrl: 'layout-grid.scss',

--- a/packages/core/src/components/link-button/link-button.tsx
+++ b/packages/core/src/components/link-button/link-button.tsx
@@ -10,6 +10,9 @@
 import { iconChevronRightSmall } from '@siemens/ix-icons/icons';
 import { Component, h, Host, Prop } from '@stencil/core';
 
+/**
+ * @slot default - Link button label.
+ */
 @Component({
   tag: 'ix-link-button',
   styleUrl: 'link-button.scss',

--- a/packages/core/src/components/menu-about-item/menu-about-item.tsx
+++ b/packages/core/src/components/menu-about-item/menu-about-item.tsx
@@ -23,6 +23,9 @@ import { CustomLabelChangeEvent } from '../utils/menu-tabs/menu-tabs-utils';
 /**
  * @deprecated since 5.0.0, use ix-tab-item instead of ix-menu-about-item
  */
+/**
+ * @slot default - About menu item content.
+ */
 @Component({
   tag: 'ix-menu-about-item',
   shadow: false,

--- a/packages/core/src/components/menu-about-item/menu-about-item.tsx
+++ b/packages/core/src/components/menu-about-item/menu-about-item.tsx
@@ -22,8 +22,6 @@ import { CustomLabelChangeEvent } from '../utils/menu-tabs/menu-tabs-utils';
 
 /**
  * @deprecated since 5.0.0, use ix-tab-item instead of ix-menu-about-item
- */
-/**
  * @slot default - About menu item content.
  */
 @Component({

--- a/packages/core/src/components/menu-about-news/menu-about-news.tsx
+++ b/packages/core/src/components/menu-about-news/menu-about-news.tsx
@@ -20,6 +20,9 @@ import {
 } from '@stencil/core';
 import { DefaultMixins } from '../utils/internal/component';
 
+/**
+ * @slot default - News content.
+ */
 @Component({
   tag: 'ix-menu-about-news',
   styleUrl: 'menu-about-news.scss',

--- a/packages/core/src/components/menu-about/menu-about.tsx
+++ b/packages/core/src/components/menu-about/menu-about.tsx
@@ -21,6 +21,9 @@ import {
 } from '@stencil/core';
 import { CustomCloseEvent } from '../utils/menu-tabs/menu-tabs-utils';
 
+/**
+ * @slot default - About overlay content.
+ */
 @Component({
   tag: 'ix-menu-about',
   styleUrl: 'menu-about.scss',

--- a/packages/core/src/components/menu-avatar/menu-avatar.tsx
+++ b/packages/core/src/components/menu-avatar/menu-avatar.tsx
@@ -21,6 +21,9 @@ import { a11yBoolean } from '../utils/a11y';
 import { makeRef } from '../utils/make-ref';
 import { getSlottedElements } from '../utils/shadow-dom';
 
+/**
+ * @slot default - Avatar dropdown items.
+ */
 @Component({
   tag: 'ix-menu-avatar',
   styleUrl: 'menu-avatar.scss',

--- a/packages/core/src/components/menu-category/menu-category.tsx
+++ b/packages/core/src/components/menu-category/menu-category.tsx
@@ -41,6 +41,9 @@ const DefaultIxMenuItemHeight = 40;
 const DefaultAnimationTimeout = 150;
 let categorySequenceId = 0;
 
+/**
+ * @slot default - Menu items in the category.
+ */
 @Component({
   tag: 'ix-menu-category',
   styleUrl: 'menu-category.scss',

--- a/packages/core/src/components/menu-item/menu-item.tsx
+++ b/packages/core/src/components/menu-item/menu-item.tsx
@@ -36,7 +36,7 @@ import { a11yBoolean } from '../utils/a11y';
 let sequenceId = 0;
 
 /**
- * @slot menu-item-label Custom label
+ * @slot default - Custom menu item label.
  */
 @Component({
   tag: 'ix-menu-item',

--- a/packages/core/src/components/menu-settings-item/menu-settings-item.tsx
+++ b/packages/core/src/components/menu-settings-item/menu-settings-item.tsx
@@ -22,8 +22,6 @@ import { CustomLabelChangeEvent } from '../utils/menu-tabs/menu-tabs-utils';
 
 /**
  * @deprecated since 5.0.0, use ix-tab-item instead of ix-menu-settings-item
- */
-/**
  * @slot default - Settings menu item content.
  */
 @Component({

--- a/packages/core/src/components/menu-settings-item/menu-settings-item.tsx
+++ b/packages/core/src/components/menu-settings-item/menu-settings-item.tsx
@@ -23,6 +23,9 @@ import { CustomLabelChangeEvent } from '../utils/menu-tabs/menu-tabs-utils';
 /**
  * @deprecated since 5.0.0, use ix-tab-item instead of ix-menu-settings-item
  */
+/**
+ * @slot default - Settings menu item content.
+ */
 @Component({
   tag: 'ix-menu-settings-item',
   shadow: false,

--- a/packages/core/src/components/menu-settings/menu-settings.tsx
+++ b/packages/core/src/components/menu-settings/menu-settings.tsx
@@ -21,6 +21,9 @@ import {
 } from '@stencil/core';
 import { CustomCloseEvent } from '../utils/menu-tabs/menu-tabs-utils';
 
+/**
+ * @slot default - Settings overlay content.
+ */
 @Component({
   tag: 'ix-menu-settings',
   styleUrl: 'menu-settings.scss',

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -40,6 +40,14 @@ import { convertToRemString } from '../utils/rwd.util';
 import { themeSwitcher } from '../utils/theme-switcher';
 import { Disposable } from '../utils/typed-event';
 
+/**
+ * @slot ix-menu-avatar - Avatar displayed at the top of the menu.
+ * @slot home - Home menu item.
+ * @slot default - Main menu items and categories.
+ * @slot bottom - Menu items displayed below the main navigation.
+ * @slot ix-menu-settings - Settings content displayed in the menu overlay.
+ * @slot ix-menu-about - About content displayed in the menu overlay.
+ */
 @Component({
   tag: 'ix-menu',
   styleUrl: 'menu.scss',

--- a/packages/core/src/components/message-bar/message-bar.tsx
+++ b/packages/core/src/components/message-bar/message-bar.tsx
@@ -33,6 +33,9 @@ interface MessageTypeConfig {
   color: NotificationColor;
 }
 
+/**
+ * @slot default - Message content.
+ */
 @Component({
   tag: 'ix-message-bar',
   styleUrl: 'message-bar.scss',

--- a/packages/core/src/components/modal-content/modal-content.tsx
+++ b/packages/core/src/components/modal-content/modal-content.tsx
@@ -9,6 +9,9 @@
 
 import { Component, h, Host } from '@stencil/core';
 
+/**
+ * @slot default - Modal body content.
+ */
 @Component({
   tag: 'ix-modal-content',
   styleUrl: 'modal-content.scss',

--- a/packages/core/src/components/modal-footer/modal-footer.tsx
+++ b/packages/core/src/components/modal-footer/modal-footer.tsx
@@ -9,6 +9,9 @@
 
 import { Component, h, Host } from '@stencil/core';
 
+/**
+ * @slot default - Modal footer actions.
+ */
 @Component({
   tag: 'ix-modal-footer',
   styleUrl: 'modal-footer.scss',

--- a/packages/core/src/components/modal-header/modal-header.tsx
+++ b/packages/core/src/components/modal-header/modal-header.tsx
@@ -20,6 +20,9 @@ import {
 import { closestPassShadow } from '../utils/shadow-dom';
 import { iconClose } from '@siemens/ix-icons/icons';
 
+/**
+ * @slot default - Modal header content.
+ */
 @Component({
   tag: 'ix-modal-header',
   styleUrl: 'modal-header.scss',

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -25,6 +25,9 @@ import { IX_MODAL_AUTOFOCUS_SELECTOR } from '../utils/modal/modal';
 import { waitForElement } from '../utils/waitForElement';
 import { IxModalSize } from './modal.types';
 
+/**
+ * @slot default - Modal sections and content.
+ */
 @Component({
   tag: 'ix-modal',
   styleUrl: 'modal.scss',

--- a/packages/core/src/components/pane-layout/pane-layout.tsx
+++ b/packages/core/src/components/pane-layout/pane-layout.tsx
@@ -22,6 +22,14 @@ import type { Composition } from '../pane/pane.types';
 import { applicationLayoutService } from '../utils/application-layout';
 import { matchBreakpoint } from '../utils/breakpoints';
 
+/**
+ * @slot left - Pane displayed to the left of the content.
+ * @slot top - Pane displayed above the content.
+ * @slot content - Main layout content.
+ * @slot default - Additional main layout content.
+ * @slot bottom - Pane displayed below the content.
+ * @slot right - Pane displayed to the right of the content.
+ */
 @Component({
   tag: 'ix-pane-layout',
   styleUrl: 'pane-layout.scss',

--- a/packages/core/src/components/pane/pane.tsx
+++ b/packages/core/src/components/pane/pane.tsx
@@ -48,6 +48,7 @@ import { a11yBoolean } from '../utils/a11y';
 
 /**
  * @slot header - Additional slot for the header content
+ * @slot default - Pane body content.
  */
 @Component({
   tag: 'ix-pane',

--- a/packages/core/src/components/pill/pill.tsx
+++ b/packages/core/src/components/pill/pill.tsx
@@ -13,6 +13,9 @@ import { IxComponentInterface } from '../utils/internal';
 import { DefaultMixins } from '../utils/internal/component';
 import { makeRef } from '../utils/make-ref';
 
+/**
+ * @slot default - Pill label.
+ */
 @Component({
   tag: 'ix-pill',
   styleUrl: 'pill.scss',

--- a/packages/core/src/components/popover-content/popover-content.tsx
+++ b/packages/core/src/components/popover-content/popover-content.tsx
@@ -13,7 +13,7 @@ import { TRAP_FOCUS_INCLUDE_ATTRIBUTE } from '../utils/focus/focus-trap';
 /**
  * Main body section of the popover.
  *
- * @slot - Popover body content.
+ * @slot default - Popover body content.
  *
  * @since 5.1.0
  */

--- a/packages/core/src/components/popover-footer/popover-footer.tsx
+++ b/packages/core/src/components/popover-footer/popover-footer.tsx
@@ -13,7 +13,7 @@ import { TRAP_FOCUS_INCLUDE_ATTRIBUTE } from '../utils/focus/focus-trap';
 /**
  * Footer section for actions and optional leading metadata.
  *
- * @slot - Footer actions (typically buttons), aligned to the end.
+ * @slot default - Footer actions (typically buttons), aligned to the end.
  * @slot start - Optional leading content (for example version text or step indicators).
  *
  * @since 5.1.0

--- a/packages/core/src/components/popover-header/popover-header.tsx
+++ b/packages/core/src/components/popover-header/popover-header.tsx
@@ -24,7 +24,7 @@ import { closestPassShadow } from '../utils/shadow-dom';
 /**
  * Header section with optional icon, title, additional items, and close button.
  *
- * @slot - Popover title (rendered as heading text).
+ * @slot default - Popover title (rendered as heading text).
  * @slot additional-items - Optional content beside the title (for example `ix-pill`).
  *
  * @since 5.1.0

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -78,7 +78,7 @@ const numberToPixel = (value?: number | null) =>
 /**
  * Floating panel anchored to a trigger element.
  *
- * @slot - Child sections in order: `ix-popover-header`, `ix-popover-image`, `ix-popover-content`, and `ix-popover-footer`.
+ * @slot default - Child sections in order: `ix-popover-header`, `ix-popover-image`, `ix-popover-content`, and `ix-popover-footer`.
  *
  * @since 5.1.0
  */

--- a/packages/core/src/components/progress-indicator/progress-indicator.tsx
+++ b/packages/core/src/components/progress-indicator/progress-indicator.tsx
@@ -23,8 +23,6 @@ import type {
 
 /**
  * @since 3.2.0
- */
-/**
  * @slot helper-text - Custom helper text content.
  * @slot default - Content displayed with the progress indicator.
  */

--- a/packages/core/src/components/progress-indicator/progress-indicator.tsx
+++ b/packages/core/src/components/progress-indicator/progress-indicator.tsx
@@ -24,6 +24,10 @@ import type {
 /**
  * @since 3.2.0
  */
+/**
+ * @slot helper-text - Custom helper text content.
+ * @slot default - Content displayed with the progress indicator.
+ */
 @Component({
   tag: 'ix-progress-indicator',
   styleUrl: 'progress-indicator.scss',

--- a/packages/core/src/components/push-card/push-card.tsx
+++ b/packages/core/src/components/push-card/push-card.tsx
@@ -10,6 +10,10 @@
 import { Component, h, Host, Prop } from '@stencil/core';
 import type { PushCardVariant } from './push-card.types';
 
+/**
+ * @slot title-action - Action displayed next to the card title.
+ * @slot default - Expandable card content.
+ */
 @Component({
   tag: 'ix-push-card',
   styleUrl: 'push-card.scss',

--- a/packages/core/src/components/radio-group/radio-group.tsx
+++ b/packages/core/src/components/radio-group/radio-group.tsx
@@ -30,6 +30,9 @@ import { makeRef } from '../utils/make-ref';
 /**
  * @form-ready
  */
+/**
+ * @slot default - Radio buttons displayed in the group.
+ */
 @Component({
   tag: 'ix-radio-group',
   styleUrl: 'radio-group.scss',

--- a/packages/core/src/components/radio-group/radio-group.tsx
+++ b/packages/core/src/components/radio-group/radio-group.tsx
@@ -29,8 +29,6 @@ import { makeRef } from '../utils/make-ref';
 
 /**
  * @form-ready
- */
-/**
  * @slot default - Radio buttons displayed in the group.
  */
 @Component({

--- a/packages/core/src/components/radio/radio.tsx
+++ b/packages/core/src/components/radio/radio.tsx
@@ -28,8 +28,6 @@ import {
 
 /**
  * @form-ready
- */
-/**
  * @slot default - Radio button label.
  */
 @Component({

--- a/packages/core/src/components/radio/radio.tsx
+++ b/packages/core/src/components/radio/radio.tsx
@@ -29,6 +29,9 @@ import {
 /**
  * @form-ready
  */
+/**
+ * @slot default - Radio button label.
+ */
 @Component({
   tag: 'ix-radio',
   styleUrl: 'radio.scss',

--- a/packages/core/src/components/range-field/range-field.tsx
+++ b/packages/core/src/components/range-field/range-field.tsx
@@ -27,6 +27,9 @@ import { DefaultMixins } from '../utils/internal/component';
 import { hasKeyboardMode } from '../utils/internal/mixins/setup.mixin';
 import { requestAnimationFrameNoNgZone } from '../utils/requestAnimationFrame';
 
+/**
+ * @slot default - Range field controls.
+ */
 @Component({
   tag: 'ix-range-field',
   styleUrl: 'range-field.scss',

--- a/packages/core/src/components/row/row.tsx
+++ b/packages/core/src/components/row/row.tsx
@@ -9,6 +9,9 @@
 
 import { Component, h, Host } from '@stencil/core';
 
+/**
+ * @slot default - Row content.
+ */
 @Component({
   tag: 'ix-row',
   styleUrl: 'row.scss',

--- a/packages/core/src/components/select/select.tsx
+++ b/packages/core/src/components/select/select.tsx
@@ -63,6 +63,9 @@ let selectId = 0;
 /**
  * @form-ready
  */
+/**
+ * @slot default - Select items.
+ */
 @Component({
   tag: 'ix-select',
   styleUrl: 'select.scss',

--- a/packages/core/src/components/select/select.tsx
+++ b/packages/core/src/components/select/select.tsx
@@ -62,8 +62,6 @@ let selectId = 0;
 
 /**
  * @form-ready
- */
-/**
  * @slot default - Select items.
  */
 @Component({

--- a/packages/core/src/components/split-button/split-button.tsx
+++ b/packages/core/src/components/split-button/split-button.tsx
@@ -33,6 +33,9 @@ import {
   AriaActiveDescendantMixinContract,
 } from '../utils/internal/mixins/accessibility/aria-activedescendant.mixin';
 
+/**
+ * @slot default - Dropdown items for the split button.
+ */
 @Component({
   tag: 'ix-split-button',
   styleUrl: 'split-button.scss',

--- a/packages/core/src/components/tab-item/tab-item.tsx
+++ b/packages/core/src/components/tab-item/tab-item.tsx
@@ -27,6 +27,9 @@ import {
 } from '../utils/internal/mixins/id.mixin';
 import { BaseTabMixin, BaseTabMixinContract } from './tab.mixin';
 
+/**
+ * @slot default - Tab label.
+ */
 @Component({
   tag: 'ix-tab-item',
   styleUrl: 'tab-item.scss',

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -29,6 +29,9 @@ import { DefaultMixins } from '../utils/internal/component';
 import { InheritAriaAttributesMixin } from '../utils/internal/mixins/accessibility/inherit-aria-attributes.mixin';
 import { requestAnimationFrameNoNgZone } from '../utils/requestAnimationFrame';
 
+/**
+ * @slot default - Tab items.
+ */
 @Component({
   tag: 'ix-tabs',
   styleUrl: 'tabs.scss',

--- a/packages/core/src/components/tile/tile.tsx
+++ b/packages/core/src/components/tile/tile.tsx
@@ -9,6 +9,12 @@
 
 import { Component, Element, h, Host, Prop, State } from '@stencil/core';
 
+/**
+ * @slot header - Content displayed in the tile header.
+ * @slot subheader - Content displayed below the tile header.
+ * @slot default - Main tile content.
+ * @slot footer - Content displayed in the tile footer.
+ */
 @Component({
   tag: 'ix-tile',
   styleUrl: 'tile.scss',

--- a/packages/core/src/components/toast/toast-container.tsx
+++ b/packages/core/src/components/toast/toast-container.tsx
@@ -12,6 +12,9 @@ import { TypedEvent } from '../utils/typed-event';
 import type { ShowToastResult } from './toast-container.types';
 import { ToastConfig } from './toast-utils';
 
+/**
+ * @slot default - Toast messages.
+ */
 @Component({
   tag: 'ix-toast-container',
   styleUrl: './toast-container.scss',

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -27,6 +27,10 @@ import {
   iconWarning,
 } from '@siemens/ix-icons/icons';
 
+/**
+ * @slot default - Toast message content.
+ * @slot action - Action displayed next to the toast message.
+ */
 @Component({
   tag: 'ix-toast',
   styleUrl: 'toast.scss',

--- a/packages/core/src/components/toggle-button/toggle-button.tsx
+++ b/packages/core/src/components/toggle-button/toggle-button.tsx
@@ -32,6 +32,9 @@ export type ToggleButtonVariant = Exclude<
   `danger-${BaseButtonVariant}`
 >;
 
+/**
+ * @slot default - Toggle button label.
+ */
 @Component({
   tag: 'ix-toggle-button',
   shadow: true,

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -49,6 +49,7 @@ let tooltipInstance = 0;
 /**
  * @slot title-icon - Icon displayed next to the tooltip title. The icon will be displayed as 16x16px.
  * @slot title-content - Content of tooltip title
+ * @slot default - Tooltip body content.
  */
 @Component({
   tag: 'ix-tooltip',

--- a/packages/core/src/components/tree-item/tree-item.tsx
+++ b/packages/core/src/components/tree-item/tree-item.tsx
@@ -11,6 +11,9 @@ import { Component, Event, EventEmitter, h, Host, Prop } from '@stencil/core';
 import { TreeItemContext } from '../tree/tree-model';
 import { iconChevronRightSmall } from '@siemens/ix-icons/icons';
 
+/**
+ * @slot default - Tree item content and nested items.
+ */
 @Component({
   tag: 'ix-tree-item',
   styleUrl: 'tree-item.scss',

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -32,6 +32,9 @@ import {
 } from './tree-model';
 import { defaultRefreshTreeOptions, RefreshTreeOptions } from './tree.types';
 
+/**
+ * @slot default - Tree items.
+ */
 @Component({
   tag: 'ix-tree',
   styleUrl: 'tree.css',

--- a/packages/core/src/components/typography/typography.tsx
+++ b/packages/core/src/components/typography/typography.tsx
@@ -14,6 +14,9 @@ import type {
   TypographyColors,
 } from './typography.types';
 
+/**
+ * @slot default - Text content.
+ */
 @Component({
   tag: 'ix-typography',
   styleUrl: 'typography.scss',

--- a/packages/core/src/components/workflow-step/workflow-step.tsx
+++ b/packages/core/src/components/workflow-step/workflow-step.tsx
@@ -29,6 +29,10 @@ import {
   Watch,
 } from '@stencil/core';
 
+/**
+ * @slot custom-icon - Custom icon displayed for the workflow step.
+ * @slot default - Workflow step label and content.
+ */
 @Component({
   tag: 'ix-workflow-step',
   styleUrl: 'workflow-step.scss',

--- a/packages/core/src/components/workflow-steps/workflow-steps.tsx
+++ b/packages/core/src/components/workflow-steps/workflow-steps.tsx
@@ -19,6 +19,9 @@ import {
 } from '@stencil/core';
 import { createMutationObserver } from '../utils/mutation-observer';
 
+/**
+ * @slot default - Workflow step items.
+ */
 @Component({
   tag: 'ix-workflow-steps',
   styleUrl: 'workflow-steps.scss',


### PR DESCRIPTION
IX-4458

## 💡 What is the current behavior?

We currently don't have descriptions for a lot of our component slots.

## 🆕 What is the new behavior?

Add missing slot descriptions

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved slot documentation across numerous components, clarifying default and named slot purposes.
  * Documented supported content areas such as labels, headers, actions, navigation items, and component body content.
  * Added missing slot descriptions for application layouts, menus, cards, dialogs, forms, navigation, and workflow components.
  * Standardized unnamed slot references to explicitly identify the `default` slot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->