### PR TITLE
docs(README): remove Community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@
     <br />
     <a href="https://ix.siemens.io/docs/home/overview">Quickstart</a>
     ·
-    <a href="https://community.siemens.com/c/ix/">Community</a>
-    ·
     <a href="https://github.com/siemens/ix/issues/new/choose">Report Issue</a>
     ·
     <a href="https://github.com/siemens/ix/issues/new/choose">Request Feature</a>


### PR DESCRIPTION
Removed Community link from README as Community is discontinued


## 💡 What is the current behavior?

README links to discontinued Community

## 🆕 What is the new behavior?

Link is removed 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed the Community link from the project header navigation in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->