### PR TITLE
Fix(core date input) month list disable offset eix 314

### DIFF
--- a/packages/core/eslint.config.cjs
+++ b/packages/core/eslint.config.cjs
@@ -17,6 +17,47 @@ const compat = new FlatCompat({
   allConfig: js.configs.all,
 });
 
+// `no-restricted-syntax` is not additive across flat-config objects - a later
+// object replaces the whole list. Keep the shared entries here so the scoped
+// override below can re-declare them alongside its own.
+const noAssertionSyntaxRules = [
+  {
+    selector:
+      "TSNonNullExpression:not([expression.type='MemberExpression'][expression.property.name='shadowRoot']):not([expression.type='CallExpression'][expression.callee.type='MemberExpression'][expression.callee.property.name='querySelector'])",
+    message:
+      'Avoid non-null assertion (!). Use safer narrowing, except for shadowRoot access and querySelector(...) results.',
+  },
+  {
+    selector:
+      "PropertyDefinition[definite=true]:not(:has(Decorator[expression.callee.name='Event'])):not(:has(Decorator[expression.callee.name='Prop'])):not(:has(Decorator[expression.callee.name='Element'])):not(:has(Decorator[expression.callee.name='Element'])):not(:has(Decorator[expression.callee.name='AttachInternals']))",
+    message:
+      'Avoid definite assignment assertion (!). Initialize the field or use an allowed decorator field.',
+  },
+];
+
+// Luxon counts months 1-12 and weekdays 1-7 (Monday = 1), but the name arrays
+// from `Info.months()` / `Info.weekdays()` and the pickers' own state are
+// 0-based. Mixing the two silently shifts the calendar by one unit, so the
+// date components must go through `utils/calendar-units.ts`, which owns every
+// conversion.
+const calendarUnitRules = [
+  {
+    selector: "MemberExpression[property.name='month']",
+    message:
+      "Luxon's .month is 1-12 but the UI month arrays are 0-based. Use monthIndexOf() / fromMonthIndex() from utils/calendar-units.ts.",
+  },
+  {
+    selector: "MemberExpression[property.name='weekday']",
+    message:
+      "Luxon's .weekday is 1-7 (Monday = 1) but the UI weekday arrays are 0-based. Use weekdayIndexOf() / weekdayColumnOf() from utils/calendar-units.ts.",
+  },
+  {
+    selector: "NewExpression[callee.name='Date'][arguments.length>=2]",
+    message:
+      'new Date(year, month, day) takes a 0-based month and resolves in local time. Use fromMonthIndex() from utils/calendar-units.ts.',
+  },
+];
+
 module.exports = [
   {
     ignores: [
@@ -52,24 +93,27 @@ module.exports = [
       'react/jsx-uses-react': 0,
       'react/react-in-jsx-scope': 0,
       '@typescript-eslint/no-confusing-non-null-assertion': 'error',
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector:
-            "TSNonNullExpression:not([expression.type='MemberExpression'][expression.property.name='shadowRoot']):not([expression.type='CallExpression'][expression.callee.type='MemberExpression'][expression.callee.property.name='querySelector'])",
-          message:
-            'Avoid non-null assertion (!). Use safer narrowing, except for shadowRoot access and querySelector(...) results.',
-        },
-        {
-          selector:
-            "PropertyDefinition[definite=true]:not(:has(Decorator[expression.callee.name='Event'])):not(:has(Decorator[expression.callee.name='Prop'])):not(:has(Decorator[expression.callee.name='Element'])):not(:has(Decorator[expression.callee.name='Element'])):not(:has(Decorator[expression.callee.name='AttachInternals']))",
-          message:
-            'Avoid definite assignment assertion (!). Initialize the field or use an allowed decorator field.',
-        },
-      ],
+      'no-restricted-syntax': ['error', ...noAssertionSyntaxRules],
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-vars': 'warn',
       'no-unused-vars': 'off',
     },
   }),
+  {
+    files: [
+      'src/components/date-picker/**/*.{ts,tsx}',
+      'src/components/date-input/**/*.{ts,tsx}',
+      'src/components/date-dropdown/**/*.{ts,tsx}',
+      'src/components/datetime-picker/**/*.{ts,tsx}',
+      'src/components/datetime-input/**/*.{ts,tsx}',
+    ],
+    ignores: ['**/test/**', '**/tests/**'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        ...noAssertionSyntaxRules,
+        ...calendarUnitRules,
+      ],
+    },
+  },
 ];

