### PR TITLE
Prevent focus in collapsed card content in CardList

### DIFF
--- a/.changeset/brave-dryers-work.md
+++ b/.changeset/brave-dryers-work.md
@@ -2,4 +2,5 @@
 '@siemens/ix': patch
 ---
 
-Prevent focus from remaining inside collapsed card lists
+Prevent focus from remaining inside collapsed card lists and provide state-aware
+default labels for their expand and collapse controls.

--- a/.changeset/brave-dryers-work.md
+++ b/.changeset/brave-dryers-work.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix': patch
+---
+
+Prevent focus from remaining inside collapsed card lists

--- a/.changeset/brave-dryers-work.md
+++ b/.changeset/brave-dryers-work.md
@@ -2,5 +2,6 @@
 '@siemens/ix': patch
 ---
 
-Prevent focus from remaining inside collapsed card lists and provide state-aware
-default labels for their expand and collapse controls.
+Prevent focus from remaining inside collapsed card lists, including lists
+without visible labels, and provide state-aware default labels for their expand
+and collapse controls.

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -581,7 +581,7 @@ export namespace Components {
     }
     interface IxCardList {
         /**
-          * ARIA label for the card's expand button. Will be set as aria-label on the nested HTML button element
+          * ARIA label for the card list's expand and collapse button. Defaults to `Collapse card list` when expanded and `Expand card list` when collapsed. A non-empty custom value overrides the label in both states.
           * @since 3.2.0
          */
         "ariaLabelExpandButton"?: string;
@@ -7482,7 +7482,7 @@ declare namespace LocalJSX {
     }
     interface IxCardList {
         /**
-          * ARIA label for the card's expand button. Will be set as aria-label on the nested HTML button element
+          * ARIA label for the card list's expand and collapse button. Defaults to `Collapse card list` when expanded and `Expand card list` when collapsed. A non-empty custom value overrides the label in both states.
           * @since 3.2.0
          */
         "ariaLabelExpandButton"?: string;

--- a/packages/core/src/components/card-list/card-list.tsx
+++ b/packages/core/src/components/card-list/card-list.tsx
@@ -35,7 +35,7 @@ function CardListTitle(props: {
     ? props.ariaLabelExpandButton
     : defaultAriaLabel;
 
-  if (!props.label) {
+  if (!props.label && !props.ariaLabelExpandButton?.trim()) {
     return null;
   }
 

--- a/packages/core/src/components/card-list/card-list.tsx
+++ b/packages/core/src/components/card-list/card-list.tsx
@@ -28,6 +28,13 @@ function CardListTitle(props: {
   hideShowAll: boolean;
   collapseButtonRef: (element?: HTMLIxIconButtonElement) => void;
 }) {
+  const defaultAriaLabel = props.isCollapsed
+    ? 'Expand card list'
+    : 'Collapse card list';
+  const ariaLabel = props.ariaLabelExpandButton?.trim()
+    ? props.ariaLabelExpandButton
+    : defaultAriaLabel;
+
   if (!props.label) {
     return null;
   }
@@ -43,7 +50,7 @@ function CardListTitle(props: {
           CardList__Title__Button: true,
           CardList__Title__Button__Collapsed: props.isCollapsed,
         }}
-        aria-label={props.ariaLabelExpandButton}
+        aria-label={ariaLabel}
         ref={props.collapseButtonRef}
       ></ix-icon-button>
       <ix-typography class="CardList_Title__Label" format="body-lg">
@@ -83,8 +90,9 @@ function CardListTitle(props: {
 })
 export class CardList {
   /**
-   * ARIA label for the card's expand button.
-   * Will be set as aria-label on the nested HTML button element
+   * ARIA label for the card list's expand and collapse button.
+   * Defaults to `Collapse card list` when expanded and `Expand card list` when
+   * collapsed. A non-empty custom value overrides the label in both states.
    *
    * @since 3.2.0
    */

--- a/packages/core/src/components/card-list/card-list.tsx
+++ b/packages/core/src/components/card-list/card-list.tsx
@@ -9,6 +9,7 @@ import {
   Listen,
   Prop,
   State,
+  Watch,
 } from '@stencil/core';
 import { createMutationObserver } from '../utils/mutation-observer';
 import { iconChevronUp, iconMoreMenu } from '@siemens/ix-icons/icons';
@@ -25,6 +26,7 @@ function CardListTitle(props: {
   labelShowLess: string;
   showLess: boolean;
   hideShowAll: boolean;
+  collapseButtonRef: (element?: HTMLIxIconButtonElement) => void;
 }) {
   if (!props.label) {
     return null;
@@ -42,6 +44,7 @@ function CardListTitle(props: {
           CardList__Title__Button__Collapsed: props.isCollapsed,
         }}
         aria-label={props.ariaLabelExpandButton}
+        ref={props.collapseButtonRef}
       ></ix-icon-button>
       <ix-typography class="CardList_Title__Label" format="body-lg">
         {props.label}
@@ -177,6 +180,21 @@ export class CardList {
   @State() private rightScrollDistance = 0;
 
   private observer?: MutationObserver;
+
+  private collapseButton?: HTMLIxIconButtonElement;
+
+  @Watch('collapse')
+  protected handleCollapseChange(isCollapsed: boolean) {
+    if (isCollapsed && this.hasFocusWithinListContent()) {
+      this.collapseButton?.focus();
+    }
+  }
+
+  private hasFocusWithinListContent() {
+    return this.getListChildren().some((child) =>
+      child.matches(':focus-within')
+    );
+  }
 
   private onCardListVisibilityToggle() {
     this.collapse = !this.collapse;
@@ -415,6 +433,7 @@ export class CardList {
         <CardListTitle
           isCollapsed={this.collapse}
           label={this.label}
+          ariaLabelExpandButton={this.ariaLabelExpandButton}
           showAllLabel={this.i18nShowAll}
           showAllCounter={
             this.showAllCount === undefined
@@ -426,6 +445,7 @@ export class CardList {
           onClick={() => this.onCardListVisibilityToggle()}
           onShowAllClick={(e) => this.onShowAllClick(e)}
           hideShowAll={this.hideShowAll}
+          collapseButtonRef={(element) => (this.collapseButton = element)}
         ></CardListTitle>
         <div
           class={{
@@ -441,6 +461,7 @@ export class CardList {
               CardList__Style__Infinite__Scroll: this.listStyle === 'scroll',
             }}
             onScroll={() => this.onCardListScroll()}
+            inert={this.collapse}
           >
             <slot
               onSlotchange={() => {

--- a/packages/core/src/components/card-list/card-list.tsx
+++ b/packages/core/src/components/card-list/card-list.tsx
@@ -191,9 +191,7 @@ export class CardList {
   }
 
   private hasFocusWithinListContent() {
-    return this.getListChildren().some((child) =>
-      child.matches(':focus-within')
-    );
+    return this.listElement?.matches(':focus-within') ?? false;
   }
 
   private onCardListVisibilityToggle() {

--- a/packages/core/src/components/card-list/test/card-list.ct.ts
+++ b/packages/core/src/components/card-list/test/card-list.ct.ts
@@ -73,6 +73,43 @@ regressionTest(
   }
 );
 
+regressionTest(
+  'moves focus from the show-more card before collapsing',
+  async ({ mount, page }) => {
+    await mount(`
+      <ix-card-list
+        label="Test"
+        list-style="stack"
+        max-visible-cards="1"
+      >
+        ${CARDS_HTML}
+      </ix-card-list>
+    `);
+
+    const cardList = page.locator('ix-card-list');
+    const collapseButton = cardList.getByRole('button', {
+      name: 'Chevron Up',
+    });
+    const showMoreCard = cardList.getByRole('button', {
+      name: /there are more cards available/i,
+    });
+    const content = cardList.locator('.CardList__Content');
+
+    await expect(cardList).toHaveClass(/\bhydrated\b/);
+    await expect(showMoreCard).toBeVisible();
+
+    await showMoreCard.focus();
+    await expect(showMoreCard).toBeFocused();
+
+    await cardList.evaluate((element: HTMLIxCardListElement) => {
+      element.collapse = true;
+    });
+
+    await expect(collapseButton).toBeFocused();
+    await expect(content).toHaveJSProperty('inert', true);
+  }
+);
+
 regressionTest('renders', async ({ mount, page }) => {
   await mount(`
     <ix-card-list label="Test">

--- a/packages/core/src/components/card-list/test/card-list.ct.ts
+++ b/packages/core/src/components/card-list/test/card-list.ct.ts
@@ -30,6 +30,49 @@ regressionTest('accessibility', async ({ mount, makeAxeBuilder }) => {
   expect(results.violations).toEqual([]);
 });
 
+regressionTest(
+  'prevents focus from remaining in collapsed card content',
+  async ({ mount, page, makeAxeBuilder }) => {
+    await mount(`
+      <button>Before</button>
+      <ix-card-list label="Test" hide-show-all>
+        <ix-card>
+          <ix-card-content>
+            <button>Card action</button>
+          </ix-card-content>
+        </ix-card>
+      </ix-card-list>
+      <button>After</button>
+    `);
+
+    const cardList = page.locator('ix-card-list');
+    const collapseButton = cardList.getByRole('button', {
+      name: 'Chevron Up',
+    });
+    const cardAction = page.getByRole('button', { name: 'Card action' });
+    const content = cardList.locator('.CardList__Content');
+    const after = page.getByRole('button', { name: 'After' });
+
+    await expect(cardList).toHaveClass(/\bhydrated\b/);
+
+    await cardAction.focus();
+    await expect(cardAction).toBeFocused();
+
+    await cardList.evaluate((element: HTMLIxCardListElement) => {
+      element.collapse = true;
+    });
+
+    await expect(collapseButton).toBeFocused();
+    await expect(content).toHaveJSProperty('inert', true);
+
+    const results = await makeAxeBuilder().analyze();
+    expect(results.violations).toEqual([]);
+
+    await page.keyboard.press('Tab');
+    await expect(after).toBeFocused();
+     }
+);
+
 regressionTest('renders', async ({ mount, page }) => {
   await mount(`
     <ix-card-list label="Test">

--- a/packages/core/src/components/card-list/test/card-list.ct.ts
+++ b/packages/core/src/components/card-list/test/card-list.ct.ts
@@ -46,14 +46,18 @@ regressionTest(
     `);
 
     const cardList = page.locator('ix-card-list');
+    await cardList.evaluate((element: HTMLIxCardListElement) => {
+      element.ariaLabelExpandButton = '   ';
+    });
     const collapseButton = cardList.getByRole('button', {
-      name: 'Chevron Up',
+      name: 'Collapse card list',
     });
     const cardAction = page.getByRole('button', { name: 'Card action' });
     const content = cardList.locator('.CardList__Content');
     const after = page.getByRole('button', { name: 'After' });
 
     await expect(cardList).toHaveClass(/\bhydrated\b/);
+    await expect(collapseButton).toBeVisible();
 
     await cardAction.focus();
     await expect(cardAction).toBeFocused();
@@ -62,7 +66,10 @@ regressionTest(
       element.collapse = true;
     });
 
-    await expect(collapseButton).toBeFocused();
+    const expandButton = cardList.getByRole('button', {
+      name: 'Expand card list',
+    });
+    await expect(expandButton).toBeFocused();
     await expect(content).toHaveJSProperty('inert', true);
 
     const results = await makeAxeBuilder().analyze();
@@ -88,7 +95,7 @@ regressionTest(
 
     const cardList = page.locator('ix-card-list');
     const collapseButton = cardList.getByRole('button', {
-      name: 'Chevron Up',
+      name: 'Collapse card list',
     });
     const showMoreCard = cardList.getByRole('button', {
       name: /there are more cards available/i,
@@ -96,6 +103,7 @@ regressionTest(
     const content = cardList.locator('.CardList__Content');
 
     await expect(cardList).toHaveClass(/\bhydrated\b/);
+    await expect(collapseButton).toBeVisible();
     await expect(showMoreCard).toBeVisible();
 
     await showMoreCard.focus();
@@ -105,7 +113,10 @@ regressionTest(
       element.collapse = true;
     });
 
-    await expect(collapseButton).toBeFocused();
+    const expandButton = cardList.getByRole('button', {
+      name: 'Expand card list',
+    });
+    await expect(expandButton).toBeFocused();
     await expect(content).toHaveJSProperty('inert', true);
   }
 );

--- a/packages/core/src/components/card-list/test/card-list.ct.ts
+++ b/packages/core/src/components/card-list/test/card-list.ct.ts
@@ -70,7 +70,7 @@ regressionTest(
 
     await page.keyboard.press('Tab');
     await expect(after).toBeFocused();
-     }
+  }
 );
 
 regressionTest('renders', async ({ mount, page }) => {

--- a/packages/core/src/components/card-list/test/card-list.ct.ts
+++ b/packages/core/src/components/card-list/test/card-list.ct.ts
@@ -81,6 +81,54 @@ regressionTest(
 );
 
 regressionTest(
+  'moves focus when collapsing a card list without a visible label',
+  async ({ mount, page }) => {
+    await mount(`
+      <ix-card-list aria-label-expand-button="Toggle card list" hide-show-all>
+        <ix-card>
+          <ix-card-content>
+            <button>Card action</button>
+          </ix-card-content>
+        </ix-card>
+      </ix-card-list>
+    `);
+
+    const cardList = page.locator('ix-card-list');
+    const collapseButton = cardList.getByRole('button', {
+      name: 'Toggle card list',
+    });
+    const cardAction = page.getByRole('button', { name: 'Card action' });
+
+    await expect(cardList).toHaveClass(/\bhydrated\b/);
+    await expect(collapseButton).toBeVisible();
+
+    await cardAction.focus();
+    await expect(cardAction).toBeFocused();
+
+    await cardList.evaluate((element: HTMLIxCardListElement) => {
+      element.collapse = true;
+    });
+
+    await expect(collapseButton).toBeFocused();
+  }
+);
+
+regressionTest(
+  'does not render a title for an unlabeled non-collapsible list',
+  async ({ mount, page }) => {
+    await mount(`
+      <ix-card-list>
+        <ix-card><ix-card-content>Card 1</ix-card-content></ix-card>
+      </ix-card-list>
+    `);
+
+    const cardList = page.locator('ix-card-list');
+    await expect(cardList).toHaveClass(/\bhydrated\b/);
+    await expect(cardList.locator('.CardList_Title')).toHaveCount(0);
+  }
+);
+
+regressionTest(
   'moves focus from the show-more card before collapsing',
   async ({ mount, page }) => {
     await mount(`


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

-Cards are focusable in cardlist even when the cardlist is collapsed

GitHub Issue Number: #<ISSUE NUMBER>

## 🆕 What is the new behavior?
- When the cardlist changes to collapsed state, the card-content container is now marked as inert. This removes slotted card content and any nested interactive controls from the tab order and accessibility tree while hidden.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [X] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [X] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [X] 🧐 Static code analysis passes (`pnpm lint`)
- [X] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved keyboard focus handling when collapsing card lists.
  * Focus now moves to the collapse control, and collapsed content is unavailable to keyboard navigation.
  * Added state-aware default labels for expand and collapse controls, with support for custom labels.
  * Improved title and labeling behavior for card lists with custom accessibility labels.
  * Verified accessible behavior, including continued focus movement to following controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->