### PR TITLE
fix: use custom observer to prevent lifecycle issues of lazy components

### DIFF
--- a/.changeset/fix-angular-menu-aria.md
+++ b/.changeset/fix-angular-menu-aria.md
@@ -1,0 +1,7 @@
+---
+'@siemens/ix': patch
+---
+
+Fix Angular NgModule menu initialization so interpolated ARIA attributes no longer cause `ariaAttributeChanged` runtime errors. Forward dynamic ARIA attribute changes in microtask batches, and keep an explicit `role` on `ix-tabs` from overriding its internal `tablist` role.
+
+Fixes #2716

--- a/.changeset/fix-angular-menu-aria.md
+++ b/.changeset/fix-angular-menu-aria.md
@@ -2,6 +2,6 @@
 '@siemens/ix': patch
 ---
 
-Fix Angular NgModule menu initialization so interpolated ARIA attributes no longer cause `ariaAttributeChanged` runtime errors. Forward dynamic ARIA attribute changes in microtask batches, and keep an explicit `role` on `ix-tabs` from overriding its internal `tablist` role.
+Fix Angular NgModule menu initialization so interpolated ARIA attributes no longer cause `ariaAttributeChanged` runtime errors. Reliably forward dynamic ARIA attribute updates and removals to internal elements, and keep an explicit `role` on `ix-tabs` from overriding its internal `tablist` role.
 
 Fixes #2716

--- a/packages/angular-test-app/src/app/app.component.spec.ts
+++ b/packages/angular-test-app/src/app/app.component.spec.ts
@@ -1,6 +1,39 @@
+import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { IxModule } from '@siemens/ix-angular';
 import { AppComponent } from './app.component';
+
+@Component({
+  template: `
+    <ix-menu [expand]="true" aria-label="Main navigation">
+      @for (item of navigationItems; track item.label) {
+      <ix-menu-category
+        [label]="item.label"
+        [attr.aria-label]="item.label"
+        aria-level="0"
+      >
+        @for (nestedItem of item.items; track nestedItem) {
+        <ix-menu-item
+          [label]="nestedItem"
+          [attr.aria-label]="nestedItem"
+          aria-level="1"
+        ></ix-menu-item>
+        }
+      </ix-menu-category>
+      }
+    </ix-menu>
+  `,
+  standalone: false,
+})
+class DynamicMenuComponent {
+  readonly navigationItems = [
+    {
+      label: 'Category',
+      items: ['Item'],
+    },
+  ];
+}
 
 describe('AppComponent', () => {
   beforeEach(async () => {
@@ -14,5 +47,52 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
+  });
+});
+
+describe('Dynamic menu ARIA bindings', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [IxModule.forRoot()],
+      declarations: [DynamicMenuComponent],
+    }).compileComponents();
+  });
+
+  it('initializes interpolated ARIA attributes without runtime errors', async () => {
+    const errors: unknown[] = [];
+    const errorHandler = (event: ErrorEvent) => {
+      errors.push(event.error ?? event.message);
+      event.preventDefault();
+    };
+    const rejectionHandler = (event: PromiseRejectionEvent) => {
+      errors.push(event.reason);
+      event.preventDefault();
+    };
+    window.addEventListener('error', errorHandler);
+    window.addEventListener('unhandledrejection', rejectionHandler);
+
+    try {
+      const fixture = TestBed.createComponent(DynamicMenuComponent);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      const menuCategory = fixture.nativeElement.querySelector(
+        'ix-menu-category'
+      ) as HTMLIxMenuCategoryElement;
+      await menuCategory.componentOnReady();
+      const categoryMenuItem = menuCategory.shadowRoot?.querySelector(
+        'ix-menu-item.category-parent'
+      ) as HTMLIxMenuItemElement;
+      await categoryMenuItem.componentOnReady();
+      const categoryButton =
+        categoryMenuItem.shadowRoot?.querySelector('button');
+
+      expect(errors).toEqual([]);
+      expect(menuCategory.classList.contains('hydrated')).toBeTrue();
+      expect(categoryButton?.getAttribute('aria-label')).toBe('Category');
+      expect(categoryButton?.getAttribute('aria-level')).toBe('0');
+    } finally {
+      window.removeEventListener('error', errorHandler);
+      window.removeEventListener('unhandledrejection', rejectionHandler);
+    }
   });
 });

--- a/packages/core/src/components/badge/badge.tsx
+++ b/packages/core/src/components/badge/badge.tsx
@@ -18,7 +18,7 @@ import {
   VNode,
   Watch,
 } from '@stencil/core';
