### PR TITLE
fix(group): improve keyboard accessibility and ARIA support for group…

### DIFF
--- a/.changeset/free-eggs-smash.md
+++ b/.changeset/free-eggs-smash.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix': patch
+---
+
+Enhance keyboard accessibility for ix-group header interaction

--- a/packages/core/src/components/group/group.tsx
+++ b/packages/core/src/components/group/group.tsx
@@ -145,6 +145,13 @@ export class Group {
     this.changeItemIndex();
   }
 
+  private onHeaderKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      this.onHeaderClick(event as unknown as Event);
+    }
+  }
+
   private changeHeaderSelection(newSelection: boolean) {
     const oldIsHeaderSelected = this.selected;
     const newIsHeaderSelected = newSelection;
@@ -240,10 +247,20 @@ export class Group {
             expand: this.expanded,
             selected: this.selected,
           }}
+          role="button"
+          aria-expanded={String(this.expanded)}
+          aria-pressed={
+            this.suppressHeaderSelection ? undefined : String(this.selected)
+          }
           tabindex="0"
+          onKeyDown={(e: KeyboardEvent) => this.onHeaderKeyDown(e)}
         >
           <div
             class="group-header-clickable"
+            aria-expanded={String(this.expanded)}
+            aria-pressed={
+              this.suppressHeaderSelection ? undefined : String(this.selected)
+            }
             onClick={(e) => this.onHeaderClick(e)}
           >
             <div
@@ -260,6 +277,7 @@ export class Group {
                   hidden: !this.showExpandCollapsedIcon,
                 }}
                 name={this.expanded ? iconChevronUpSmall : iconChevronDownSmall}
+                aria-hidden="true"
                 onClick={(event: Event) => this.onExpandClick(event)}
               ></ix-icon>
             </div>

--- a/packages/core/src/components/group/group.tsx
+++ b/packages/core/src/components/group/group.tsx
@@ -146,7 +146,7 @@ export class Group {
   }
 
   private onHeaderKeyDown(event: KeyboardEvent) {
-    if (event.key === 'Enter') {
+    if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       this.onHeaderClick(event as unknown as Event);
     }

--- a/packages/core/src/components/group/group.tsx
+++ b/packages/core/src/components/group/group.tsx
@@ -146,7 +146,10 @@ export class Group {
   }
 
   private onHeaderKeyDown(event: KeyboardEvent) {
-    if (event.key === 'Enter' || event.key === ' ') {
+    if (
+      (event.key === 'Enter' || event.key === ' ') &&
+      event.target === event.currentTarget
+    ) {
       event.preventDefault();
       this.onHeaderClick(event as unknown as Event);
     }
@@ -277,7 +280,7 @@ export class Group {
                   hidden: !this.showExpandCollapsedIcon,
                 }}
                 name={this.expanded ? iconChevronUpSmall : iconChevronDownSmall}
-                aria-hidden="true"
+                aria-hidden={this.suppressHeaderSelection ? 'true' : 'false'}
                 onClick={(event: Event) => this.onExpandClick(event)}
               ></ix-icon>
             </div>


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?
1. Keyboard interaction is not working as expected.
2. Screen reader announcements are incorrect.

Jira ticket: IX-4341

## 🆕 What is the new behavior?
1. Keyboard interactions function as expected, supporting the intended navigation and activation behavior.
2. Screen reader announcements are accurate and provide the expected information to assistive technology users.


## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [X] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [X] 🧐 Static code analysis passes (`pnpm lint`)
- [X] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Group headers can now be activated using the Enter or Space keys.
  * Updated group header markup with button semantics and appropriate expanded/pressed state for assistive technologies.
  * Expand/collapse icons are now hidden from screen readers when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->