### PR TITLE
fix(core/breadcrumb): add missing aria-label to next items dropdown button of breadcrumb 

### DIFF
--- a/packages/core/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/core/src/components/breadcrumb/breadcrumb.tsx
@@ -208,6 +208,7 @@ export class Breadcrumb extends Mixin(...DefaultMixins) {
             variant="tertiary"
             enableTopLayer={this.enableTopLayer}
             aria-current="page"
+            aria-label={`Show ${labelLastItem.label ?? labelLastItem.innerText}`}
           >
             <ix-icon
               slot="button-label"

--- a/packages/core/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/core/src/components/breadcrumb/breadcrumb.tsx
@@ -157,6 +157,8 @@ export class Breadcrumb extends Mixin(...DefaultMixins) {
 
   override render() {
     const labelLastItem = this.items?.[this.items.length - 1];
+    const labelLastItemText =
+      labelLastItem?.label ?? labelLastItem?.textContent?.trim();
 
     this.inheritAriaAttributes['aria-label'] =
       this.inheritAriaAttributes['aria-label'] ?? 'Breadcrumbs';
@@ -203,12 +205,12 @@ export class Breadcrumb extends Mixin(...DefaultMixins) {
 
         {this.shouldRenderNextDropdown && (
           <ix-dropdown-button
-            label={labelLastItem.label ?? labelLastItem.innerText}
+            label={labelLastItemText}
             class="next-button"
             variant="tertiary"
             enableTopLayer={this.enableTopLayer}
             aria-current="page"
-            aria-label={`Show ${labelLastItem.label ?? labelLastItem.innerText}`}
+            aria-label={`Show ${labelLastItemText} next items`}
           >
             <ix-icon
               slot="button-label"

--- a/packages/core/src/components/breadcrumb/test/breadcrumb.ct.ts
+++ b/packages/core/src/components/breadcrumb/test/breadcrumb.ct.ts
@@ -17,13 +17,25 @@
 import { Locator } from '@playwright/test';
 import { regressionTest, expect } from '@utils/test';
 
-regressionTest('accessibility', async ({ mount, makeAxeBuilder }) => {
+regressionTest('accessibility', async ({ mount, makeAxeBuilder, page }) => {
   await mount(`
   <ix-breadcrumb>
     <ix-breadcrumb-item label="Item 1" breadcrumb-key="item-1"></ix-breadcrumb-item>
     <ix-breadcrumb-item label="Item 2" breadcrumb-key="item-2"></ix-breadcrumb-item>
     <ix-breadcrumb-item label="Item 3" breadcrumb-key="item-3"></ix-breadcrumb-item>
   </ix-breadcrumb>`);
+
+  const breadcrumb = page.locator('ix-breadcrumb');
+
+  await breadcrumb.evaluate((bc: HTMLIxBreadcrumbElement) => {
+    bc.nextItems = [{ label: 'Next Item 1', breadcrumbKey: 'next-item-1' }];
+  });
+
+  const nextButton = breadcrumb.locator('ix-dropdown-button.next-button');
+
+  await expect(
+    nextButton.getByRole('button', { name: 'Show Item 3 next items' })
+  ).toBeVisible();
 
   const results = await makeAxeBuilder().analyze();
   expect(results.violations).toEqual([]);
@@ -253,6 +265,9 @@ regressionTest(
 
     const nextButton = breadcrumb.locator('ix-dropdown-button.next-button');
     await expect(nextButton).toBeVisible();
-    await expect(nextButton).toHaveAttribute('aria-label', 'Show Item 3');
+    await expect(nextButton).toHaveAttribute(
+      'aria-label',
+      'Show Item 3 next items'
+    );
   }
 );

--- a/packages/core/src/components/breadcrumb/test/breadcrumb.ct.ts
+++ b/packages/core/src/components/breadcrumb/test/breadcrumb.ct.ts
@@ -17,6 +17,18 @@
 import { Locator } from '@playwright/test';
 import { regressionTest, expect } from '@utils/test';
 
+regressionTest('accessibility', async ({ mount, makeAxeBuilder }) => {
+  await mount(`
+  <ix-breadcrumb>
+    <ix-breadcrumb-item label="Item 1" breadcrumb-key="item-1"></ix-breadcrumb-item>
+    <ix-breadcrumb-item label="Item 2" breadcrumb-key="item-2"></ix-breadcrumb-item>
+    <ix-breadcrumb-item label="Item 3" breadcrumb-key="item-3"></ix-breadcrumb-item>
+  </ix-breadcrumb>`);
+
+  const results = await makeAxeBuilder().analyze();
+  expect(results.violations).toEqual([]);
+});
+
 regressionTest('renders', async ({ mount, page }) => {
   await mount(`
   <ix-breadcrumb>
@@ -223,3 +235,24 @@ regressionTest.describe('keyboard navigation', () => {
     await expect(item2).toHaveVisibleFocus();
   });
 });
+
+regressionTest(
+  'should set aria-label on next dropdown button matching last item label',
+  async ({ mount, page }) => {
+    await mount(`
+  <ix-breadcrumb>
+    <ix-breadcrumb-item label="Item 1" breadcrumb-key="item-1"></ix-breadcrumb-item>
+    <ix-breadcrumb-item label="Item 2" breadcrumb-key="item-2"></ix-breadcrumb-item>
+    <ix-breadcrumb-item label="Item 3" breadcrumb-key="item-3"></ix-breadcrumb-item>
+  </ix-breadcrumb>`);
+
+    const breadcrumb = page.locator('ix-breadcrumb');
+    await breadcrumb.evaluate((bc: HTMLIxBreadcrumbElement) => {
+      bc.nextItems = [{ label: 'Next Item 1', breadcrumbKey: 'next-item-1' }];
+    });
+
+    const nextButton = breadcrumb.locator('ix-dropdown-button.next-button');
+    await expect(nextButton).toBeVisible();
+    await expect(nextButton).toHaveAttribute('aria-label', 'Show Item 3');
+  }
+);

--- a/packages/core/src/components/breadcrumb/test/breadcrumb.ct.ts
+++ b/packages/core/src/components/breadcrumb/test/breadcrumb.ct.ts
@@ -17,25 +17,13 @@
 import { Locator } from '@playwright/test';
 import { regressionTest, expect } from '@utils/test';
 
-regressionTest('accessibility', async ({ mount, makeAxeBuilder, page }) => {
+regressionTest('accessibility', async ({ mount, makeAxeBuilder }) => {
   await mount(`
   <ix-breadcrumb>
     <ix-breadcrumb-item label="Item 1" breadcrumb-key="item-1"></ix-breadcrumb-item>
     <ix-breadcrumb-item label="Item 2" breadcrumb-key="item-2"></ix-breadcrumb-item>
-    <ix-breadcrumb-item label="Item 3" breadcrumb-key="item-3"></ix-breadcrumb-item>
+    <ix-breadcrumb-item breadcrumb-key="item-3">Item 3</ix-breadcrumb-item>
   </ix-breadcrumb>`);
-
-  const breadcrumb = page.locator('ix-breadcrumb');
-
-  await breadcrumb.evaluate((bc: HTMLIxBreadcrumbElement) => {
-    bc.nextItems = [{ label: 'Next Item 1', breadcrumbKey: 'next-item-1' }];
-  });
-
-  const nextButton = breadcrumb.locator('ix-dropdown-button.next-button');
-
-  await expect(
-    nextButton.getByRole('button', { name: 'Show Item 3 next items' })
-  ).toBeVisible();
 
   const results = await makeAxeBuilder().analyze();
   expect(results.violations).toEqual([]);


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

The next items dropdown button had no `aria-label`, making it unannounced and non-navigable for screen reader users.

JIRA: IX-4347

## 🆕 What is the new behavior?

The next items dropdown button had now `aria-label`, making it announced and navigable for screen reader users.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved breadcrumb navigation with a descriptive label for the next-items dropdown button.
  * Ensured the label reflects the displayed breadcrumb content.
  * Added accessibility coverage to help prevent future breadcrumb usability regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->