-import { a11yBoolean, a11yHostAttributes } from '../utils/a11y';
+import { a11yBoolean } from '../utils/a11y';
 import { DefaultMixins } from '../utils/internal/component';
 import {
   InheritAriaAttributesMixin,
@@ -245,6 +245,8 @@ export class Badge
   }
 
   override connectedCallback() {
+    super.connectedCallback();
+
     if (this.hasDisconnected) {
       this.syncAnchorDescribedBy();
       this.hasDisconnected = false;
@@ -252,6 +254,8 @@ export class Badge
   }
 
   override disconnectedCallback() {
+    super.disconnectedCallback();
+
     this.clearAnchorDescribedBy();
     this.hasDisconnected = true;
   }
@@ -306,7 +310,7 @@ export class Badge
       this.hasAnchor = true;
       // Strip any ARIA still on the host (e.g. re-applied while standalone) and discard —
       // attached mode must not keep role / aria-* on the wrapper.
-      a11yHostAttributes(this.hostElement);
+      this.readAriaAttributesFromHost();
       this.inheritAriaAttributes = {};
       this.descriptionId = `${this.getHostElementId()}-description`;
       return;
@@ -314,7 +318,7 @@ export class Badge
 
     this.hasAnchor = false;
     // Leaving attached: capture any author ARIA set on the host for standalone `<Host>`.
-    this.inheritAriaAttributes = a11yHostAttributes(this.hostElement);
+    this.inheritAriaAttributes = this.readAriaAttributesFromHost();
   }
 
   private getResolvedVariant(): BadgeVariant {

--- a/packages/core/src/components/menu-item/menu-item.tsx
+++ b/packages/core/src/components/menu-item/menu-item.tsx
@@ -186,6 +186,8 @@ export class MenuItem
   }
 
   override connectedCallback() {
+    super.connectedCallback();
+
     this.observer.observe(this.hostElement, {
       subtree: true,
       childList: true,
@@ -229,7 +231,12 @@ export class MenuItem
       this.tooltipText !== this.hostElement.textContent;
 
     if (hasDistinctTooltip) {
-      return `${this.label ?? this.menuCategoryLabel ?? this.hostElement.textContent ?? ''} ${this.tooltipText}`;
+      return `${
+        this.label ??
+        this.menuCategoryLabel ??
+        this.hostElement.textContent ??
+        ''
+      } ${this.tooltipText}`;
     }
 
     return undefined;

--- a/packages/core/src/components/menu-item/test/menu-item.ct.ts
+++ b/packages/core/src/components/menu-item/test/menu-item.ct.ts
@@ -27,6 +27,178 @@ regressionTest('renders', async ({ mount, page }) => {
   await expect(menuItem1.locator('.tab-text').locator('slot')).toBeAttached();
 });
 
+regressionTest(
+  'shares ARIA observation across hosts',
+  async ({ mount, page }) => {
+    await page.evaluate(() => {
+      const NativeMutationObserver = window.MutationObserver;
+      const ariaObservers = new Set<MutationObserver>();
+
+      window.MutationObserver = class extends NativeMutationObserver {
+        override observe(target: Node, options?: MutationObserverInit): void {
+          if (
+            options?.attributeFilter?.includes('aria-label') &&
+            options.attributeFilter.includes('role')
+          ) {
+            ariaObservers.add(this);
+          }
+          super.observe(target, options);
+        }
+      };
+
+      (
+        window as Window & { getAriaObserverCount: () => number }
+      ).getAriaObserverCount = () => ariaObservers.size;
+    });
+
+    const items = Array.from(
+      { length: 100 },
+      (_, index) => `<ix-menu-item>Item ${index}</ix-menu-item>`
+    ).join('');
+    await mount(`<ix-application><ix-menu>${items}</ix-menu></ix-application>`);
+
+    const menuItems = page.locator('ix-menu-item');
+    await expect(menuItems).toHaveCount(100);
+    await expect(menuItems.last()).toHaveClass(/hydrated/);
+
+    await menuItems.evaluateAll((elements) => {
+      elements.forEach((element, index) =>
+        element.setAttribute('aria-label', `Item label ${index}`)
+      );
+    });
+
+    await expect(menuItems.first().getByRole('menuitem')).toHaveAttribute(
+      'aria-label',
+      'Item label 0'
+    );
+    await expect(menuItems.last().getByRole('menuitem')).toHaveAttribute(
+      'aria-label',
+      'Item label 99'
+    );
+    expect(
+      await page.evaluate(() =>
+        (
+          window as Window & { getAriaObserverCount: () => number }
+        ).getAriaObserverCount()
+      )
+    ).toBe(1);
+  }
+);
+
+regressionTest(
+  'releases disconnected ARIA-observed hosts',
+  async ({ mount, page }) => {
+    await mount(`
+      <ix-application>
+        <ix-button id="retained-aria-host">Retained button</ix-button>
+      </ix-application>
+    `);
+    await expect(page.locator('#retained-aria-host')).toHaveClass(/hydrated/);
+
+    await page.evaluate(async () => {
+      let hostElement: HTMLIxButtonElement | null =
+        document.createElement('ix-button');
+      hostElement.textContent = 'Temporary button';
+      document.body.append(hostElement);
+      await hostElement.componentOnReady();
+      hostElement.remove();
+      await new Promise(requestAnimationFrame);
+
+      (
+        window as Window & {
+          disconnectedAriaHost?: WeakRef<HTMLIxButtonElement>;
+        }
+      ).disconnectedAriaHost = new WeakRef(hostElement);
+      hostElement = null;
+    });
+
+    const devtools = await page.context().newCDPSession(page);
+    await expect
+      .poll(async () => {
+        await devtools.send('HeapProfiler.collectGarbage');
+        return page.evaluate(
+          () =>
+            (
+              window as Window & {
+                disconnectedAriaHost?: WeakRef<HTMLIxButtonElement>;
+              }
+            ).disconnectedAriaHost?.deref() === undefined
+        );
+      })
+      .toBe(true);
+
+    await devtools.detach();
+    await page.evaluate(() => {
+      Reflect.deleteProperty(window, 'disconnectedAriaHost');
+    });
+  }
+);
+
+regressionTest('updates inherited ARIA attributes', async ({ mount, page }) => {
+  await mount(`
+    <ix-application>
+      <ix-menu>
+        <ix-menu-item aria-label="Initial label" aria-level="0">
+          Foo bar
+        </ix-menu-item>
+      </ix-menu>
+    </ix-application>
+  `);
+  const menuItem = page.locator('ix-menu-item');
+  const button = menuItem.getByRole('menuitem');
+
+  await expect(button).toHaveAttribute('aria-label', 'Initial label');
+  await expect(button).toHaveAttribute('aria-level', '0');
+
+  await menuItem.evaluate((element) => {
+    element.removeAttribute('aria-label');
+    element.removeAttribute('aria-level');
+  });
+
+  await expect(button).not.toHaveAttribute('aria-label');
+  await expect(button).not.toHaveAttribute('aria-level');
+
+  await menuItem.evaluate((element) => {
+    element.setAttribute('aria-label', 'Updated label');
+    element.setAttribute('aria-level', '1');
+  });
+
+  await expect(button).toHaveAttribute('aria-label', 'Updated label');
+  await expect(button).toHaveAttribute('aria-level', '1');
+
+  await menuItem.evaluate((element) => {
+    element.removeAttribute('aria-label');
+    element.removeAttribute('aria-level');
+  });
+
+  await expect(button).not.toHaveAttribute('aria-label');
+  await expect(button).not.toHaveAttribute('aria-level');
+
+  await menuItem.evaluate((element) => {
+    const parent = element.parentElement;
+    element.setAttribute('aria-label', 'Queued before disconnect');
+    element.remove();
+    parent?.append(element);
+  });
+
+  await expect(button).toHaveAttribute(
+    'aria-label',
+    'Queued before disconnect'
+  );
+
+  await menuItem.evaluate((element) => {
+    const parent = element.parentElement;
+    element.remove();
+    element.setAttribute('aria-label', 'Changed while disconnected');
+    parent?.append(element);
+  });
+
+  await expect(button).toHaveAttribute(
+    'aria-label',
+    'Changed while disconnected'
+  );
+});
+
 async function expectMenuItemToHaveTooltip(
   page: Page,
   menuItem: Locator,

--- a/packages/core/src/components/menu-item/test/menu-item.ct.ts
+++ b/packages/core/src/components/menu-item/test/menu-item.ct.ts
@@ -190,6 +190,8 @@ regressionTest('updates inherited ARIA attributes', async ({ mount, page }) => {
     const parent = element.parentElement;
     element.remove();
     element.setAttribute('aria-label', 'Changed while disconnected');
+    element.setAttribute('aria-level', '2');
+    element.setAttribute('data-reconnect-marker', 'preserved');
     parent?.append(element);
   });
 
@@ -197,6 +199,10 @@ regressionTest('updates inherited ARIA attributes', async ({ mount, page }) => {
     'aria-label',
     'Changed while disconnected'
   );
+  await expect(button).toHaveAttribute('aria-level', '2');
+  await expect(menuItem).not.toHaveAttribute('aria-label');
+  await expect(menuItem).not.toHaveAttribute('aria-level');
+  await expect(menuItem).toHaveAttribute('data-reconnect-marker', 'preserved');
 });
 
 async function expectMenuItemToHaveTooltip(

--- a/packages/core/src/components/menu-item/test/menu-item.ct.ts
+++ b/packages/core/src/components/menu-item/test/menu-item.ct.ts
@@ -30,58 +30,101 @@ regressionTest('renders', async ({ mount, page }) => {
 regressionTest(
   'shares ARIA observation across hosts',
   async ({ mount, page }) => {
-    await page.evaluate(() => {
-      const NativeMutationObserver = window.MutationObserver;
-      const ariaObservers = new Set<MutationObserver>();
-
-      window.MutationObserver = class extends NativeMutationObserver {
-        override observe(target: Node, options?: MutationObserverInit): void {
-          if (
-            options?.attributeFilter?.includes('aria-label') &&
-            options.attributeFilter.includes('role')
-          ) {
-            ariaObservers.add(this);
-          }
-          super.observe(target, options);
-        }
+    const originalGlobals = await page.evaluateHandle(() => {
+      const testWindow = window as Window & {
+        getAriaObserverCount?: () => number;
       };
 
-      (
-        window as Window & { getAriaObserverCount: () => number }
-      ).getAriaObserverCount = () => ariaObservers.size;
+      return {
+        mutationObserver: window.MutationObserver,
+        getAriaObserverCount: testWindow.getAriaObserverCount,
+        hadGetAriaObserverCount: Object.hasOwn(
+          testWindow,
+          'getAriaObserverCount'
+        ),
+      };
     });
 
-    const items = Array.from(
-      { length: 100 },
-      (_, index) => `<ix-menu-item>Item ${index}</ix-menu-item>`
-    ).join('');
-    await mount(`<ix-application><ix-menu>${items}</ix-menu></ix-application>`);
+    try {
+      await page.evaluate(() => {
+        const NativeMutationObserver = window.MutationObserver;
+        const ariaObservers = new Set<MutationObserver>();
 
-    const menuItems = page.locator('ix-menu-item');
-    await expect(menuItems).toHaveCount(100);
-    await expect(menuItems.last()).toHaveClass(/hydrated/);
+        window.MutationObserver = class extends NativeMutationObserver {
+          override observe(target: Node, options?: MutationObserverInit): void {
+            if (
+              options?.attributeFilter?.includes('aria-label') &&
+              options.attributeFilter.includes('role')
+            ) {
+              ariaObservers.add(this);
+            }
+            super.observe(target, options);
+          }
+        };
 
-    await menuItems.evaluateAll((elements) => {
-      elements.forEach((element, index) =>
-        element.setAttribute('aria-label', `Item label ${index}`)
-      );
-    });
-
-    await expect(menuItems.first().getByRole('menuitem')).toHaveAttribute(
-      'aria-label',
-      'Item label 0'
-    );
-    await expect(menuItems.last().getByRole('menuitem')).toHaveAttribute(
-      'aria-label',
-      'Item label 99'
-    );
-    expect(
-      await page.evaluate(() =>
         (
-          window as Window & { getAriaObserverCount: () => number }
-        ).getAriaObserverCount()
-      )
-    ).toBe(1);
+          window as Window & { getAriaObserverCount?: () => number }
+        ).getAriaObserverCount = () => ariaObservers.size;
+      });
+
+      const items = Array.from(
+        { length: 100 },
+        (_, index) => `<ix-menu-item>Item ${index}</ix-menu-item>`
+      ).join('');
+      await mount(
+        `<ix-application><ix-menu>${items}</ix-menu></ix-application>`
+      );
+
+      const menuItems = page.locator('ix-menu-item');
+      await expect(menuItems).toHaveCount(100);
+      await expect(menuItems.last()).toHaveClass(/hydrated/);
+
+      await menuItems.evaluateAll((elements) => {
+        elements.forEach((element, index) =>
+          element.setAttribute('aria-label', `Item label ${index}`)
+        );
+      });
+
+      await expect(menuItems.first().getByRole('menuitem')).toHaveAttribute(
+        'aria-label',
+        'Item label 0'
+      );
+      await expect(menuItems.last().getByRole('menuitem')).toHaveAttribute(
+        'aria-label',
+        'Item label 99'
+      );
+      expect(
+        await page.evaluate(() =>
+          (
+            window as Window & { getAriaObserverCount?: () => number }
+          ).getAriaObserverCount?.()
+        )
+      ).toBe(1);
+    } finally {
+      try {
+        await page.evaluate(
+          ({
+            mutationObserver,
+            getAriaObserverCount,
+            hadGetAriaObserverCount,
+          }) => {
+            const testWindow = window as Window & {
+              getAriaObserverCount?: () => number;
+            };
+
+            window.MutationObserver = mutationObserver;
+            if (hadGetAriaObserverCount) {
+              testWindow.getAriaObserverCount = getAriaObserverCount;
+            } else {
+              Reflect.deleteProperty(testWindow, 'getAriaObserverCount');
+            }
+          },
+          originalGlobals
+        );
+      } finally {
+        await originalGlobals.dispose();
+      }
+    }
   }
 );
 

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -290,6 +290,8 @@ export class Popover
   }
 
   override connectedCallback() {
+    super.connectedCallback();
+
     if (this.hasDisconnected) {
       popoverController.connected(this);
       void this.initializePopover();
@@ -316,6 +318,8 @@ export class Popover
   }
 
   override disconnectedCallback() {
+    super.disconnectedCallback();
+
     this.hasDisconnected = true;
     this.clearHideTimeout();
     this.disposeAutoUpdate?.();

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -21,6 +21,7 @@ import {
   State,
   Watch,
 } from '@stencil/core';
+import { A11yAttributeName } from '../utils/a11y';
 import { makeRef } from '../utils/make-ref';
 import { TabClickDetail } from '../tab-item/tab-item.types';
 import { emitEvent } from '../utils/event';
@@ -41,6 +42,10 @@ import { requestAnimationFrameNoNgZone } from '../utils/requestAnimationFrame';
 })
 export class Tabs extends Mixin(...DefaultMixins, InheritAriaAttributesMixin) {
   @Element() override hostElement!: HTMLIxTabsElement;
+
+  override getIgnoredAriaAttributes(): A11yAttributeName[] {
+    return ['role'];
+  }
 
   /**
    * Set tab items to small size
@@ -137,6 +142,8 @@ export class Tabs extends Mixin(...DefaultMixins, InheritAriaAttributesMixin) {
   }
 
   override componentWillLoad() {
+    super.componentWillLoad();
+
     this.onComponentChildrenChange();
     if (this.activeTabKey) {
       this.setTabActive(this.activeTabKey);
@@ -144,6 +151,8 @@ export class Tabs extends Mixin(...DefaultMixins, InheritAriaAttributesMixin) {
   }
 
   override disconnectedCallback() {
+    super.disconnectedCallback();
+
     if (this.resizeObserver) {
       this.resizeObserver.disconnect();
     }

--- a/packages/core/src/components/tabs/test/tabs.ct.ts
+++ b/packages/core/src/components/tabs/test/tabs.ct.ts
@@ -52,6 +52,20 @@ regressionTest('renders', async ({ mount, page }) => {
   await expect(tab).toHaveClass(/\bselected\b/);
 });
 
+regressionTest('preserves the tablist role', async ({ mount, page }) => {
+  await mount(`
+    <ix-tabs role="navigation" aria-label="Process steps">
+      <ix-tab-item tab-key="tab-1">Item 1</ix-tab-item>
+    </ix-tabs>
+  `);
+  const tabs = page.locator('ix-tabs');
+  const tablist = tabs.getByRole('tablist');
+
+  await expect(tabs).toHaveAttribute('role', 'navigation');
+  await expect(tablist).toHaveAttribute('role', 'tablist');
+  await expect(tablist).toHaveAttribute('aria-label', 'Process steps');
+});
+
 regressionTest('should change tab', async ({ mount, page }) => {
   await mount(`
     <ix-tabs active-tab-key="tab-1">

--- a/packages/core/src/components/utils/a11y.ts
+++ b/packages/core/src/components/utils/a11y.ts
@@ -129,7 +129,7 @@ export type A11yAttributeName =
   | 'aria-valuenow'
   | 'aria-valuetext';
 
-const a11yAttributes: A11yAttributeName[] = [
+export const a11yAttributes: A11yAttributeName[] = [
   'role',
   'aria-activedescendant',
   'aria-atomic',

--- a/packages/core/src/components/utils/internal/mixins/accessibility/aria-attribute-observer.ts
+++ b/packages/core/src/components/utils/internal/mixins/accessibility/aria-attribute-observer.ts
@@ -1,0 +1,140 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { A11yAttributeName, a11yAttributes } from './../../../a11y';
+
+type AriaMutationHandler = (
+  attributeNames: ReadonlySet<A11yAttributeName>
+) => void;
+
+interface AriaObserverRegistration {
+  handler: AriaMutationHandler;
+}
+
+const reportMutationError = (error: unknown) => {
+  if (typeof reportError === 'function') {
+    reportError(error);
+    return;
+  }
+
+  console.error(error);
+};
+
+// A MutationObserver can watch many direct targets and keeps only weak references
+// to them, so all IX hosts can share one observer without observing a whole subtree.
+const registrations = new WeakMap<HTMLElement, AriaObserverRegistration>();
+const suppressedHosts = new WeakSet<HTMLElement>();
+let observer: MutationObserver | undefined;
+let registrationCount = 0;
+
+const dispatchMutations: MutationCallback = (mutations) => {
+  const changesByHandler = new Map<
+    AriaMutationHandler,
+    Set<A11yAttributeName>
+  >();
+
+  mutations.forEach((mutation) => {
+    const hostElement = mutation.target as HTMLElement;
+    if (suppressedHosts.has(hostElement)) {
+      return;
+    }
+
+    const registration = registrations.get(hostElement);
+    const attributeName = mutation.attributeName as A11yAttributeName | null;
+    if (!registration || !attributeName) {
+      return;
+    }
+
+    let changedAttributes = changesByHandler.get(registration.handler);
+    if (!changedAttributes) {
+      changedAttributes = new Set();
+      changesByHandler.set(registration.handler, changedAttributes);
+    }
+    changedAttributes.add(attributeName);
+  });
+
+  changesByHandler.forEach((attributeNames, handler) => {
+    try {
+      handler(attributeNames);
+    } catch (error) {
+      reportMutationError(error);
+    }
+  });
+};
+
+const getObserver = () => {
+  if (typeof MutationObserver === 'undefined') {
+    return undefined;
+  }
+
+  observer ??= new MutationObserver(dispatchMutations);
+  return observer;
+};
+
+export const observeAriaAttributes = (
+  hostElement: HTMLElement,
+  handler: AriaMutationHandler
+): boolean => {
+  const ariaObserver = getObserver();
+  if (!ariaObserver) {
+    return false;
+  }
+
+  if (!registrations.has(hostElement)) {
+    registrationCount++;
+  }
+  registrations.set(hostElement, { handler });
+  ariaObserver.observe(hostElement, {
+    attributeFilter: a11yAttributes,
+    attributes: true,
+  });
+  return true;
+};
+
+export const unobserveAriaAttributes = (hostElement: HTMLElement) => {
+  if (!registrations.delete(hostElement)) {
+    return;
+  }
+
+  registrationCount--;
+  if (registrationCount === 0) {
+    observer?.disconnect();
+    observer = undefined;
+  }
+};
+
+export const runWithoutAriaAttributeObservation = <T>(
+  hostElement: HTMLElement,
+  callback: () => T
+): T => {
+  const registration = registrations.get(hostElement);
+  if (!registration || !observer) {
+    return callback();
+  }
+
+  const activeObserver = observer;
+  dispatchMutations(activeObserver.takeRecords(), activeObserver);
+  suppressedHosts.add(hostElement);
+
+  try {
+    return callback();
+  } finally {
+    const remainingMutations = activeObserver
+      .takeRecords()
+      .filter((mutation) => mutation.target !== hostElement);
+    suppressedHosts.delete(hostElement);
+    dispatchMutations(remainingMutations, activeObserver);
+  }
+};
+
+export const flushAriaAttributeMutations = () => {
+  if (observer) {
+    dispatchMutations(observer.takeRecords(), observer);
+  }
+};

--- a/packages/core/src/components/utils/internal/mixins/accessibility/inherit-aria-attributes.mixin.ts
+++ b/packages/core/src/components/utils/internal/mixins/accessibility/inherit-aria-attributes.mixin.ts
@@ -143,6 +143,11 @@ export const InheritAriaAttributesMixin = <
 
       const hostElement = this.#getHostElement();
       const removeAttribute = hostElement.removeAttribute.bind(hostElement);
+
+      // ARIA attributes are moved from the host to the internal element during
+      // initialization. When Angular later calls removeAttribute(), the host
+      // attribute is already absent, so no MutationObserver record is created.
+      // Intercept the call to also clear the forwarded internal attribute.
       hostElement.removeAttribute = (attributeName) => {
         removeAttribute(attributeName);
 

--- a/packages/core/src/components/utils/internal/mixins/accessibility/inherit-aria-attributes.mixin.ts
+++ b/packages/core/src/components/utils/internal/mixins/accessibility/inherit-aria-attributes.mixin.ts
@@ -7,119 +7,282 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { MixedInCtor, State, Watch } from '@stencil/core';
+import { MixedInCtor, State } from '@stencil/core';
 import { StencilLifecycle } from '../../component';
 import {
   A11yAttributeName,
   A11yAttributes,
+  a11yAttributes,
   a11yHostAttributes,
 } from './../../../a11y';
+import {
+  flushAriaAttributeMutations,
+  observeAriaAttributes,
+  runWithoutAriaAttributeObservation,
+  unobserveAriaAttributes,
+} from './aria-attribute-observer';
 
 export interface InheritAriaAttributesMixinContract {
   inheritAriaAttributes: A11yAttributes;
   getIgnoredAriaAttributes?(): A11yAttributeName[];
+  readAriaAttributesFromHost(): A11yAttributes;
+}
+
+export interface LifecycleWithInheritAriaAttributesMixin {
+  connectedCallback(): void;
+  componentWillLoad(): Promise<void> | void;
+  disconnectedCallback(): void;
 }
 
 export const InheritAriaAttributesMixin = <
   B extends MixedInCtor<StencilLifecycle>,
 >(
   Base: B
-) => {
+): B &
+  MixedInCtor<
+    InheritAriaAttributesMixinContract & LifecycleWithInheritAriaAttributesMixin
+  > => {
   class InheritAriaAttributesMixinCtor
     extends Base
     implements InheritAriaAttributesMixinContract
   {
     @State() inheritAriaAttributes: A11yAttributes = {};
 
-    constructor(...args: any[]) {
-      super(...args);
+    #ariaObserverInitialized = false;
+    #ariaObservationActive = false;
+    #ariaInitializationPending = false;
+    #disconnected = false;
+    #ariaAttributesBeforeDisconnect?: Map<A11yAttributeName, string>;
+    #ariaAttributesChangedWhileDisconnected = new Set<A11yAttributeName>();
+    #ariaAttributeRemovalPatched = false;
+    #readingAriaAttributes = false;
+
+    #handleAriaMutations(changedAttributes: ReadonlySet<A11yAttributeName>) {
+      const hostElement = this.#getHostElement();
+      const ignoredAttributes = this.getIgnoredAriaAttributes();
+      let updatedAttributes = this.inheritAriaAttributes;
+
+      changedAttributes.forEach((attributeName) => {
+        if (ignoredAttributes.includes(attributeName)) {
+          return;
+        }
+
+        const newValue = hostElement.getAttribute(attributeName);
+        const currentValue = updatedAttributes[attributeName] ?? null;
+        if (newValue === currentValue) {
+          return;
+        }
+
+        if (updatedAttributes === this.inheritAriaAttributes) {
+          updatedAttributes = { ...updatedAttributes };
+        }
+
+        if (newValue === null) {
+          delete updatedAttributes[attributeName];
+        } else {
+          updatedAttributes[attributeName] = newValue;
+        }
+      });
+
+      if (updatedAttributes !== this.inheritAriaAttributes) {
+        this.inheritAriaAttributes = updatedAttributes;
+      }
     }
 
     getIgnoredAriaAttributes(): A11yAttributeName[] {
       return [];
     }
 
-    override componentWillLoad(): Promise<void> | void {
+    readAriaAttributesFromHost(): A11yAttributes {
+      const hostElement = this.#getHostElement();
+      return runWithoutAriaAttributeObservation(hostElement, () => {
+        this.#readingAriaAttributes = true;
+
+        try {
+          return a11yHostAttributes(
+            hostElement,
+            this.getIgnoredAriaAttributes()
+          );
+        } finally {
+          this.#readingAriaAttributes = false;
+        }
+      });
+    }
+
+    #getHostElement(): HTMLElement {
       if (!this.hostElement) {
         throw new Error(
           'Host element is not defined. Make sure to apply the InheritAriaAttributesMixin to a Stencil component.'
         );
       }
 
-      this.inheritAriaAttributes = a11yHostAttributes(
-        this.hostElement,
-        this.getIgnoredAriaAttributes ? this.getIgnoredAriaAttributes() : []
-      );
+      return this.hostElement;
     }
 
-    @Watch('role')
-    @Watch('aria-activedescendant')
-    @Watch('aria-atomic')
-    @Watch('aria-autocomplete')
-    @Watch('aria-braillelabel')
-    @Watch('aria-brailleroledescription')
-    @Watch('aria-busy')
-    @Watch('aria-checked')
-    @Watch('aria-colcount')
-    @Watch('aria-colindex')
-    @Watch('aria-colindextext')
-    @Watch('aria-colspan')
-    @Watch('aria-controls')
-    @Watch('aria-current')
-    @Watch('aria-describedby')
-    @Watch('aria-description')
-    @Watch('aria-details')
-    @Watch('aria-disabled')
-    @Watch('aria-errormessage')
-    @Watch('aria-expanded')
-    @Watch('aria-flowto')
-    @Watch('aria-haspopup')
-    @Watch('aria-hidden')
-    @Watch('aria-invalid')
-    @Watch('aria-keyshortcuts')
-    @Watch('aria-label')
-    @Watch('aria-labelledby')
-    @Watch('aria-level')
-    @Watch('aria-live')
-    @Watch('aria-multiline')
-    @Watch('aria-multiselectable')
-    @Watch('aria-orientation')
-    @Watch('aria-owns')
-    @Watch('aria-placeholder')
-    @Watch('aria-posinset')
-    @Watch('aria-pressed')
-    @Watch('aria-readonly')
-    @Watch('aria-relevant')
-    @Watch('aria-required')
-    @Watch('aria-roledescription')
-    @Watch('aria-rowcount')
-    @Watch('aria-rowindex')
-    @Watch('aria-rowindextext')
-    @Watch('aria-rowspan')
-    @Watch('aria-selected')
-    @Watch('aria-setsize')
-    @Watch('aria-sort')
-    @Watch('aria-valuemax')
-    @Watch('aria-valuemin')
-    @Watch('aria-valuenow')
-    @Watch('aria-valuetext')
-    ariaAttributeChanged(
-      newValue: string | null,
-      _: string | null,
-      propName: string
-    ) {
-      const ignoredAttributes = this.getIgnoredAriaAttributes();
-      if (ignoredAttributes.includes(propName as A11yAttributeName)) {
+    #getAriaAttributesFromHost() {
+      const hostElement = this.#getHostElement();
+      const attributes = new Map<A11yAttributeName, string>();
+
+      a11yAttributes.forEach((attributeName) => {
+        const value = hostElement.getAttribute(attributeName);
+        if (value !== null) {
+          attributes.set(attributeName, value);
+        }
+      });
+
+      return attributes;
+    }
+
+    #patchAriaAttributeRemoval() {
+      if (
+        this.#ariaAttributeRemovalPatched ||
+        typeof MutationObserver === 'undefined'
+      ) {
         return;
       }
 
-      const updateAttribute = {
-        [propName]: newValue,
+      const hostElement = this.#getHostElement();
+      const removeAttribute = hostElement.removeAttribute.bind(hostElement);
+      hostElement.removeAttribute = (attributeName) => {
+        removeAttribute(attributeName);
+
+        if (a11yAttributes.includes(attributeName as A11yAttributeName)) {
+          if (this.#readingAriaAttributes) {
+            return;
+          }
+
+          if (!this.#ariaObservationActive) {
+            this.#ariaAttributesChangedWhileDisconnected.add(
+              attributeName as A11yAttributeName
+            );
+          }
+
+          this.#updateInheritedAriaAttribute(
+            null,
+            attributeName as A11yAttributeName
+          );
+        }
       };
-      this.inheritAriaAttributes = {
+      this.#ariaAttributeRemovalPatched = true;
+    }
+
+    #observeAriaAttributes() {
+      this.#ariaObservationActive = observeAriaAttributes(
+        this.#getHostElement(),
+        (attributeNames) => this.#handleAriaMutations(attributeNames)
+      );
+    }
+
+    override connectedCallback(): void {
+      if (super.connectedCallback) {
+        super.connectedCallback();
+      }
+
+      this.#disconnected = false;
+      if (this.#ariaInitializationPending && !this.#ariaObserverInitialized) {
+        this.#ariaInitializationPending = false;
+        this.#initializeAriaAttributes();
+        return;
+      }
+
+      if (this.#ariaObserverInitialized) {
+        const hostElement = this.#getHostElement();
+        if (this.#ariaAttributesBeforeDisconnect) {
+          a11yAttributes.forEach((attributeName) => {
+            const oldValue =
+              this.#ariaAttributesBeforeDisconnect?.get(attributeName) ?? null;
+            const newValue = hostElement.getAttribute(attributeName);
+            if (
+              newValue !== oldValue ||
+              this.#ariaAttributesChangedWhileDisconnected.has(attributeName)
+            ) {
+              this.#updateInheritedAriaAttribute(
+                newValue ?? null,
+                attributeName
+              );
+            }
+          });
+        }
+        this.#observeAriaAttributes();
+      }
+      this.#ariaAttributesBeforeDisconnect = undefined;
+      this.#ariaAttributesChangedWhileDisconnected.clear();
+    }
+
+    override componentWillLoad(): Promise<void> | void {
+      if (super.componentWillLoad) {
+        const baseLoad = super.componentWillLoad();
+        if (baseLoad) {
+          return baseLoad.then(() =>
+            this.#initializeAriaAttributesIfConnected()
+          );
+        }
+      }
+
+      this.#initializeAriaAttributesIfConnected();
+    }
+
+    #initializeAriaAttributesIfConnected() {
+      if (this.#disconnected) {
+        this.#ariaInitializationPending = true;
+        return;
+      }
+
+      this.#initializeAriaAttributes();
+    }
+
+    #initializeAriaAttributes() {
+      this.inheritAriaAttributes = this.readAriaAttributesFromHost();
+
+      this.#patchAriaAttributeRemoval();
+      this.#ariaObserverInitialized = true;
+      this.#observeAriaAttributes();
+    }
+
+    #updateInheritedAriaAttribute(
+      newValue: string | null,
+      propName: A11yAttributeName
+    ) {
+      const ignoredAttributes = this.getIgnoredAriaAttributes();
+      if (ignoredAttributes.includes(propName)) {
+        return;
+      }
+
+      const currentValue = this.inheritAriaAttributes[propName] ?? null;
+      if (newValue === currentValue) {
+        return;
+      }
+
+      const updatedAttributes = {
         ...this.inheritAriaAttributes,
-        ...updateAttribute,
       };
+
+      if (newValue === null) {
+        delete updatedAttributes[propName];
+      } else {
+        updatedAttributes[propName] = newValue;
+      }
+
+      this.inheritAriaAttributes = updatedAttributes;
+    }
+
+    override disconnectedCallback(): void {
+      this.#disconnected = true;
+      this.#ariaAttributesChangedWhileDisconnected.clear();
+
+      if (this.#ariaObserverInitialized) {
+        flushAriaAttributeMutations();
+        this.#ariaAttributesBeforeDisconnect =
+          this.#getAriaAttributesFromHost();
+        unobserveAriaAttributes(this.#getHostElement());
+        this.#ariaObservationActive = false;
+      } else {
+        this.#ariaAttributesBeforeDisconnect = undefined;
+      }
+
+      if (super.disconnectedCallback) {
+        super.disconnectedCallback();
+      }
     }
   }
 

--- a/packages/core/src/components/utils/internal/mixins/accessibility/inherit-aria-attributes.mixin.ts
+++ b/packages/core/src/components/utils/internal/mixins/accessibility/inherit-aria-attributes.mixin.ts
@@ -192,11 +192,17 @@ export const InheritAriaAttributesMixin = <
 
       if (this.#ariaObserverInitialized) {
         const hostElement = this.#getHostElement();
+        this.#observeAriaAttributes();
+
         if (this.#ariaAttributesBeforeDisconnect) {
+          const inheritedAttributes = this.readAriaAttributesFromHost();
+
           a11yAttributes.forEach((attributeName) => {
             const oldValue =
               this.#ariaAttributesBeforeDisconnect?.get(attributeName) ?? null;
-            const newValue = hostElement.getAttribute(attributeName);
+            const newValue =
+              inheritedAttributes[attributeName] ??
+              hostElement.getAttribute(attributeName);
             if (
               newValue !== oldValue ||
               this.#ariaAttributesChangedWhileDisconnected.has(attributeName)
@@ -208,7 +214,6 @@ export const InheritAriaAttributesMixin = <
             }
           });
         }
-        this.#observeAriaAttributes();
       }
       this.#ariaAttributesBeforeDisconnect = undefined;
       this.#ariaAttributesChangedWhileDisconnected.clear();

--- a/packages/core/src/components/utils/internal/mixins/accessibility/test/inherit-aria-attributes.mixin.spec.ts
+++ b/packages/core/src/components/utils/internal/mixins/accessibility/test/inherit-aria-attributes.mixin.spec.ts
@@ -235,6 +235,7 @@ describe('InheritAriaAttributesMixin', () => {
     expect(component.inheritAriaAttributes['aria-label']).toBe(
       'While disconnected'
     );
+    expect(hostElement).not.toHaveAttribute('aria-label');
     expect(MutationObserverMock.instances).toHaveLength(2);
 
     component.disconnectedCallback();

--- a/packages/core/src/components/utils/internal/mixins/accessibility/test/inherit-aria-attributes.mixin.spec.ts
+++ b/packages/core/src/components/utils/internal/mixins/accessibility/test/inherit-aria-attributes.mixin.spec.ts
@@ -1,0 +1,403 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type { HTMLStencilElement } from '@stencil/core/internal';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { A11yAttributeName } from './../../../../a11y';
+
+type InheritAriaAttributesMixinModule =
+  typeof import('../inherit-aria-attributes.mixin');
+type AriaAttributeObserverModule = typeof import('../aria-attribute-observer');
+
+const originalGlobalMutationObserver = Object.getOwnPropertyDescriptor(
+  globalThis,
+  'MutationObserver'
+);
+const originalWindowMutationObserver = Object.getOwnPropertyDescriptor(
+  window,
+  'MutationObserver'
+);
+const originalReportError = Object.getOwnPropertyDescriptor(
+  globalThis,
+  'reportError'
+);
+
+function restoreProperty(
+  target: object,
+  key: string,
+  descriptor?: PropertyDescriptor
+) {
+  if (descriptor) {
+    Object.defineProperty(target, key, descriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(target, key);
+}
+
+class MutationObserverMock {
+  static instances: MutationObserverMock[] = [];
+
+  readonly observations: {
+    target: Node;
+    options?: MutationObserverInit;
+  }[] = [];
+  readonly disconnect = vi.fn(() => {
+    this.records = [];
+  });
+  readonly takeRecords = vi.fn(() => this.records.splice(0));
+
+  private records: MutationRecord[] = [];
+
+  constructor(private readonly callback: MutationCallback) {
+    MutationObserverMock.instances.push(this);
+  }
+
+  observe(target: Node, options?: MutationObserverInit) {
+    this.observations.push({ target, options });
+  }
+
+  queue(...records: MutationRecord[]) {
+    this.records.push(...records);
+  }
+
+  notify(...records: MutationRecord[]) {
+    this.callback(records, this as unknown as MutationObserver);
+  }
+}
+
+const createMutationRecord = (
+  target: HTMLElement,
+  attributeName: A11yAttributeName
+) =>
+  ({
+    attributeName,
+    target,
+    type: 'attributes',
+  }) as unknown as MutationRecord;
+
+describe('InheritAriaAttributesMixin', () => {
+  let mixinModule: InheritAriaAttributesMixinModule;
+  let observerModule: AriaAttributeObserverModule;
+  let reportErrorMock: ReturnType<typeof vi.fn>;
+
+  const createComponent = () => {
+    class BaseComponent {
+      hostElement?: HTMLStencilElement;
+    }
+
+    const MixedComponent =
+      mixinModule.InheritAriaAttributesMixin(BaseComponent);
+    const component = new MixedComponent();
+    const hostElement = document.createElement(
+      'div'
+    ) as unknown as HTMLStencilElement;
+    component.hostElement = hostElement;
+
+    return { component, hostElement };
+  };
+
+  beforeEach(async () => {
+    vi.resetModules();
+    MutationObserverMock.instances = [];
+    reportErrorMock = vi.fn();
+    vi.doMock('@stencil/core', () => ({
+      State: () => () => undefined,
+    }));
+
+    Object.defineProperty(globalThis, 'MutationObserver', {
+      configurable: true,
+      writable: true,
+      value: MutationObserverMock,
+    });
+    Object.defineProperty(window, 'MutationObserver', {
+      configurable: true,
+      writable: true,
+      value: MutationObserverMock,
+    });
+    Object.defineProperty(globalThis, 'reportError', {
+      configurable: true,
+      writable: true,
+      value: reportErrorMock,
+    });
+
+    mixinModule = await import('../inherit-aria-attributes.mixin');
+    observerModule = await import('../aria-attribute-observer');
+  });
+
+  afterEach(() => {
+    vi.doUnmock('@stencil/core');
+    restoreProperty(
+      globalThis,
+      'MutationObserver',
+      originalGlobalMutationObserver
+    );
+    restoreProperty(window, 'MutationObserver', originalWindowMutationObserver);
+    restoreProperty(globalThis, 'reportError', originalReportError);
+    vi.restoreAllMocks();
+  });
+
+  it('forwards initial attributes and shares one observer between hosts', () => {
+    const first = createComponent();
+    const second = createComponent();
+    first.hostElement.setAttribute('aria-label', 'First');
+    second.hostElement.setAttribute('aria-label', 'Second');
+
+    first.component.componentWillLoad();
+    second.component.componentWillLoad();
+
+    expect(first.component.inheritAriaAttributes).toEqual({
+      'aria-label': 'First',
+    });
+    expect(second.component.inheritAriaAttributes).toEqual({
+      'aria-label': 'Second',
+    });
+    expect(first.hostElement).not.toHaveAttribute('aria-label');
+    expect(second.hostElement).not.toHaveAttribute('aria-label');
+
+    expect(MutationObserverMock.instances).toHaveLength(1);
+    const [observer] = MutationObserverMock.instances;
+    expect(observer.observations).toHaveLength(2);
+    expect(observer.observations[0]).toMatchObject({
+      target: first.hostElement,
+      options: {
+        attributes: true,
+      },
+    });
+    expect(observer.observations[0].options?.subtree).toBeUndefined();
+    expect(observer.observations[0].options?.attributeFilter).toContain(
+      'aria-label'
+    );
+
+    first.component.disconnectedCallback();
+    expect(observer.disconnect).not.toHaveBeenCalled();
+    second.component.disconnectedCallback();
+    expect(observer.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it('batches multiple mutations into one state update per host', () => {
+    const { component, hostElement } = createComponent();
+    component.componentWillLoad();
+    const [observer] = MutationObserverMock.instances;
+
+    let inheritedAttributes = component.inheritAriaAttributes;
+    let stateUpdates = 0;
+    Object.defineProperty(component, 'inheritAriaAttributes', {
+      configurable: true,
+      get: () => inheritedAttributes,
+      set: (value) => {
+        inheritedAttributes = value;
+        stateUpdates++;
+      },
+    });
+
+    hostElement.setAttribute('aria-label', 'Updated');
+    hostElement.setAttribute('aria-level', '2');
+    observer.notify(
+      createMutationRecord(hostElement, 'aria-label'),
+      createMutationRecord(hostElement, 'aria-level'),
+      createMutationRecord(hostElement, 'aria-label')
+    );
+
+    expect(component.inheritAriaAttributes).toEqual({
+      'aria-label': 'Updated',
+      'aria-level': '2',
+    });
+    expect(stateUpdates).toBe(1);
+
+    component.disconnectedCallback();
+  });
+
+  it('removes disconnected hosts from the weak handler registry', () => {
+    const { component, hostElement } = createComponent();
+    component.componentWillLoad();
+    const [observer] = MutationObserverMock.instances;
+
+    hostElement.setAttribute('aria-label', 'Queued');
+    observer.queue(createMutationRecord(hostElement, 'aria-label'));
+    component.disconnectedCallback();
+
+    expect(component.inheritAriaAttributes['aria-label']).toBe('Queued');
+    expect(observer.takeRecords).toHaveBeenCalled();
+    expect(observer.disconnect).toHaveBeenCalledOnce();
+
+    hostElement.setAttribute('aria-label', 'While disconnected');
+    observer.notify(createMutationRecord(hostElement, 'aria-label'));
+    expect(component.inheritAriaAttributes['aria-label']).toBe('Queued');
+
+    component.connectedCallback();
+    expect(component.inheritAriaAttributes['aria-label']).toBe(
+      'While disconnected'
+    );
+    expect(MutationObserverMock.instances).toHaveLength(2);
+
+    component.disconnectedCallback();
+  });
+
+  it('reconciles a removed and reapplied attribute after reconnect', () => {
+    const { component, hostElement } = createComponent();
+    hostElement.setAttribute('aria-label', 'Initial');
+    component.componentWillLoad();
+
+    component.disconnectedCallback();
+    hostElement.removeAttribute('aria-label');
+    expect(component.inheritAriaAttributes).toEqual({});
+
+    hostElement.setAttribute('aria-label', 'Initial');
+    component.connectedCallback();
+
+    expect(component.inheritAriaAttributes).toEqual({
+      'aria-label': 'Initial',
+    });
+
+    component.disconnectedCallback();
+  });
+
+  it('continues dispatching when one host handler throws', () => {
+    const first = createComponent();
+    const second = createComponent();
+    first.component.componentWillLoad();
+    second.component.componentWillLoad();
+    const [observer] = MutationObserverMock.instances;
+    const error = new Error('ARIA handler failed');
+    first.component.getIgnoredAriaAttributes = () => {
+      throw error;
+    };
+
+    first.hostElement.setAttribute('aria-label', 'First');
+    second.hostElement.setAttribute('aria-label', 'Second');
+    observer.notify(
+      createMutationRecord(first.hostElement, 'aria-label'),
+      createMutationRecord(second.hostElement, 'aria-label')
+    );
+
+    expect(reportErrorMock).toHaveBeenCalledWith(error);
+    expect(second.component.inheritAriaAttributes).toEqual({
+      'aria-label': 'Second',
+    });
+
+    first.component.getIgnoredAriaAttributes = () => [];
+    first.component.disconnectedCallback();
+    second.component.disconnectedCallback();
+  });
+
+  it('waits for the base componentWillLoad before initializing', async () => {
+    let resolveBaseLoad!: () => void;
+    const baseLoad = new Promise<void>((resolve) => {
+      resolveBaseLoad = resolve;
+    });
+    class AsyncBaseComponent {
+      hostElement?: HTMLStencilElement;
+
+      componentWillLoad() {
+        return baseLoad;
+      }
+    }
+    const MixedComponent =
+      mixinModule.InheritAriaAttributesMixin(AsyncBaseComponent);
+    const component = new MixedComponent();
+    component.hostElement = document.createElement(
+      'div'
+    ) as unknown as HTMLStencilElement;
+
+    const componentLoad = component.componentWillLoad();
+    expect(MutationObserverMock.instances).toHaveLength(0);
+
+    resolveBaseLoad();
+    await componentLoad;
+
+    expect(MutationObserverMock.instances).toHaveLength(1);
+    component.disconnectedCallback();
+  });
+
+  it('defers initialization when disconnected during an async base load', async () => {
+    let resolveBaseLoad!: () => void;
+    const baseLoad = new Promise<void>((resolve) => {
+      resolveBaseLoad = resolve;
+    });
+    class AsyncBaseComponent {
+      hostElement?: HTMLStencilElement;
+
+      componentWillLoad() {
+        return baseLoad;
+      }
+    }
+    const MixedComponent =
+      mixinModule.InheritAriaAttributesMixin(AsyncBaseComponent);
+    const component = new MixedComponent();
+    const hostElement = document.createElement(
+      'div'
+    ) as unknown as HTMLStencilElement;
+    component.hostElement = hostElement;
+    hostElement.setAttribute('aria-label', 'Deferred');
+
+    const componentLoad = component.componentWillLoad();
+    component.disconnectedCallback();
+    resolveBaseLoad();
+    await componentLoad;
+
+    expect(MutationObserverMock.instances).toHaveLength(0);
+    expect(hostElement.getAttribute('aria-label')).toBe('Deferred');
+
+    component.connectedCallback();
+
+    expect(component.inheritAriaAttributes).toEqual({
+      'aria-label': 'Deferred',
+    });
+    expect(hostElement).not.toHaveAttribute('aria-label');
+    expect(MutationObserverMock.instances).toHaveLength(1);
+
+    component.disconnectedCallback();
+  });
+
+  it('does not restore a registration released during suppression', () => {
+    const hostElement = document.createElement('div');
+    const handler = vi.fn();
+    observerModule.observeAriaAttributes(hostElement, handler);
+    const [observer] = MutationObserverMock.instances;
+
+    expect(() =>
+      observerModule.runWithoutAriaAttributeObservation(hostElement, () =>
+        observerModule.unobserveAriaAttributes(hostElement)
+      )
+    ).not.toThrow();
+
+    expect(observer.disconnect).toHaveBeenCalledOnce();
+    hostElement.setAttribute('aria-label', 'Ignored');
+    observer.notify(createMutationRecord(hostElement, 'aria-label'));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('does not process attributes removed during internal extraction', () => {
+    const { component, hostElement } = createComponent();
+    component.componentWillLoad();
+    const [observer] = MutationObserverMock.instances;
+
+    hostElement.setAttribute('aria-label', 'Extracted');
+    observer.queue(createMutationRecord(hostElement, 'aria-label'));
+
+    const removeAttribute = hostElement.removeAttribute.bind(hostElement);
+    hostElement.removeAttribute = (attributeName) => {
+      removeAttribute(attributeName);
+      observer.queue(
+        createMutationRecord(hostElement, attributeName as A11yAttributeName)
+      );
+    };
+
+    const extractedAttributes = component.readAriaAttributesFromHost();
+
+    expect(extractedAttributes).toEqual({ 'aria-label': 'Extracted' });
+    expect(component.inheritAriaAttributes).toEqual({
+      'aria-label': 'Extracted',
+    });
+    expect(hostElement).not.toHaveAttribute('aria-label');
+
+    component.disconnectedCallback();
+  });
+});


### PR DESCRIPTION
<!--
 First off, thanks for taking the time to contribute! ❤️
 We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

In Angular applications, initial ARIA attribute bindings can trigger Stencil `@Watch` handlers before the lazy component instance is initialized. This can cause runtime errors and prevent attributes such as `aria-label` and `aria-level` from being forwarded to the component’s internal interactive element.

GitHub Issue Number: #2716  
Internal tracked: EIX-220

## 🆕 What is the new behavior?

- Replaces native ARIA `@Watch` handlers with one shared, attribute-filtered `MutationObserver`, avoiding the unsafe Stencil initialization path without changing the Stencil runtime or enabling `initializeNextTick`.
- Preserves initial and dynamic ARIA forwarding, including removals, disconnects and reconnects. Updates are applied in the next microtask and batched per component.
- Uses weak registrations and tears down the shared observer when unused, preventing retained component references.
- Adds direct mixin, lifecycle, memory, accessibility and Angular regression coverage.
- Preserves component-specific host semantics, including the `tablist` role used by `ix-tabs`.

## 🏁 Checklist

- [x] 🦮 Accessibility (a11y) features were implemented
- [x] 🗺️ Internationalization (i18n) - no hard coded strings
- [x] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [x] 📕 Add or update a Storybook story — not required; no visual or usage changes
- [x] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs) — no documentation changes required
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [x] 📸 Visual regression tests were added/updated and pass (not required; rendered appearance is unchanged)
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved ARIA label and level handling for nested Angular menus, including dynamic updates.
  * Preserved custom `ix-tabs` roles and labels while maintaining internal tablist semantics.
  * Improved ARIA attribute inheritance and synchronization across menu items and other components.
  * Preserved accessibility attributes when badges switch between link and standalone modes.
* **Bug Fixes**
  * Improved component initialization and cleanup to keep accessibility state consistent.
* **Tests**
  * Added regression coverage for dynamic ARIA updates, disconnected components, and tab accessibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->