### PR TITLE
fix(core): render semantic headings for application and content headers

### DIFF
--- a/.changeset/semantic-header-headings.md
+++ b/.changeset/semantic-header-headings.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix': patch
+---
+
+Render `ix-application-header` and `ix-content-header` titles as semantic headings to improve document structure and accessibility.

--- a/packages/core/src/components/application-header/application-header.scss
+++ b/packages/core/src/components/application-header/application-header.scss
@@ -104,7 +104,7 @@
 
     .application-name {
       @include fonts.typography-body-lg;
-      
+
       margin: 0;
       padding: 0;
       flex: 0 1 auto;

--- a/packages/core/src/components/application-header/application-header.scss
+++ b/packages/core/src/components/application-header/application-header.scss
@@ -104,6 +104,7 @@
 
     .application-name {
       @include fonts.typography-body-lg;
+      
       margin: 0;
       padding: 0;
       flex: 0 1 auto;

--- a/packages/core/src/components/application-header/application-header.scss
+++ b/packages/core/src/components/application-header/application-header.scss
@@ -8,6 +8,7 @@
  */
 @use 'mixins/shadow-dom/component';
 @use 'mixins/break-points';
+@use 'mixins/fonts';
 
 :host {
   display: flex;
@@ -102,6 +103,9 @@
     }
 
     .application-name {
+      @include fonts.typography-body-lg;
+      margin: 0;
+      padding: 0;
       flex: 0 1 auto;
       min-width: 0;
       flex-shrink: 0;

--- a/packages/core/src/components/application-header/application-header.tsx
+++ b/packages/core/src/components/application-header/application-header.tsx
@@ -406,7 +406,7 @@ export class ApplicationHeader {
             ></slot>
           </div>
           <div class="name">
-            <h1 class="application-name">{this.name}</h1>
+            {this.name && <h1 class="application-name">{this.name}</h1>}
             {this.nameSuffix && this.breakpoint !== 'sm' && (
               <ix-typography format="body-xs" class="application-name-suffix">
                 {this.nameSuffix}

--- a/packages/core/src/components/application-header/application-header.tsx
+++ b/packages/core/src/components/application-header/application-header.tsx
@@ -406,9 +406,7 @@ export class ApplicationHeader {
             ></slot>
           </div>
           <div class="name">
-            <ix-typography format="body-lg" class="application-name">
-              {this.name}
-            </ix-typography>
+            <h1 class="application-name">{this.name}</h1>
             {this.nameSuffix && this.breakpoint !== 'sm' && (
               <ix-typography format="body-xs" class="application-name-suffix">
                 {this.nameSuffix}

--- a/packages/core/src/components/application-header/test/application-header.ct.ts
+++ b/packages/core/src/components/application-header/test/application-header.ct.ts
@@ -32,6 +32,13 @@ test('renders application name as h1', async ({ mount, page }) => {
   await expect(heading).toBeVisible();
 });
 
+test('does not render h1 when name is omitted', async ({ mount, page }) => {
+  await mount(`<ix-application-header></ix-application-header>`);
+
+  const heading = page.locator('ix-application-header').locator('h1');
+  await expect(heading).toHaveCount(0);
+});
+
 test('renders', async ({ mount, page }) => {
   page.setViewportSize({
     height: 500,

--- a/packages/core/src/components/application-header/test/application-header.ct.ts
+++ b/packages/core/src/components/application-header/test/application-header.ct.ts
@@ -11,6 +11,27 @@ import { test, viewPorts } from '@utils/test';
 import { ApplicationLayoutContext } from '../../utils/application-layout/context';
 import { ContextType } from '../../utils/context';
 
+test('accessibility', async ({ mount, makeAxeBuilder }) => {
+  await mount(
+    `<ix-application-header name="Test Application"></ix-application-header>`
+  );
+
+  const results = await makeAxeBuilder().analyze();
+  expect(results.violations).toEqual([]);
+});
+
+test('renders application name as h1', async ({ mount, page }) => {
+  await mount(
+    `<ix-application-header name="Test Application"></ix-application-header>`
+  );
+
+  const heading = page
+    .locator('ix-application-header')
+    .locator('h1.application-name');
+  await expect(heading).toBeVisible();
+  await expect(heading).toContainText('Test Application');
+});
+
 test('renders', async ({ mount, page }) => {
   page.setViewportSize({
     height: 500,

--- a/packages/core/src/components/application-header/test/application-header.ct.ts
+++ b/packages/core/src/components/application-header/test/application-header.ct.ts
@@ -25,11 +25,11 @@ test('renders application name as h1', async ({ mount, page }) => {
     `<ix-application-header name="Test Application"></ix-application-header>`
   );
 
-  const heading = page
-    .locator('ix-application-header')
-    .locator('h1.application-name');
+  const heading = page.getByRole('heading', {
+    level: 1,
+    name: 'Test Application',
+  });
   await expect(heading).toBeVisible();
-  await expect(heading).toContainText('Test Application');
 });
 
 test('renders', async ({ mount, page }) => {

--- a/packages/core/src/components/content-header/content-header.scss
+++ b/packages/core/src/components/content-header/content-header.scss
@@ -8,6 +8,7 @@
  */
 
 @use 'mixins/fonts';
+@use 'misc/common-variables' as vars;
 
 :host {
   display: flex;
@@ -30,12 +31,14 @@
 
     .header-title {
       @include fonts.typography-h3;
+
       margin: 0;
       padding: 0;
 
       &.secondary {
         @include fonts.typography-h4;
-        padding: 0.25rem 0;
+
+        padding: vars.$tiny-space 0;
       }
     }
 

--- a/packages/core/src/components/content-header/content-header.scss
+++ b/packages/core/src/components/content-header/content-header.scss
@@ -7,6 +7,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@use 'mixins/fonts';
+
 :host {
   display: flex;
   flex-direction: row;
@@ -26,6 +28,17 @@
       text-overflow: ellipsis;
     }
 
+    .header-title {
+      @include fonts.typography-h3;
+      margin: 0;
+      padding: 0;
+
+      &.secondary {
+        @include fonts.typography-h4;
+        padding: 0.25rem 0;
+      }
+    }
+
     .headerTitleRow {
       display: flex;
 
@@ -33,10 +46,6 @@
         display: inline-flex;
         margin-left: 0.5rem;
       }
-    }
-
-    .secondary {
-      padding: 0.25rem 0;
     }
   }
 

--- a/packages/core/src/components/content-header/content-header.tsx
+++ b/packages/core/src/components/content-header/content-header.tsx
@@ -60,15 +60,15 @@ export class ContentHeader {
 
         <div class="titleGroup">
           <div class="headerTitleRow">
-            <ix-typography
-              format={this.variant === 'secondary' ? 'h4' : 'h3'}
+            <h2
               class={{
+                'header-title': true,
                 secondary: this.variant === 'secondary',
                 titleOverflow: true,
               }}
             >
               {this.headerTitle}
-            </ix-typography>
+            </h2>
             <div class="headerSlot">
               <slot name="header" />
             </div>

--- a/packages/core/src/components/content-header/content-header.tsx
+++ b/packages/core/src/components/content-header/content-header.tsx
@@ -60,15 +60,17 @@ export class ContentHeader {
 
         <div class="titleGroup">
           <div class="headerTitleRow">
-            <h2
-              class={{
-                'header-title': true,
-                secondary: this.variant === 'secondary',
-                titleOverflow: true,
-              }}
-            >
-              {this.headerTitle}
-            </h2>
+            {this.headerTitle && (
+              <h2
+                class={{
+                  'header-title': true,
+                  secondary: this.variant === 'secondary',
+                  titleOverflow: true,
+                }}
+              >
+                {this.headerTitle}
+              </h2>
+            )}
             <div class="headerSlot">
               <slot name="header" />
             </div>

--- a/packages/core/src/components/content-header/test/content-header.ct.ts
+++ b/packages/core/src/components/content-header/test/content-header.ct.ts
@@ -51,11 +51,24 @@ for (const { variant, expected, hasSecondaryClass } of variants) {
       });
       await expect(heading).toBeVisible();
 
+      const titleElement = page
+        .locator('ix-content-header')
+        .locator('h2.header-title');
       if (hasSecondaryClass) {
-        await expect(
-          page.locator('ix-content-header').locator('h2.header-title')
-        ).toHaveClass(/\bsecondary\b/);
+        await expect(titleElement).toHaveClass(/\bsecondary\b/);
+      } else {
+        await expect(titleElement).not.toHaveClass(/\bsecondary\b/);
       }
     }
   );
 }
+
+regressionTest(
+  'does not render h2 when headerTitle is omitted',
+  async ({ mount, page }) => {
+    await mount(`<ix-content-header></ix-content-header>`);
+
+    const heading = page.locator('ix-content-header').locator('h2');
+    await expect(heading).toHaveCount(0);
+  }
+);

--- a/packages/core/src/components/content-header/test/content-header.ct.ts
+++ b/packages/core/src/components/content-header/test/content-header.ct.ts
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { expect } from '@playwright/test';
+import { regressionTest } from '@utils/test';
+
+regressionTest('accessibility', async ({ mount, makeAxeBuilder }) => {
+  await mount(
+    `<ix-content-header header-title="Content title"></ix-content-header>`
+  );
+
+  const results = await makeAxeBuilder().analyze();
+  expect(results.violations).toEqual([]);
+});
+
+regressionTest('renders', async ({ mount, page }) => {
+  await mount(
+    `<ix-content-header header-title="Content title"></ix-content-header>`
+  );
+
+  const element = page.locator('ix-content-header');
+  await expect(element).toHaveClass(/\bhydrated\b/);
+  await expect(element).toBeVisible();
+});
+
+const variants = [
+  { variant: '', expected: 'primary', hasSecondaryClass: false },
+  {
+    variant: 'variant="secondary"',
+    expected: 'secondary',
+    hasSecondaryClass: true,
+  },
+];
+
+for (const { variant, expected, hasSecondaryClass } of variants) {
+  regressionTest(
+    `renders header title as h2 for ${expected} variant`,
+    async ({ mount, page }) => {
+      await mount(
+        `<ix-content-header ${variant} header-title="My Content Page"></ix-content-header>`
+      );
+
+      const heading = page
+        .locator('ix-content-header')
+        .locator('h2.header-title');
+      await expect(heading).toBeVisible();
+      await expect(heading).toContainText('My Content Page');
+
+      if (hasSecondaryClass) {
+        await expect(heading).toHaveClass(/\bsecondary\b/);
+      }
+    }
+  );
+}

--- a/packages/core/src/components/content-header/test/content-header.ct.ts
+++ b/packages/core/src/components/content-header/test/content-header.ct.ts
@@ -45,14 +45,16 @@ for (const { variant, expected, hasSecondaryClass } of variants) {
         `<ix-content-header ${variant} header-title="My Content Page"></ix-content-header>`
       );
 
-      const heading = page
-        .locator('ix-content-header')
-        .locator('h2.header-title');
+      const heading = page.getByRole('heading', {
+        level: 2,
+        name: 'My Content Page',
+      });
       await expect(heading).toBeVisible();
-      await expect(heading).toContainText('My Content Page');
 
       if (hasSecondaryClass) {
-        await expect(heading).toHaveClass(/\bsecondary\b/);
+        await expect(
+          page.locator('ix-content-header').locator('h2.header-title')
+        ).toHaveClass(/\bsecondary\b/);
       }
     }
   );


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

**ix-application-header** and **ix-content-header** render their titles through [**ix-typography**](vscode-file://vscode-app/c:/Users/z004twus/AppData/Local/Programs/Microsoft%20VS%20Code/8a7abeba6e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), so the headings are not native HTML heading elements. The visual style depends on the typography format prop, and the DOM does not expose semantic h1/[h2](vscode-file://vscode-app/c:/Users/z004twus/AppData/Local/Programs/Microsoft%20VS%20Code/8a7abeba6e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) structure.

JIRA : IX-4327

## 🆕 What is the new behavior?

ix-application-header now renders its title as a native h1, and ix-content-header renders its title as a native [h2](vscode-file://vscode-app/c:/Users/z004twus/AppData/Local/Programs/Microsoft%20VS%20Code/8a7abeba6e/resources/app/out/vs/code/electron-browser/workbench/workbench.html). The visual typography stays the same through SCSS mixins, and the variant-specific styling is preserved with classes instead of heading-format props.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Application names now render as semantic `<h1>` headings.
  * Content header titles now render as semantic `<h2>` headings, improving document structure and assistive technology support.
* **Style**
  * Refined application and content header typography, spacing, and secondary-title presentation.
* **Tests**
  * Added coverage for heading semantics, visibility, hydration, accessibility, and primary and secondary header variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->