--- a/packages/core/src/components/date-picker/date-picker.tsx
+++ b/packages/core/src/components/date-picker/date-picker.tsx
@@ -26,6 +26,18 @@ import {
 } from '@stencil/core';
 import { DateTime, Info } from 'luxon';
 import type { DateTimeCardCorners } from '../date-time-card/date-time-card.types';
+import {
+  type MonthIndex,
+  addMonths,
+  daysInMonth,
+  fromMonthIndex,
+  isDayWithinRange,
+  isMonthWithinRange,
+  isYearWithinRange,
+  localFromMonthIndex,
+  monthIndexOf,
+  weekdayColumnOf,
+} from '../utils/calendar-units';
 import { queryElements } from '../utils/focus/focus-utilities';
 import { DefaultMixins } from '../utils/internal/component';
 import { makeRef } from '../utils/make-ref';
@@ -340,9 +352,7 @@ export class DatePicker
   }
 
   private getDaysInCurrentMonth(): number {
-    return (
-      DateTime.utc(this.selectedYear, this.selectedMonth + 1).daysInMonth || 0
-    );
+    return daysInMonth(this.selectedYear, this.selectedMonth);
   }
 
   private getFirstDayOfWeek(day: number): number {
@@ -385,7 +395,7 @@ export class DatePicker
   @Method()
   async updateSelectedYearMonth(date: DateTime) {
     this.selectedYear = date.year;
-    this.selectedMonth = date.month - 1;
+    this.selectedMonth = monthIndexOf(date);
   }
 
   onDayBlur() {
@@ -410,8 +420,9 @@ export class DatePicker
     this.startYear = year - 101;
     this.endYear = year + 101;
 
-    this.selectedMonth =
-      (this.currFromDate?.month ?? this.getDateTimeNow().month) - 1;
+    this.selectedMonth = monthIndexOf(
+      this.currFromDate ?? this.getDateTimeNow()
+    );
     this.selectedYear = year;
     this.tempMonth = this.selectedMonth;
     this.tempYear = this.selectedYear;
@@ -526,27 +537,18 @@ export class DatePicker
 
   private calculateCalendar() {
     const calendar: CalendarWeek[] = [];
-    const month = DateTime.utc(this.selectedYear, this.selectedMonth + 1);
+    const month = fromMonthIndex(this.selectedYear, this.selectedMonth);
     const monthStart = month.startOf('month');
     const monthEnd = month.endOf('month');
     let startWeek = monthStart.weekNumber;
     let endWeek = monthEnd.weekNumber;
-    let monthStartWeekDayIndex = monthStart.weekday - 1;
-    let monthEndWeekDayIndex = monthEnd.weekday - 1;
-
-    if (this.weekStartIndex !== 0) {
-      // Find the positions where to start/stop counting the day-numbers based on which day the week starts
-      const weekdays = Info.weekdays();
-      const monthStartWeekDayName = weekdays[monthStart.weekday];
-
-      monthStartWeekDayIndex = this.dayNames.findIndex(
-        (d) => d === monthStartWeekDayName
-      );
-      const monthEndWeekDayName = weekdays[monthEnd.weekday];
-      monthEndWeekDayIndex = this.dayNames.findIndex(
-        (d) => d === monthEndWeekDayName
-      );
-    }
+    // Positions where to start/stop counting the day-numbers, based on which
+    // day the week starts.
+    const monthStartWeekDayIndex = weekdayColumnOf(
+      monthStart,
+      this.weekStartIndex
+    );
+    const monthEndWeekDayIndex = weekdayColumnOf(monthEnd, this.weekStartIndex);
 
     let correctLastWeek = false;
     if (endWeek === 1) {
@@ -618,39 +620,29 @@ export class DatePicker
   }
 
   private changeCalendarView(number: -1 | 1) {
-    if (this.selectedMonth + number < 0) {
-      this.selectedYear--;
-      this.selectedMonth = 11;
-    } else if (this.selectedMonth + number > 11) {
-      this.selectedYear++;
-      this.selectedMonth = 0;
-    } else {
-      this.selectedMonth += number;
-    }
+    const { year, month } = addMonths(
+      this.selectedYear,
+      this.selectedMonth,
+      number
+    );
+
+    this.selectedYear = year;
+    this.selectedMonth = month;
 
     this.tempMonth = this.selectedMonth;
     this.tempYear = this.selectedYear;
   }
 
   private navigateByMonthOrYear(unit: 'month' | 'year', direction: -1 | 1) {
-    let targetYear = this.selectedYear;
-    let targetMonth = this.selectedMonth;
+    const { year: targetYear, month: targetMonth } =
+      unit === 'year'
+        ? {
+            year: this.selectedYear + direction,
+            month: this.selectedMonth,
+          }
+        : addMonths(this.selectedYear, this.selectedMonth, direction);
 
-    if (unit === 'year') {
-      targetYear += direction;
-    } else {
-      targetMonth += direction;
-      if (targetMonth < 0) {
-        targetMonth = 11;
-        targetYear--;
-      } else if (targetMonth > 11) {
-        targetMonth = 0;
-        targetYear++;
-      }
-    }
-
-    const daysInTargetMonth =
-      DateTime.utc(targetYear, targetMonth + 1).daysInMonth || 0;
+    const daysInTargetMonth = daysInMonth(targetYear, targetMonth);
     this.focusedDay = Math.min(this.focusedDay, daysInTargetMonth);
 
     this.selectedYear = targetYear;
@@ -665,8 +657,10 @@ export class DatePicker
       return;
     }
 
-    const date = DateTime.fromJSDate(
-      new Date(this.selectedYear, this.selectedMonth, selectedDay)
+    const date = localFromMonthIndex(
+      this.selectedYear,
+      this.selectedMonth,
+      selectedDay
     );
 
     if (this.singleSelection || this.currFromDate === undefined) {
@@ -710,8 +704,10 @@ export class DatePicker
 
   private getUtilitiesBasedOnDay(day: number) {
     const todayObj = this.getDateTimeNow();
-    const selectedDayObj = DateTime.fromJSDate(
-      new Date(this.selectedYear, this.selectedMonth, day)
+    const selectedDayObj = localFromMonthIndex(
+      this.selectedYear,
+      this.selectedMonth,
+      day
     );
     return {
       isFirstDay: () => day === 1,
@@ -732,8 +728,10 @@ export class DatePicker
   }
 
   private getDayClasses(day: number): Record<string, boolean> {
-    const selectedDayObj = DateTime.fromJSDate(
-      new Date(this.selectedYear, this.selectedMonth, day)
+    const selectedDayObj = localFromMonthIndex(
+      this.selectedYear,
+      this.selectedMonth,
+      day
     );
 
     const util = this.getUtilitiesBasedOnDay(day);
@@ -748,53 +746,36 @@ export class DatePicker
     };
   }
 
-  private isWithinMinMaxYear(year: number): boolean {
-    const minDateYear = this.minDate
-      ? DateTime.fromFormat(this.minDate, this.format).year
-      : undefined;
-    const maxDateYear = this.maxDate
-      ? DateTime.fromFormat(this.maxDate, this.format).year
-      : undefined;
-    const isBefore = minDateYear ? year < minDateYear : false;
-    const isAfter = maxDateYear ? year > maxDateYear : false;
-
-    return !isBefore && !isAfter;
-  }
-
-  private isWithinMinMaxMonth(month: number): boolean {
-    const minDateObj = this.minDate
+  private getMinDateObj(): DateTime | undefined {
+    return this.minDate
       ? DateTime.fromFormat(this.minDate, this.format)
       : undefined;
-    const maxDateObj = this.maxDate
+  }
+
+  private getMaxDateObj(): DateTime | undefined {
+    return this.maxDate
       ? DateTime.fromFormat(this.maxDate, this.format)
       : undefined;
-    const minDateMonth = minDateObj?.month;
-    const maxDateMonth = maxDateObj?.month;
-    const isBefore = minDateMonth
-      ? this.tempYear === minDateObj.year && month < minDateMonth
-      : false;
-    const isAfter = maxDateMonth
-      ? this.tempYear === maxDateObj.year && month > maxDateMonth
-      : false;
+  }
 
-    return !isBefore && !isAfter;
+  private isWithinMinMaxYear(year: number): boolean {
+    return isYearWithinRange(year, this.getMinDateObj(), this.getMaxDateObj());
+  }
+
+  /**
+   * `month` is a 0-based month index, as used by `monthNames` and `tempMonth`.
+   */
+  private isWithinMinMaxMonth(month: MonthIndex): boolean {
+    return isMonthWithinRange(
+      this.tempYear,
+      month,
+      this.getMinDateObj(),
+      this.getMaxDateObj()
+    );
   }
 
   private isWithinMinMaxDate(date: DateTime): boolean {
-    const _minDate = this.minDate
-      ? DateTime.fromFormat(this.minDate, this.format)
-      : undefined;
-    const _maxDate = this.maxDate
-      ? DateTime.fromFormat(this.maxDate, this.format)
-      : undefined;
-    const isBefore = _minDate
-      ? date.startOf('day') < _minDate.startOf('day')
-      : false;
-    const isAfter = _maxDate
-      ? date.startOf('day') > _maxDate.startOf('day')
-      : false;
-
-    return !isBefore && !isAfter;
+    return isDayWithinRange(date, this.getMinDateObj(), this.getMaxDateObj());
   }
 
   private renderMonths() {

--- a/packages/core/src/components/date-picker/test/date-picker.ct.ts
+++ b/packages/core/src/components/date-picker/test/date-picker.ct.ts
@@ -382,3 +382,130 @@ regressionTest.describe('keyboard navigation', () => {
     await expect(dateInputElement).toHaveAttribute('value', '2024/09/05');
   });
 });
+
+regressionTest.describe('month dropdown min/max range', () => {
+  const openMonthDropdown = async (page: Page) => {
+    await page.waitForSelector('ix-date-time-card');
+    const monthSelection = page.getByLabel('Select month');
+
+    await expect(monthSelection).toBeVisible();
+    await monthSelection.click();
+
+    return monthSelection;
+  };
+
+  const expectMonths = async (
+    monthSelection: ReturnType<Page['getByLabel']>,
+    enabled: string[],
+    disabled: string[]
+  ) => {
+    for (const name of enabled) {
+      await expect(
+        monthSelection.getByRole('menuitem', { name })
+      ).not.toHaveClass(/disabled-item/);
+    }
+
+    for (const name of disabled) {
+      await expect(monthSelection.getByRole('menuitem', { name })).toHaveClass(
+        /disabled-item/
+      );
+    }
+  };
+
+  regressionTest(
+    'enables the month a single-month range sits in',
+    async ({ mount, page }) => {
+      await mount(
+        `<ix-date-picker from="2026/07/06" min-date="2026/07/05" max-date="2026/07/15" single-selection></ix-date-picker>`
+      );
+
+      const monthSelection = await openMonthDropdown(page);
+
+      await expectMonths(monthSelection, ['July'], ['June', 'August']);
+    }
+  );
+
+  regressionTest(
+    'enables both months a two-month range spans',
+    async ({ mount, page }) => {
+      await mount(
+        `<ix-date-picker from="2026/07/06" min-date="2026/07/05" max-date="2026/08/15" single-selection></ix-date-picker>`
+      );
+
+      const monthSelection = await openMonthDropdown(page);
+
+      await expectMonths(
+        monthSelection,
+        ['July', 'August'],
+        ['June', 'September']
+      );
+    }
+  );
+
+  regressionTest(
+    'disables every month of a year outside the range',
+    async ({ mount, page }) => {
+      await mount(
+        `<ix-date-picker from="2027/07/06" min-date="2026/07/05" max-date="2026/07/15" single-selection></ix-date-picker>`
+      );
+
+      const monthSelection = await openMonthDropdown(page);
+
+      await expectMonths(
+        monthSelection,
+        [],
+        ['January', 'June', 'July', 'August', 'December']
+      );
+    }
+  );
+});
+
+regressionTest.describe('week start index', () => {
+  // 2023-09-01 is a Friday, so the first row's leading blank cells are the only
+  // thing that shifts when the week starts on a different day.
+  const columnOfFirstDay = async (page: Page) => {
+    await page.waitForSelector('ix-date-time-card');
+    const firstWeek = page
+      .locator('[role="row"]')
+      .filter({ has: page.locator('[data-calendar-day="1"]') });
+    const cells = firstWeek.locator('[role="gridcell"]');
+
+    for (let index = 0; index < (await cells.count()); index++) {
+      if ((await cells.nth(index).getAttribute('data-calendar-day')) === '1') {
+        return index;
+      }
+    }
+
+    return -1;
+  };
+
+  regressionTest(
+    'places the first day for a Monday-first week',
+    async ({ mount, page }) => {
+      await mount(
+        `<ix-date-picker from="2023/09/01" single-selection></ix-date-picker>`
+      );
+
+      expect(await columnOfFirstDay(page)).toBe(4);
+    }
+  );
+
+  regressionTest(
+    'places the first day for a Sunday-first week',
+    async ({ mount, page }) => {
+      await mount(
+        `<ix-date-picker from="2023/09/01" week-start-index="6" single-selection></ix-date-picker>`
+      );
+
+      expect(await columnOfFirstDay(page)).toBe(5);
+    }
+  );
+
+  regressionTest('is unaffected by the locale', async ({ mount, page }) => {
+    await mount(
+      `<ix-date-picker from="2023/09/01" week-start-index="6" locale="de" single-selection></ix-date-picker>`
+    );
+
+    expect(await columnOfFirstDay(page)).toBe(5);
+  });
+});

--- a/packages/core/src/components/utils/calendar-units.ts
+++ b/packages/core/src/components/utils/calendar-units.ts
@@ -1,0 +1,161 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import { DateTime } from 'luxon';
+
+/**
+ * Luxon and the UI disagree about where calendar units start counting:
+ *
+ * | Unit    | Luxon                     | `Info.months()` / `Info.weekdays()` |
+ * | ------- | ------------------------- | ----------------------------------- |
+ * | Month   | `.month` is 1-12          | index 0-11, 0 = January             |
+ * | Weekday | `.weekday` is 1-7, Mon=1  | index 0-6, 0 = Monday               |
+ *
+ * Mixing the two silently produces off-by-one bugs, so this module is the only
+ * place allowed to convert between them. Everything crossing its boundary is
+ * either a `DateTime` or a 0-based index, never a raw Luxon unit number.
+ */
+
+/** 0-based month index, 0 = January. Matches `Info.months()` ordering. */
+export type MonthIndex = number;
+
+/** 0-based weekday index, 0 = Monday. Matches `Info.weekdays()` ordering. */
+export type WeekdayIndex = number;
+
+export const MONTHS_IN_YEAR = 12;
+export const DAYS_IN_WEEK = 7;
+
+/** The 0-based month index of `date`, e.g. `2026-07-05` -> `6`. */
+export function monthIndexOf(date: DateTime): MonthIndex {
+  return date.month - 1;
+}
+
+/** The 0-based weekday index of `date`, e.g. a Monday -> `0`, a Sunday -> `6`. */
+export function weekdayIndexOf(date: DateTime): WeekdayIndex {
+  return date.weekday - 1;
+}
+
+/**
+ * Build a UTC `DateTime` from a 0-based `month` index.
+ *
+ * Use instead of `new Date(year, month, day)`, which is 0-based *and* resolves
+ * in local time — mixing it with the UTC dates used elsewhere shifts days
+ * across the midnight boundary for non-UTC offsets.
+ */
+export function fromMonthIndex(
+  year: number,
+  month: MonthIndex,
+  day = 1
+): DateTime {
+  return DateTime.utc(year, month + 1, day);
+}
+
+/**
+ * Build a system-zone `DateTime` from a 0-based `month` index.
+ *
+ * Use for days that are compared against dates parsed with
+ * `DateTime.fromFormat` / `DateTime.fromISO`, which are zone-local: `hasSame`
+ * and the ordering operators resolve the other operand into the receiver's
+ * zone, so a UTC midnight lands on the previous day for any negative offset.
+ * Prefer {@link fromMonthIndex} for pure calendar arithmetic.
+ */
+export function localFromMonthIndex(
+  year: number,
+  month: MonthIndex,
+  day = 1
+): DateTime {
+  return DateTime.local(year, month + 1, day);
+}
+
+/**
+ * Move `delta` months from `year`/`month`, wrapping the year as needed.
+ * `month` is 0-based in and out.
+ */
+export function addMonths(
+  year: number,
+  month: MonthIndex,
+  delta: number
+): { year: number; month: MonthIndex } {
+  const target = fromMonthIndex(year, month).plus({ months: delta });
+
+  return { year: target.year, month: monthIndexOf(target) };
+}
+
+/**
+ * Number of days in the given 0-based `month`, accounting for leap years.
+ */
+export function daysInMonth(year: number, month: MonthIndex): number {
+  return fromMonthIndex(year, month).daysInMonth ?? 0;
+}
+
+/**
+ * Whether `date`'s day falls within `[min, max]`. Bounds are inclusive and
+ * each is optional; an absent bound is unbounded in that direction.
+ */
+export function isDayWithinRange(
+  date: DateTime,
+  min?: DateTime,
+  max?: DateTime
+): boolean {
+  const day = date.startOf('day');
+  const isBefore = min ? day < min.startOf('day') : false;
+  const isAfter = max ? day > max.startOf('day') : false;
+
+  return !isBefore && !isAfter;
+}
+
+/**
+ * Whether the given 0-based `month` in `year` contains any day within
+ * `[min, max]`. Bounds are inclusive and each is optional.
+ *
+ * The comparison runs on real `DateTime`s rather than bare month numbers, so
+ * the year is always part of it — a month in a year outside the range is
+ * correctly excluded even when its month number sits between the bounds.
+ */
+export function isMonthWithinRange(
+  year: number,
+  month: MonthIndex,
+  min?: DateTime,
+  max?: DateTime
+): boolean {
+  const monthStart = fromMonthIndex(year, month);
+  const isBefore = min ? monthStart < min.startOf('month') : false;
+  const isAfter = max ? monthStart > max.startOf('month') : false;
+
+  return !isBefore && !isAfter;
+}
+
+/**
+ * Whether `year` contains any day within `[min, max]`. Bounds are inclusive
+ * and each is optional.
+ */
+export function isYearWithinRange(
+  year: number,
+  min?: DateTime,
+  max?: DateTime
+): boolean {
+  const isBefore = min ? year < min.year : false;
+  const isAfter = max ? year > max.year : false;
+
+  return !isBefore && !isAfter;
+}
+
+/**
+ * The column `date` occupies in a calendar grid whose first column is
+ * `weekStart` (a 0-based weekday index, 0 = Monday).
+ *
+ * Pure arithmetic on indices — no weekday-name lookup — so it cannot be thrown
+ * off by the locale used to render the column headers.
+ */
+export function weekdayColumnOf(
+  date: DateTime,
+  weekStart: WeekdayIndex = 0
+): number {
+  return (
+    (((weekdayIndexOf(date) - weekStart) % DAYS_IN_WEEK) + DAYS_IN_WEEK) %
+    DAYS_IN_WEEK
+  );
+}

--- a/packages/core/src/components/utils/test/calendar-units.spec.ts
+++ b/packages/core/src/components/utils/test/calendar-units.spec.ts
@@ -1,0 +1,276 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Siemens AG
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import { DateTime } from 'luxon';
+import { describe, expect, it } from 'vitest';
+import {
+  MONTHS_IN_YEAR,
+  addMonths,
+  daysInMonth,
+  fromMonthIndex,
+  isDayWithinRange,
+  isMonthWithinRange,
+  isYearWithinRange,
+  localFromMonthIndex,
+  monthIndexOf,
+  weekdayColumnOf,
+  weekdayIndexOf,
+} from '../calendar-units';
+
+const JANUARY = 0;
+const JUNE = 5;
+const JULY = 6;
+const AUGUST = 7;
+const SEPTEMBER = 8;
+const DECEMBER = 11;
+
+const allMonths = Array.from({ length: MONTHS_IN_YEAR }, (_, i) => i);
+
+describe('monthIndexOf / fromMonthIndex', () => {
+  it('round-trips every month', () => {
+    allMonths.forEach((month) => {
+      expect(monthIndexOf(fromMonthIndex(2026, month))).toBe(month);
+    });
+  });
+
+  it('maps July to index 6', () => {
+    expect(monthIndexOf(DateTime.utc(2026, 7, 5))).toBe(JULY);
+  });
+
+  it('builds a UTC date from a 0-based month', () => {
+    const date = fromMonthIndex(2026, JULY, 5);
+
+    expect(date.toISODate()).toBe('2026-07-05');
+    expect(date.zoneName).toBe('UTC');
+  });
+
+  it('defaults to the first of the month', () => {
+    expect(fromMonthIndex(2026, JULY).toISODate()).toBe('2026-07-01');
+  });
+});
+
+describe('localFromMonthIndex', () => {
+  it('builds a system-zone date from a 0-based month', () => {
+    const date = localFromMonthIndex(2026, JULY, 5);
+
+    expect(date.toISODate()).toBe('2026-07-05');
+    expect(date.zone.type).toBe('system');
+  });
+
+  it('matches the calendar day of a locally parsed date', () => {
+    const parsed = DateTime.fromFormat('2026/07/05', 'yyyy/LL/dd');
+
+    expect(localFromMonthIndex(2026, JULY, 5).hasSame(parsed, 'day')).toBe(
+      true
+    );
+  });
+
+  it('defaults to the first of the month', () => {
+    expect(localFromMonthIndex(2026, JULY).toISODate()).toBe('2026-07-01');
+  });
+});
+
+describe('weekdayIndexOf', () => {
+  it('maps Monday to 0 and Sunday to 6', () => {
+    // 2026-08-31 is a Monday, 2026-09-06 is a Sunday.
+    expect(weekdayIndexOf(DateTime.utc(2026, 8, 31))).toBe(0);
+    expect(weekdayIndexOf(DateTime.utc(2026, 9, 6))).toBe(6);
+  });
+});
+
+describe('addMonths', () => {
+  it('wraps forwards across the year boundary', () => {
+    expect(addMonths(2026, DECEMBER, 1)).toEqual({
+      year: 2027,
+      month: JANUARY,
+    });
+  });
+
+  it('wraps backwards across the year boundary', () => {
+    expect(addMonths(2026, JANUARY, -1)).toEqual({
+      year: 2025,
+      month: DECEMBER,
+    });
+  });
+
+  it('handles deltas larger than a year', () => {
+    expect(addMonths(2026, JULY, 14)).toEqual({ year: 2027, month: SEPTEMBER });
+    expect(addMonths(2026, JULY, -14)).toEqual({ year: 2025, month: 4 });
+  });
+
+  it('is a no-op for a zero delta', () => {
+    expect(addMonths(2026, JULY, 0)).toEqual({ year: 2026, month: JULY });
+  });
+});
+
+describe('daysInMonth', () => {
+  it('accounts for leap years', () => {
+    expect(daysInMonth(2024, 1)).toBe(29);
+    expect(daysInMonth(2026, 1)).toBe(28);
+  });
+
+  it('returns 31 for July', () => {
+    expect(daysInMonth(2026, JULY)).toBe(31);
+  });
+});
+
+describe('isMonthWithinRange', () => {
+  describe('range inside a single month (5-15 July 2026)', () => {
+    const min = DateTime.utc(2026, 7, 5);
+    const max = DateTime.utc(2026, 7, 15);
+
+    it('includes July', () => {
+      expect(isMonthWithinRange(2026, JULY, min, max)).toBe(true);
+    });
+
+    it('excludes every other month of the same year', () => {
+      allMonths
+        .filter((month) => month !== JULY)
+        .forEach((month) => {
+          expect(isMonthWithinRange(2026, month, min, max)).toBe(false);
+        });
+    });
+
+    it('excludes August, which sits directly after the range', () => {
+      expect(isMonthWithinRange(2026, AUGUST, min, max)).toBe(false);
+    });
+  });
+
+  describe('range spanning two months (5 July - 15 August 2026)', () => {
+    const min = DateTime.utc(2026, 7, 5);
+    const max = DateTime.utc(2026, 8, 15);
+
+    it('includes both months the range touches', () => {
+      expect(isMonthWithinRange(2026, JULY, min, max)).toBe(true);
+      expect(isMonthWithinRange(2026, AUGUST, min, max)).toBe(true);
+    });
+
+    it('excludes the months either side of the range', () => {
+      expect(isMonthWithinRange(2026, JUNE, min, max)).toBe(false);
+      expect(isMonthWithinRange(2026, SEPTEMBER, min, max)).toBe(false);
+    });
+  });
+
+  describe('years outside the range', () => {
+    const min = DateTime.utc(2026, 7, 5);
+    const max = DateTime.utc(2026, 7, 15);
+
+    it('excludes all months of an earlier year', () => {
+      allMonths.forEach((month) => {
+        expect(isMonthWithinRange(2025, month, min, max)).toBe(false);
+      });
+    });
+
+    it('excludes all months of a later year', () => {
+      allMonths.forEach((month) => {
+        expect(isMonthWithinRange(2027, month, min, max)).toBe(false);
+      });
+    });
+  });
+
+  describe('open-ended ranges', () => {
+    it('treats an absent minimum as unbounded', () => {
+      const max = DateTime.utc(2026, 7, 15);
+
+      expect(isMonthWithinRange(1999, JANUARY, undefined, max)).toBe(true);
+      expect(isMonthWithinRange(2026, AUGUST, undefined, max)).toBe(false);
+    });
+
+    it('treats an absent maximum as unbounded', () => {
+      const min = DateTime.utc(2026, 7, 5);
+
+      expect(isMonthWithinRange(2099, DECEMBER, min, undefined)).toBe(true);
+      expect(isMonthWithinRange(2026, JUNE, min, undefined)).toBe(false);
+    });
+
+    it('treats both absent as unbounded', () => {
+      allMonths.forEach((month) => {
+        expect(isMonthWithinRange(2026, month)).toBe(true);
+      });
+    });
+  });
+});
+
+describe('isYearWithinRange', () => {
+  const min = DateTime.utc(2026, 7, 5);
+  const max = DateTime.utc(2028, 7, 15);
+
+  it('includes the boundary years and everything between', () => {
+    expect(isYearWithinRange(2026, min, max)).toBe(true);
+    expect(isYearWithinRange(2027, min, max)).toBe(true);
+    expect(isYearWithinRange(2028, min, max)).toBe(true);
+  });
+
+  it('excludes years outside the bounds', () => {
+    expect(isYearWithinRange(2025, min, max)).toBe(false);
+    expect(isYearWithinRange(2029, min, max)).toBe(false);
+  });
+
+  it('treats absent bounds as unbounded', () => {
+    expect(isYearWithinRange(1900)).toBe(true);
+  });
+});
+
+describe('isDayWithinRange', () => {
+  const min = DateTime.utc(2026, 7, 5);
+  const max = DateTime.utc(2026, 7, 15);
+
+  it('includes both bounds', () => {
+    expect(isDayWithinRange(DateTime.utc(2026, 7, 5), min, max)).toBe(true);
+    expect(isDayWithinRange(DateTime.utc(2026, 7, 15), min, max)).toBe(true);
+  });
+
+  it('ignores the time of day', () => {
+    expect(isDayWithinRange(DateTime.utc(2026, 7, 15, 23, 59), min, max)).toBe(
+      true
+    );
+  });
+
+  it('excludes days either side of the range', () => {
+    expect(isDayWithinRange(DateTime.utc(2026, 7, 4), min, max)).toBe(false);
+    expect(isDayWithinRange(DateTime.utc(2026, 7, 16), min, max)).toBe(false);
+  });
+});
+
+describe('weekdayColumnOf', () => {
+  // 2026-08-31 is a Monday, so this covers Monday through Sunday in order.
+  const week = Array.from({ length: 7 }, (_, i) =>
+    DateTime.utc(2026, 8, 31).plus({ days: i })
+  );
+
+  it('is identity for a Monday-first grid', () => {
+    week.forEach((date, index) => {
+      expect(weekdayColumnOf(date, 0)).toBe(index);
+    });
+  });
+
+  it('defaults to a Monday-first grid', () => {
+    expect(weekdayColumnOf(week[0])).toBe(0);
+  });
+
+  it('shifts every column for a Sunday-first grid', () => {
+    // weekStart 6 = Sunday, so Sunday lands in column 0 and Monday in column 1.
+    expect(weekdayColumnOf(week[6], 6)).toBe(0);
+    week.slice(0, 6).forEach((date, index) => {
+      expect(weekdayColumnOf(date, 6)).toBe(index + 1);
+    });
+  });
+
+  it('returns a valid column for every weekday and every week start', () => {
+    for (let weekStart = 0; weekStart < 7; weekStart++) {
+      const columns = week.map((date) => weekdayColumnOf(date, weekStart));
+
+      expect([...columns].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    }
+  });
+
+  it('handles Sunday, whose Luxon weekday is 7', () => {
+    const sunday = week[6];
+
+    expect(sunday.weekday).toBe(7);
+    expect(weekdayColumnOf(sunday, 0)).toBe(6);
+  });
+});


### PR DESCRIPTION
## 💡 What is the current behavior?

There are numerous bugs in the code related to mismatched indexes being compared across the logic. E.g. the month disabling code that compares 0-base index month names to 1-base month list.

GitHub Issue Number: #2780 

## 🆕 What is the new behavior?

This PR fixes any existing Date index mismatches and removes the scope for any further mismatches via normalising all DateTime logic to use consistent Luxon objects and then resolve strings and values directly from these objects when required, rather than using the strings and values for comparison.

Tests have been added to ensure behaviour is kept consistent, and to cover the revealed prior bugs.

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🦮 Accessibility (a11y) features were implemented
- [ ] 🗺️ Internationalization (i18n) - no hard coded strings
- [ ] 📲 Responsiveness - components handle viewport changes and content overflow gracefully
- [ ] 📕 Add or update a Storybook story
- [ ] 📄 Documentation was reviewed/updated [siemens/ix-docs](https://github.com/siemens/ix-docs)
- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🧐 Static code analysis passes (`pnpm lint`)
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved date-picker month and year navigation using more reliable calendar handling.
  * Added localized month and weekday labels with support for configurable week starts.
  * Improved enforcement of minimum and maximum date ranges for day, month, and year selection.
  * Added support for Sunday-first calendar layouts.

* **Bug Fixes**
  * Prevented invalid calendar selections and corrected date positioning across locales and week-start configurations.

* **Tests**
  * Added comprehensive coverage for calendar calculations, date ranges, localization, leap years, and week layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->