### PR TITLE
ci(build): execute on tag push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
       - 'main'
       - 'release/*'
       - 'release-*'
+    tags:
+      - '@siemens/ix@*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- siemens/ix-docs needs tag build pipeline to download artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build workflow to run automatically when matching release tags are pushed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->