### PR TITLE
fix(core/filter-chip): Added state to filter-chip to reflect correctly in tooltip

### DIFF
--- a/.changeset/filter-chip-stale-title.md
+++ b/.changeset/filter-chip-stale-title.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix': patch
+---
+
+Fix `ix-filter-chip` (and the `ix-select` overflow chip) showing a stale native tooltip (`title`) after its slotted label content changed, e.g. the overflow chip tooltip kept showing an outdated count instead of the current one.

--- a/packages/core/src/components/filter-chip/filter-chip.tsx
+++ b/packages/core/src/components/filter-chip/filter-chip.tsx
@@ -16,6 +16,7 @@ import {
   h,
   Host,
   Prop,
+  State,
 } from '@stencil/core';
 
 /**
@@ -57,6 +58,26 @@ export class FilterChip {
    */
   @Event() closeClick!: EventEmitter<void>;
 
+  @State() private slotText = '';
+
+  private slotObserver?: MutationObserver;
+
+  connectedCallback() {
+    this.slotText = this.hostElement.textContent ?? '';
+    this.slotObserver = new MutationObserver(() => {
+      this.slotText = this.hostElement.textContent ?? '';
+    });
+    this.slotObserver.observe(this.hostElement, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+  }
+
+  disconnectedCallback() {
+    this.slotObserver?.disconnect();
+  }
+
   private onCloseClick(event: Event) {
     event.preventDefault();
     event.stopPropagation();
@@ -71,7 +92,7 @@ export class FilterChip {
           readonly: this.readonly,
           'hide-close-button': this.hideCloseButton,
         }}
-        title={this.hostElement.textContent}
+        title={this.slotText}
       >
         <div class="slot-container">
           <slot></slot>

--- a/packages/core/src/components/select/test/select.ct.ts
+++ b/packages/core/src/components/select/test/select.ct.ts
@@ -1462,6 +1462,41 @@ test('multiple mode: removing a hidden item from "+N" dropdown updates count', a
   await expect(overflowChip).not.toHaveText(initialCount ?? '');
 });
 
+test('multiple mode: "+N" chip tooltip (title) updates when hidden count changes', async ({
+  mount,
+  page,
+}) => {
+  await mount(`
+    <ix-select mode="multiple" style="width: 220px; display: block;">
+      <ix-select-item value="1" label="Item number one"></ix-select-item>
+      <ix-select-item value="2" label="Item number two"></ix-select-item>
+      <ix-select-item value="3" label="Item number three"></ix-select-item>
+      <ix-select-item value="4" label="Item number four"></ix-select-item>
+      <ix-select-item value="5" label="Item number five"></ix-select-item>
+    </ix-select>
+  `);
+
+  const select = page.locator('ix-select');
+  await select.evaluate((el: HTMLIxSelectElement) => {
+    el.value = ['1', '2', '3'];
+  });
+
+  const overflowChip = select.locator('ix-filter-chip.chip-overflow');
+  await expect(overflowChip).toBeVisible();
+  const initialTitle = await overflowChip.getAttribute('title');
+  expect(initialTitle).toContain(await overflowChip.textContent());
+
+  await select.evaluate((el: HTMLIxSelectElement) => {
+    el.value = ['1', '2', '3', '4', '5'];
+  });
+
+  await expect
+    .poll(async () => overflowChip.getAttribute('title'))
+    .toBe(await overflowChip.textContent());
+  const updatedTitle = await overflowChip.getAttribute('title');
+  expect(updatedTitle).not.toBe(initialTitle);
+});
+
 test('multiple mode: focused "+N" chip opens overflow dropdown with Enter', async ({
   mount,
   page,


### PR DESCRIPTION
## 💡 What is the current behavior?
While many options are selected in the ix select, the tooltip doesnt reflect the number of selected items correctly

GitHub Issue Number: #2773 

## 🆕 What is the new behavior?

Number displayed in the tooltip is correct now.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🧐 Static code analysis passes (`pnpm lint`)
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed filter chip tooltips so they update when their displayed label or count changes.
  - Updated multi-select overflow chip tooltips to reflect the current number of hidden selections.

- **Tests**
  - Added coverage verifying that overflow chip tooltips update correctly as selections change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->