### PR TITLE
fix(core/category-filter): allow Space in the filter input EIX-302

### DIFF
--- a/.changeset/category-filter-space-input.md
+++ b/.changeset/category-filter-space-input.md
@@ -1,0 +1,7 @@
+---
+'@siemens/ix': patch
+---
+
+Allow Space to be typed in the **ix-category-filter** input instead of swallowing the key as a dropdown shortcut.
+
+Fixes #2757

--- a/packages/core/src/components/category-filter/category-filter.tsx
+++ b/packages/core/src/components/category-filter/category-filter.tsx
@@ -931,6 +931,8 @@ export class CategoryFilter {
             trigger={this.hostElement}
             header={this.getDropdownHeader()}
             enableTopLayer={this.enableTopLayer}
+            keyboardActivationKeys={['ArrowUp', 'ArrowDown']}
+            keyboardItemTriggerKeys={['Enter']}
           >
             {this.renderDropdownContent()}
           </ix-dropdown>

--- a/packages/core/src/components/category-filter/test/category-filter.ct.ts
+++ b/packages/core/src/components/category-filter/test/category-filter.ct.ts
@@ -151,26 +151,4 @@ regressionTest.describe('filter input keyboard', () => {
 
     await expect(input).toHaveValue('env 1');
   });
-
-  regressionTest('allows a leading space character', async ({ page }) => {
-    const input = page.locator('ix-category-filter').getByRole('textbox');
-    await input.click();
-    await input.press('Space');
-    await input.pressSequentially('env');
-
-    await expect(input).toHaveValue(' env');
-  });
-
-  regressionTest('commits a token that contains a space', async ({ page }) => {
-    const categoryFilter = page.locator('ix-category-filter');
-    const input = categoryFilter.getByRole('textbox');
-    await input.click();
-    await input.pressSequentially('env 1');
-    await page.keyboard.press('Enter');
-
-    await expect(
-      categoryFilter.locator('ix-filter-chip').first()
-    ).toContainText('env 1');
-    await expect(input).toHaveValue('');
-  });
 });

--- a/packages/core/src/components/category-filter/test/category-filter.ct.ts
+++ b/packages/core/src/components/category-filter/test/category-filter.ct.ts
@@ -12,7 +12,7 @@ import { expect } from '@playwright/test';
 regressionTest('renders', async ({ mount, page }) => {
   await mount(`<ix-category-filter></ix-category-filter>`);
   const categoryFilter = page.locator('ix-category-filter');
-  await expect(categoryFilter).toHaveClass(/hydrated/);
+  await expect(categoryFilter).toHaveClass(/\bhydrated\b/);
 });
 
 regressionTest.describe('category-preview test', () => {
@@ -122,4 +122,55 @@ regressionTest.describe('focus behavior', () => {
       await expect(input).toBeFocused();
     }
   );
+});
+
+regressionTest.describe('filter input keyboard', () => {
+  regressionTest.beforeEach(async ({ mount, page }) => {
+    await mount(`<ix-category-filter></ix-category-filter>`);
+
+    const categoryFilter = page.locator('ix-category-filter');
+    await expect(categoryFilter).toHaveClass(/\bhydrated\b/);
+    await categoryFilter.evaluate((el: HTMLIxCategoryFilterElement) => {
+      el.categories = {
+        ID_1: {
+          label: 'Vendor',
+          options: ['Apple', 'MS', 'Siemens'],
+        },
+        ID_2: {
+          label: 'Product',
+          options: ['iPhone X', 'Windows', 'APS'],
+        },
+      };
+    });
+  });
+
+  regressionTest('allows space characters while typing', async ({ page }) => {
+    const input = page.locator('ix-category-filter').getByRole('textbox');
+    await input.click();
+    await input.pressSequentially('env 1');
+
+    await expect(input).toHaveValue('env 1');
+  });
+
+  regressionTest('allows a leading space character', async ({ page }) => {
+    const input = page.locator('ix-category-filter').getByRole('textbox');
+    await input.click();
+    await input.press('Space');
+    await input.pressSequentially('env');
+
+    await expect(input).toHaveValue(' env');
+  });
+
+  regressionTest('commits a token that contains a space', async ({ page }) => {
+    const categoryFilter = page.locator('ix-category-filter');
+    const input = categoryFilter.getByRole('textbox');
+    await input.click();
+    await input.pressSequentially('env 1');
+    await page.keyboard.press('Enter');
+
+    await expect(
+      categoryFilter.locator('ix-filter-chip').first()
+    ).toContainText('env 1');
+    await expect(input).toHaveValue('');
+  });
 });

