### PR TITLE
fix(core/menu-category): Fix unit test race condition

### DIFF
--- a/packages/core/src/components/menu-category/test/menu-category.ct.ts
+++ b/packages/core/src/components/menu-category/test/menu-category.ct.ts
@@ -490,6 +490,7 @@ regressionTest(
     // Category should be expanded initially because one item is active
     const menuItems = categoryElement.locator('.menu-items');
     await expect(menuItems).toHaveClass(/menu-items--expanded/);
+    // Waiting for aria-posinset to ensure tabindex intialization is complete
     await expect(categoryButton).toHaveAttribute('aria-posinset', '1');
 
     await categoryButton.focus();

--- a/packages/core/src/components/menu-category/test/menu-category.ct.ts
+++ b/packages/core/src/components/menu-category/test/menu-category.ct.ts
@@ -490,6 +490,7 @@ regressionTest(
     // Category should be expanded initially because one item is active
     const menuItems = categoryElement.locator('.menu-items');
     await expect(menuItems).toHaveClass(/menu-items--expanded/);
+    await expect(categoryButton).toHaveAttribute('aria-posinset', '1');
 
     await categoryButton.focus();
 


### PR DESCRIPTION
Currently this unit test sometimes fails due to a race condition. categoryButton.focus() was called without ensuring tabindex initialization for the categoryButton was complete.
This change prevents this by waiting for aria-posinset to be intialized, signaling that roving-tabindex intialization is complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a regression assertion verifying the category button’s accessible position before keyboard navigation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->