### PR TITLE
2667 - fix vue types path and add changeset (patch)

### DIFF
--- a/.changeset/vue-types-path-fix.md
+++ b/.changeset/vue-types-path-fix.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix-vue': patch
+---
+
+Fix incorrect `types` path in published package by setting `rootDir` to `src` in tsconfig, so declaration files are emitted at `dist/index.d.ts` instead of `dist/src/index.d.ts`.

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -9,7 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "sourceMap": true,
-    "rootDir": ".",
+    "rootDir": "src",
     "outDir": "./dist",
     "lib": ["dom", "es2020"],
     "module": "es2015",


### PR DESCRIPTION
## 💡 What is the current behavior?

ix-vue has an incorrect path in the "types" field in package.json, so typescript projects fail when using the package

GitHub Issue Number: #2667

## 🆕 What is the new behavior?

The path is now fixed, via fixing the `rootDir` property in tsconfig for the vue package

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the published Vue package’s TypeScript declaration path, improving compatibility for TypeScript consumers.

* **Chores**
  * Added a patch release entry for the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->