--- a/packages/storybook-docs/src/stories/category-filter.stories.tsx
+++ b/packages/storybook-docs/src/stories/category-filter.stories.tsx
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { LogicalFilterOperator } from '@siemens/ix';
+import type { Components } from '@siemens/ix/components';
+import { h } from '@stencil/core';
+import type { ArgTypes, Meta, StoryObj } from '@storybook/web-components-vite';
+import { stencil } from '@utils/stencil-render';
+import { makeArgTypes } from './utils/generic-render';
+
+type Element = Components.IxCategoryFilter;
+
+const categories: NonNullable<Element['categories']> = {
+  ID_1: {
+    label: 'Vendor',
+    options: ['Apple', 'MS', 'Siemens'],
+  },
+  ID_2: {
+    label: 'Product',
+    options: ['iPhone X', 'Windows', 'APS'],
+  },
+};
+
+const meta = {
+  title: 'Example/Category Filter',
+  tags: [],
+  render: stencil((args) => (
+    <ix-category-filter {...args}></ix-category-filter>
+  )),
+  argTypes: makeArgTypes<Partial<ArgTypes<Element>>>('ix-category-filter', {
+    categories: { control: { type: 'object' } },
+    filterState: { control: { type: 'object' } },
+    suggestions: { control: { type: 'object' } },
+    nonSelectableCategories: { control: { type: 'object' } },
+  }),
+} satisfies Meta<Element>;
+
+export default meta;
+type Story = StoryObj<Element>;
+
+export const Default: Story = {
+  args: {
+    placeholder: 'Filter assets',
+  },
+};
+
+export const WithCategories: Story = {
+  name: 'With categories',
+  render: stencil((args) => (
+    <div style={{ minHeight: '280px' }}>
+      <ix-category-filter {...args}></ix-category-filter>
+    </div>
+  )),
+  args: {
+    placeholder: 'Filter by',
+    uniqueCategories: false,
+    categories,
+    filterState: {
+      tokens: ['Custom filter text'],
+      categories: [
+        {
+          id: 'ID_1',
+          value: 'IBM',
+          operator: LogicalFilterOperator.NOT_EQUAL,
+        },
+      ],
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Click the input and type a value that contains a space, e.g. `env 1`. The space must appear. Press Enter to commit a token. Click the input or press ArrowDown to open the category list (Vendor, Product; Product includes `iPhone X`).',
+      },
+    },
+  },
+};

--- a/packages/storybook-docs/src/stories/category-filter.stories.tsx
+++ b/packages/storybook-docs/src/stories/category-filter.stories.tsx
@@ -21,6 +21,10 @@ const categories: NonNullable<Element['categories']> = {
     label: 'Product',
     options: ['iPhone X', 'Windows', 'APS'],
   },
+  ID_3: {
+    label: 'Asset group',
+    options: ['Line 1', 'Bay 2'],
+  },
 };
 
 const meta = {
@@ -72,7 +76,7 @@ export const WithCategories: Story = {
     docs: {
       description: {
         story:
-          'Click the input and type a value that contains a space, e.g. `env 1`. The space must appear. Press Enter to commit a token. Click the input or press ArrowDown to open the category list (Vendor, Product; Product includes `iPhone X`).',
+          'Click the input and type a value that contains a space, e.g. `env 1`. The space must appear. Press Enter to commit a token. Click the input or press ArrowDown to open the category list (Vendor, Product, **Asset group**). Open Product to see a value with a space (`iPhone X`).',
       },
     },
   },


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## 💡 What is the current behavior?

Typing Space in the `ix-category-filter` text input is swallowed. No space character is inserted, so values such as `env 1` cannot be entered.

This is a side effect of `ix-dropdown` treating Space as a menu shortcut (open / activate). The category filter uses the host as the dropdown trigger and did not opt out of those keys the way `ix-select` and date inputs already do.

GitHub Issue Number: #2757  

## 🆕 What is the new behavior?

- Space is typed into the filter input (including a leading space). Enter still commits a token; tokens may contain spaces.
- The inner `ix-dropdown` uses the same key override as `ix-select`: `keyboardActivationKeys={['ArrowUp', 'ArrowDown']}` and `keyboardItemTriggerKeys={['Enter']}`. Arrow keys still open and move in the list.
- Component tests cover typing `env 1`, a leading space, and committing a token that contains a space (`pressSequentially` / `press('Space')`, not `fill()`).

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented *keyboard typing restored; no new ARIA surface*
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings *N/A*
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully *N/A*
- [ ] 📕 Add or update a Storybook story *N/A — existing previews cover the input*
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs) *N/A — no API change; behavior matches documented examples that already use spaced tokens*
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`) *category-filter CT; `pnpm run test.ct -- --grep category-filter` passed (8 tests)*
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing)) *N/A — keyboard behavior only, no visual change*
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

Manual check: http://localhost:5173/preview/category-filter (also `/preview/category-filter-suggestions`).

Click the input and type a value with a space, e.g. `env 1`. The space should appear. Enter should still create a chip with that text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Space characters can now be entered in the category filter input without triggering unintended dropdown shortcuts.
  * Arrow keys navigate dropdown options, and Enter selects the highlighted option.

* **New Features**
  * Added a categorized filtering example with configurable categories and filter states.

* **Documentation**
  * Expanded category-filter guidance to cover inputs containing spaces and category-list interactions.

* **Tests**
  * Added coverage for keyboard input and improved hydration-state assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->